### PR TITLE
Init(project): ky 및 TanStack Query 세팅

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -16,15 +16,18 @@
   },
   "dependencies": {
     "@siksa/sds-ui": "workspace:*",
+    "@tanstack/react-query": "catalog:",
     "clsx": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "tailwind-merge": "catalog:"
+    "tailwind-merge": "catalog:",
+    "ky": "catalog:"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
     "@playwright/test": "catalog:",
     "@tailwindcss/vite": "catalog:",
+    "@tanstack/react-query-devtools": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/user-event": "catalog:",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,6 +20,7 @@
     "clsx": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-error-boundary": "catalog:",
     "tailwind-merge": "catalog:",
     "ky": "catalog:"
   },

--- a/apps/client/src/app/main.tsx
+++ b/apps/client/src/app/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from '@/app/App'
 import '@/app/styles/global.css'
+import QueryProvider from '@/app/providers/QueryProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryProvider>
+      <App />
+    </QueryProvider>
   </StrictMode>,
 )

--- a/apps/client/src/app/providers/AsyncBoundary.tsx
+++ b/apps/client/src/app/providers/AsyncBoundary.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+import { QueryErrorResetBoundary } from '@tanstack/react-query'
+import { ErrorBoundary } from 'react-error-boundary'
+
+interface AsyncBoundaryProps {
+  children: ReactNode
+}
+
+const AsyncBoundary = ({ children }: AsyncBoundaryProps) => {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <section>
+              <p>일시적인 오류가 발생했습니다.</p>
+              <button type="button" onClick={resetErrorBoundary}>
+                다시 시도
+              </button>
+            </section>
+          )}
+        >
+          <Suspense fallback={<p>불러오는 중입니다.</p>}>{children}</Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}
+
+export default AsyncBoundary

--- a/apps/client/src/app/providers/QueryProvider.tsx
+++ b/apps/client/src/app/providers/QueryProvider.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { queryClient } from '@/shared/lib/queryClient'
+import AsyncBoundary from '@/app/providers/AsyncBoundary'
 
 interface QueryProviderProps {
   children: ReactNode
@@ -10,7 +11,7 @@ interface QueryProviderProps {
 const QueryProvider = ({ children }: QueryProviderProps) => {
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
+      <AsyncBoundary>{children}</AsyncBoundary>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   )

--- a/apps/client/src/app/providers/QueryProvider.tsx
+++ b/apps/client/src/app/providers/QueryProvider.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { queryClient } from '@/shared/lib/queryClient'
+
+interface QueryProviderProps {
+  children: ReactNode
+}
+
+const QueryProvider = ({ children }: QueryProviderProps) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
+}
+
+export default QueryProvider

--- a/apps/client/src/shared/api/apiClient.ts
+++ b/apps/client/src/shared/api/apiClient.ts
@@ -1,0 +1,14 @@
+import ky from 'ky'
+
+const API_TIMEOUT = 10_000
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL 환경 변수가 필요합니다.')
+}
+
+export const apiClient = ky.create({
+  baseUrl: API_BASE_URL,
+  timeout: API_TIMEOUT,
+  retry: 0,
+})

--- a/apps/client/src/shared/lib/queryClient.ts
+++ b/apps/client/src/shared/lib/queryClient.ts
@@ -1,0 +1,28 @@
+import { QueryClient } from '@tanstack/react-query'
+import { isHTTPError, isNetworkError, isTimeoutError } from 'ky'
+
+const MAX_QUERY_RETRY_COUNT = 1
+
+const checkShouldRetryQuery = (failureCount: number, error: Error) => {
+  if (failureCount >= MAX_QUERY_RETRY_COUNT) {
+    return false
+  }
+
+  if (isHTTPError(error)) {
+    return error.response.status >= 500
+  }
+
+  return isNetworkError(error) || isTimeoutError(error)
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: checkShouldRetryQuery,
+      staleTime: 30_000,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+})

--- a/apps/client/src/shared/lib/queryClient.ts
+++ b/apps/client/src/shared/lib/queryClient.ts
@@ -18,6 +18,8 @@ const checkShouldRetryQuery = (failureCount: number, error: Error) => {
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      gcTime: 10 * 60 * 1_000,
+      refetchOnWindowFocus: false,
       retry: checkShouldRetryQuery,
       staleTime: 30_000,
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
+import pluginQuery from '@tanstack/eslint-plugin-query'
 
 export default tseslint.config(
   {
@@ -39,5 +40,6 @@ export default tseslint.config(
       'react-refresh/only-export-components': 'off',
     },
   },
+  ...pluginQuery.configs['flat/recommended'],
   prettier,
 )

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
+    "@tanstack/eslint-plugin-query": "catalog:",
     "@turbo/gen": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.18.3",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "pnpm --filter @siksa/client dev",
     "build": "turbo build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     react-dom:
       specifier: ^19.2.6
       version: 19.2.7
+    react-error-boundary:
+      specifier: ^6.0.0
+      version: 6.1.2
     tailwind-merge:
       specifier: ^3.6.0
       version: 3.6.0
@@ -188,6 +191,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.7(react@19.2.7)
+      react-error-boundary:
+        specifier: 'catalog:'
+        version: 6.1.2(react@19.2.7)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.6.0
@@ -3457,6 +3463,11 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-error-boundary@6.1.2:
+    resolution: {integrity: sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -6949,6 +6960,10 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-error-boundary@6.1.2(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   react-is@17.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,15 @@ catalogs:
     '@tailwindcss/vite':
       specifier: ^4.3.1
       version: 4.3.1
+    '@tanstack/eslint-plugin-query':
+      specifier: ^5.101.0
+      version: 5.101.1
+    '@tanstack/react-query':
+      specifier: ^5.101.0
+      version: 5.101.1
+    '@tanstack/react-query-devtools':
+      specifier: ^5.101.0
+      version: 5.101.1
     '@testing-library/jest-dom':
       specifier: ^6.9.0
       version: 6.9.1
@@ -63,6 +72,9 @@ catalogs:
     jsdom:
       specifier: ^26.1.0
       version: 26.1.0
+    ky:
+      specifier: ^2.0.2
+      version: 2.0.2
     lint-staged:
       specifier: ^17.0.8
       version: 17.0.8
@@ -110,6 +122,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
+      '@tanstack/eslint-plugin-query':
+        specifier: 'catalog:'
+        version: 5.101.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@turbo/gen':
         specifier: 'catalog:'
         version: 2.9.18(@types/node@24.13.2)
@@ -158,9 +173,15 @@ importers:
       '@siksa/sds-ui':
         specifier: workspace:*
         version: link:../../packages/sds-ui
+      '@tanstack/react-query':
+        specifier: 'catalog:'
+        version: 5.101.1(react@19.2.7)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
+      ky:
+        specifier: 'catalog:'
+        version: 2.0.2
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -180,6 +201,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/react-query-devtools':
+        specifier: 'catalog:'
+        version: 5.101.1(@tanstack/react-query@5.101.1(react@19.2.7))(react@19.2.7)
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1164,35 +1188,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
     resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
     resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
@@ -1287,56 +1306,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.111.0':
     resolution: {integrity: sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
     resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
     resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
     resolution: {integrity: sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
     resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.111.0':
     resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.111.0':
     resolution: {integrity: sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.111.0':
     resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
@@ -1441,70 +1452,60 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
@@ -1601,79 +1602,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1746,28 +1734,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -1801,6 +1785,32 @@ packages:
     resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/eslint-plugin-query@5.101.1':
+    resolution: {integrity: sha512-gssErdsLIoeiJI6mbU1YTNlNxktj/Dt8r8QSXNxz8P4gBTnKl9xAPix84orbkIbd133ewAbqieRMZUQmxL+34w==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ^5.4.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@tanstack/query-core@5.101.1':
+    resolution: {integrity: sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==}
+
+  '@tanstack/query-devtools@5.101.1':
+    resolution: {integrity: sha512-37RQ9U2PxlXQiv1era2t+uHgVhmiyvxqTMu30+KoVf0rufiucu6rpGRKFJk61Wh5OAZFKqCQd6lxTzFWfLZiuQ==}
+
+  '@tanstack/react-query-devtools@5.101.1':
+    resolution: {integrity: sha512-OXFR9XKdEslraq3cpl3kCUeNvTIq/xGWEZiFZdn2bLB/q4WxSALMEDKYZ5yYjMQytsfnQxwQYqV4qtVEf0nuog==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.1
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.101.1':
+    resolution: {integrity: sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2957,6 +2967,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  ky@2.0.2:
+    resolution: {integrity: sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg==}
+    engines: {node: '>=22'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2996,28 +3010,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5112,6 +5122,30 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@tanstack/eslint-plugin-query@5.101.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/query-core@5.101.1': {}
+
+  '@tanstack/query-devtools@5.101.1': {}
+
+  '@tanstack/react-query-devtools@5.101.1(@tanstack/react-query@5.101.1(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.1
+      '@tanstack/react-query': 5.101.1(react@19.2.7)
+      react: 19.2.7
+
+  '@tanstack/react-query@5.101.1(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.1
+      react: 19.2.7
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -6519,6 +6553,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  ky@2.0.2: {}
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,3 +40,4 @@ catalog:
   vite: ^8.0.12
   vitest: ^3.2.4
   ky: ^2.0.2
+  react-error-boundary: ^6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ catalog:
   '@eslint/js': ^10.0.1
   '@playwright/test': ^1.55.0
   '@tailwindcss/vite': ^4.3.1
+  '@tanstack/eslint-plugin-query': ^5.101.0
+  '@tanstack/react-query': ^5.101.0
+  '@tanstack/react-query-devtools': ^5.101.0
   '@testing-library/jest-dom': ^6.9.0
   '@testing-library/react': ^16.3.0
   '@testing-library/user-event': ^14.6.1
@@ -36,3 +39,4 @@ catalog:
   vercel: ^54.14.0
   vite: ^8.0.12
   vitest: ^3.2.4
+  ky: ^2.0.2


### PR DESCRIPTION
## 📌 Summary

> ky와 TanStack Query를 활용한 API 통신 및 서버 상태 관리 환경을 세팅했습니다!

Jira: SIKSA-19

## 📚 Tasks

- ky 설치 및 공통 API 클라이언트 설정
- TanStack Query 설치 및 공통 `QueryClient` 설정
- 네트워크·timeout·HTTP 상태별 query 재시도 정책 설정
- `QueryClientProvider` 전역 연결
- React Query Devtools 추가
- TanStack Query ESLint 권장 규칙 추가
- 관련 패키지 catalog 버전 관리 추가

## 🔍 Details

### 패키지 설치

API 통신과 서버 상태 관리를 위해 아래 패키지를 추가했습니다!

```txt
ky
@tanstack/react-query
@tanstack/react-query-devtools
@tanstack/eslint-plugin-query
```

각 패키지의 역할은 다음과 같습니다.

- `ky`: Fetch API 기반 HTTP 클라이언트
- `@tanstack/react-query`: 서버 상태 조회, 캐싱 및 동기화
- `@tanstack/react-query-devtools`: query와 mutation 상태를 확인하는 개발 도구
- `@tanstack/eslint-plugin-query`: TanStack Query 사용 시 발생할 수 있는 실수를 검사하는 ESLint 플러그인

### ky API 클라이언트 설정

공통 API 클라이언트는 아래 위치에 추가했습니다.

```txt
apps/client/src/shared/api/apiClient.ts
```

```ts
import ky from 'ky'

const API_TIMEOUT = 10_000
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL

if (!API_BASE_URL) {
  throw new Error('VITE_API_BASE_URL 환경 변수가 필요합니다.')
}

export const apiClient = ky.create({
  baseUrl: API_BASE_URL,
  timeout: API_TIMEOUT,
  retry: 0,
})
```

`baseUrl`은 Vite 환경 변수인 `VITE_API_BASE_URL`을 사용하도록 설정했습니다.

```env
VITE_API_BASE_URL=https://api.example.com/
```

실제 API 주소는 환경별 `.env` 또는 배포 환경 변수에서 관리하며 저장소에는 포함하지 않습니다.

API 요청이 무한정 대기하지 않도록 공통 timeout은 10초로 설정했습니다.

```ts
timeout: 10_000
```

ky의 자체 retry는 비활성화했습니다.

```ts
retry: 0
```

ky와 TanStack Query가 모두 retry를 수행하면 하나의 query 요청 안에서 HTTP 요청 횟수가 중첩될 수 있기 때문입니다.

이번 설정에서는 재시도 여부를 TanStack Query가 한 곳에서 담당합니다.

### ky 활용 방식

추후 기능별 API 함수에서는 공통 `apiClient`를 가져와 사용할 수 있습니다.

```ts
import { apiClient } from '@/shared/api/apiClient'

interface Restaurant {
  id: number
  name: string
}

export const getRestaurants = () => {
  return apiClient.get('restaurants').json<Restaurant[]>()
}
```

각 기능에서는 API 주소, timeout, retry 설정을 반복하지 않고 endpoint와 응답 타입만 정의하면 됩니다.

실제 endpoint와 응답 타입은 백엔드 API 계약이 확정된 뒤 기능별 작업에서 추가할 예정입니다.

### TanStack Query 클라이언트 설정

공통 `QueryClient`는 아래 위치에 추가했습니다.

```txt
apps/client/src/shared/lib/queryClient.ts
```

```ts
import { QueryClient } from '@tanstack/react-query'
import { isHTTPError, isNetworkError, isTimeoutError } from 'ky'

const MAX_QUERY_RETRY_COUNT = 1

const checkShouldRetryQuery = (failureCount: number, error: Error) => {
  if (failureCount >= MAX_QUERY_RETRY_COUNT) {
    return false
  }

  if (isHTTPError(error)) {
    return error.response.status >= 500
  }

  return isNetworkError(error) || isTimeoutError(error)
}

export const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      retry: checkShouldRetryQuery,
      staleTime: 30_000,
    },
    mutations: {
      retry: false,
    },
  },
})
```

#### query 재시도 정책

query는 아래 오류만 최대 1회 재시도합니다.

```txt
네트워크 오류
timeout
500 이상 서버 오류
```

다음 오류는 재시도하지 않습니다.

```txt
400, 401, 403, 404 등의 클라이언트 오류
응답 파싱 오류
코드 실행 오류
```

4xx 응답은 동일한 요청을 반복해도 성공할 가능성이 낮고, 인증이나 요청 데이터 수정처럼 별도 처리가 필요하기 때문입니다.

#### mutation 재시도 정책

mutation은 자동 재시도를 비활성화했습니다.

```ts
mutations: {
  retry: false,
}
```

생성, 수정, 삭제 요청은 자동으로 다시 실행될 경우 중복 생성이나 중복 처리 문제가 발생할 수 있기 때문입니다.

#### staleTime 설정

```ts
staleTime: 30_000
```

query로 받아온 데이터는 30초 동안 fresh 상태로 판단합니다.

짧은 시간 안에 같은 화면이 다시 마운트됐을 때 불필요한 요청이 반복되는 것을 줄이기 위한 초기 공통값입니다.

데이터마다 최신성 기준이 다를 수 있으므로, 추후 필요한 query에서는 개별적으로 `staleTime`을 덮어쓸 수 있습니다.

### Query Provider 설정

TanStack Query를 앱 전체에서 사용할 수 있도록 Provider를 추가했습니다.

```txt
apps/client/src/app/providers/QueryProvider.tsx
```

```tsx
import type { ReactNode } from 'react'
import { QueryClientProvider } from '@tanstack/react-query'
import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
import { queryClient } from '@/shared/lib/queryClient'

interface QueryProviderProps {
  children: ReactNode
}

const QueryProvider = ({ children }: QueryProviderProps) => {
  return (
    <QueryClientProvider client={queryClient}>
      {children}
      <ReactQueryDevtools initialIsOpen={false} />
    </QueryClientProvider>
  )
}

export default QueryProvider
```

그리고 `main.tsx`에서 앱 전체를 `QueryProvider`로 감싸도록 설정했습니다.

```tsx
createRoot(document.getElementById('root')!).render(
  <StrictMode>
    <QueryProvider>
      <App />
    </QueryProvider>
  </StrictMode>,
)
```

이제 `apps/client` 내부의 page와 feature에서 동일한 `QueryClient`와 query cache를 사용할 수 있습니다.

### React Query Devtools

개발 중 query 상태를 확인할 수 있도록 React Query Devtools를 연결했습니다.

Devtools에서는 다음 내용을 확인할 수 있습니다.

```txt
등록된 query key
query의 fresh / stale 상태
fetching 상태
cache 데이터
mutation 상태
```

처음에는 닫힌 상태로 표시되도록 설정했습니다.

```tsx
<ReactQueryDevtools initialIsOpen={false} />
```

아직 실제 query가 등록되지 않았기 때문에 현재 Devtools의 query 목록이 비어 있는 것은 정상입니다.

### TanStack Query ESLint 설정

TanStack Query 사용 과정에서 발생할 수 있는 실수를 확인하기 위해 공식 ESLint 권장 규칙을 추가했습니다.

```js
import pluginQuery from '@tanstack/eslint-plugin-query'

export default tseslint.config(
  // 기존 설정
  ...pluginQuery.configs['flat/recommended'],
  prettier,
)
```

이 설정을 통해 다음과 같은 Query 관련 문제를 정적 검사할 수 있습니다.

```txt
query dependency 누락
불안정한 QueryClient 생성
불안정한 query dependency 사용
infinite query option 순서 오류
void query function 사용
```

### catalog 버전 관리

이번에 추가한 패키지도 기존 프로젝트 기준에 맞춰 pnpm catalog로 관리하도록 설정했습니다!

```txt
ky
@tanstack/react-query
@tanstack/react-query-devtools
@tanstack/eslint-plugin-query
```

실제 버전은 `pnpm-workspace.yaml`에서 관리합니다.

```yaml
catalog:
  '@tanstack/eslint-plugin-query': ^5.101.0
  '@tanstack/react-query': ^5.101.0
  '@tanstack/react-query-devtools': ^5.101.0
  ky: ^2.0.2
```

각 `package.json`에서는 버전을 직접 작성하지 않고 `catalog:`를 참조합니다.

```json
{
  "@tanstack/react-query": "catalog:",
  "@tanstack/react-query-devtools": "catalog:",
  "ky": "catalog:"
}
```

이를 통해 TanStack Query 관련 패키지의 버전을 한 곳에서 일관되게 관리할 수 있습니다.

## ✅ Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- 변경된 구현 파일 Prettier 검사

## 👀 To Reviewer

- ky와 TanStack Query의 retry가 중복되지 않도록 query 재시도는 TanStack Query에서만 처리하도록 구성했습니다.
- query는 네트워크 오류, timeout, 5xx 응답만 최대 1회 재시도합니다.
- mutation은 중복 요청 가능성을 고려해 자동 재시도를 비활성화했습니다.
- 인증 header, token refresh, 공통 응답 타입과 endpoint 구조는 백엔드 API 계약이 확정된 뒤 별도 작업에서 추가할 예정입니다.
- API 요청을 사용하려면 실행 환경에 `VITE_API_BASE_URL` 설정이 필요합니다.

<!--
## 📸 Screenshot

UI 변경사항이 없어 Screenshot 섹션은 생략합니다.
-->