### PR TITLE
Init(project): 개발 워크플로우 자동화 구축

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TEAM-SIKSA/siksa-client

--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,28 @@
+name: Auto Assign Author
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request
+            const author = pullRequest.user.login
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequest.number,
+              assignees: [author],
+            })

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,101 @@
+name: Auto Label
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label from PR title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const typeLabels = {
+              docs: '📝 DOCS',
+              feat: '✨ FEAT',
+              init: '🌱 INIT',
+              fix: '🩹 FIX',
+              test: '🧪 TEST',
+              deploy: '🚀 DEPLOY',
+              refactor: '♻️ REFACTOR',
+              style: '🎨 STYLE',
+              chore: '🧹 CHORE',
+            }
+
+            const authorLabels = {
+              gyeongbibin: '🫪 경빈',
+              chungyo: '🥸 충영',
+              MinseoSONG: '😋 민서',
+              yurimidaH: '😜 유림',
+              jyeon03: '🙄 지연',
+            }
+
+            const pullRequest = context.payload.pull_request
+            const title = pullRequest.title
+            const match = title.match(/^([a-zA-Z]+)(?:\([^)]+\))?:/)
+            const author = pullRequest.user.login
+            const authorLabel = authorLabels[author]
+
+            if (!match) {
+              core.info(`No PR type found in title: ${title}`)
+            }
+
+            const type = match?.[1].toLowerCase()
+            const typeLabel = type ? typeLabels[type] : undefined
+
+            if (type && !typeLabel) {
+              core.info(`No label mapping found for PR type: ${type}`)
+            }
+
+            if (!authorLabel) {
+              core.info(`No author label mapping found for PR author: ${author}`)
+            }
+
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const issue_number = pullRequest.number
+            const typeLabelNames = Object.values(typeLabels)
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number,
+            })
+
+            const currentLabelNames = currentLabels.map((label) => label.name)
+            const labelsToRemove = typeLabel
+              ? currentLabelNames.filter(
+                  (label) => typeLabelNames.includes(label) && label !== typeLabel,
+                )
+              : []
+
+            await Promise.all(
+              labelsToRemove.map((label) =>
+                github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: label,
+                }),
+              ),
+            )
+
+            const labelsToAdd = [typeLabel, authorLabel].filter(
+              (label) => label && !currentLabelNames.includes(label),
+            )
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: labelsToAdd,
+              })
+            }

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -1,0 +1,324 @@
+name: Discord PR Notify
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, closed]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send PR notification to Discord
+        uses: actions/github-script@v7
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        with:
+          script: |
+            const webhookUrl = process.env.DISCORD_WEBHOOK_URL
+
+            if (!webhookUrl) {
+              core.setFailed('DISCORD_WEBHOOK_URL secret is required.')
+              return
+            }
+
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+
+            const colors = {
+              opened: 0x57cc99,
+              review: 0xffd166,
+              mergeable: 0x80ed99,
+              merged: 0x90dbf4,
+              stale: 0xffadad,
+            }
+
+            const truncate = (text, maxLength = 240) => {
+              if (!text) {
+                return '내용 없음'
+              }
+
+              return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text
+            }
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+            const getAuthor = (pullRequest) => ({
+              name: pullRequest.user.login,
+              icon_url: pullRequest.user.avatar_url,
+              url: pullRequest.user.html_url,
+            })
+
+            const sendDiscord = async ({
+              title,
+              url,
+              description,
+              color,
+              author,
+              fields = [],
+            }) => {
+              const response = await fetch(webhookUrl, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                  embeds: [
+                    {
+                      title,
+                      url,
+                      description,
+                      color,
+                      author,
+                      fields,
+                      footer: {
+                        text: 'TEAM-SIKSA GitHub Automation',
+                      },
+                      timestamp: new Date().toISOString(),
+                    },
+                  ],
+                }),
+              })
+
+              if (!response.ok) {
+                const body = await response.text()
+                core.setFailed(`Discord notification failed: ${response.status} ${body}`)
+              }
+            }
+
+            const getPullRequestState = async (number) => {
+              const query = `
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewDecision
+                      mergeStateStatus
+                      isDraft
+                    }
+                  }
+                }
+              `
+
+              const result = await github.graphql(query, {
+                owner,
+                repo,
+                number,
+              })
+
+              return result.repository.pullRequest
+            }
+
+            const createPrFields = (pullRequest) => [
+              {
+                name: 'Author',
+                value: `@${pullRequest.user.login}`,
+                inline: true,
+              },
+            ]
+
+            if (context.eventName === 'schedule' || context.eventName === 'workflow_dispatch') {
+              const now = Date.now()
+              const oneDay = 24 * 60 * 60 * 1000
+              const { data: pullRequests } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              })
+
+              const stalePullRequests = pullRequests.filter((pullRequest) => {
+                return !pullRequest.draft && now - new Date(pullRequest.created_at).getTime() >= oneDay
+              })
+
+              if (stalePullRequests.length === 0) {
+                core.info('No stale pull requests found.')
+                return
+              }
+
+              const description = stalePullRequests
+                .slice(0, 10)
+                .map((pullRequest) => {
+                  const createdAt = new Date(pullRequest.created_at).toISOString().slice(0, 10)
+                  return `- [#${pullRequest.number} ${pullRequest.title}](${pullRequest.html_url}) / @${pullRequest.user.login} / ${createdAt}`
+                })
+                .join('\n')
+
+              await sendDiscord({
+                title: '⏰ 24시간 이상 머지되지 않은 PR',
+                url: `https://github.com/${owner}/${repo}/pulls`,
+                description,
+                color: colors.stale,
+                fields: [
+                  {
+                    name: 'Count',
+                    value: `${stalePullRequests.length}`,
+                    inline: true,
+                  },
+                ],
+              })
+
+              return
+            }
+
+            if (context.eventName === 'pull_request_target') {
+              let pullRequest = context.payload.pull_request
+              const action = context.payload.action
+
+              if (action === 'closed' && !pullRequest.merged) {
+                core.info('PR was closed without merge. Skipping Discord notification.')
+                return
+              }
+
+              if (action !== 'closed') {
+                await sleep(10000)
+
+                const { data: refreshedPullRequest } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pullRequest.number,
+                })
+
+                pullRequest = refreshedPullRequest
+              }
+
+              const titleByAction = {
+                opened: '🆕 새 PR이 올라왔어요',
+                reopened: '🔄 PR이 다시 열렸어요',
+                ready_for_review: '👀 Draft PR이 리뷰 준비 상태가 됐어요',
+                closed: '✅ PR이 머지됐어요',
+              }
+
+              const requestedReviewers = [
+                ...pullRequest.requested_reviewers.map((reviewer) => `@${reviewer.login}`),
+                ...pullRequest.requested_teams.map((team) => `@${owner}/${team.slug}`),
+              ]
+
+              const fields = [
+                ...createPrFields(pullRequest),
+                {
+                  name: 'Event',
+                  value: action,
+                  inline: true,
+                },
+              ]
+
+              if (action !== 'closed') {
+                fields.push({
+                  name: 'Requested Reviewers',
+                  value: requestedReviewers.length > 0 ? requestedReviewers.join(', ') : '없음',
+                  inline: false,
+                })
+              }
+
+              await sendDiscord({
+                title: titleByAction[action],
+                url: pullRequest.html_url,
+                description: `[#${pullRequest.number}] ${pullRequest.title}\n\n${truncate(pullRequest.body)}`,
+                color: action === 'closed' ? colors.merged : colors.opened,
+                author: getAuthor(pullRequest),
+                fields,
+              })
+
+              return
+            }
+
+            if (context.eventName === 'check_suite') {
+              const checkSuite = context.payload.check_suite
+
+              if (checkSuite.conclusion !== 'success') {
+                core.info(`Check suite conclusion is ${checkSuite.conclusion}. Skipping.`)
+                return
+              }
+
+              const pullRequestReference = checkSuite.pull_requests?.[0]
+
+              if (!pullRequestReference) {
+                core.info('No pull request found for this check suite.')
+                return
+              }
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullRequestReference.number,
+              })
+
+              const state = await getPullRequestState(pullRequest.number)
+
+              if (
+                state.reviewDecision === 'APPROVED' &&
+                state.mergeStateStatus === 'CLEAN' &&
+                !state.isDraft
+              ) {
+                await sendDiscord({
+                  title: '🟢 PR이 머지 가능한 상태가 됐어요',
+                  url: pullRequest.html_url,
+                  description: `[#${pullRequest.number}] ${pullRequest.title}`,
+                  color: colors.mergeable,
+                  author: getAuthor(pullRequest),
+                  fields: createPrFields(pullRequest),
+                })
+              }
+
+              return
+            }
+
+            if (context.eventName === 'pull_request_review') {
+              const pullRequest = context.payload.pull_request
+              const review = context.payload.review
+              const reviewState = review.state.toLowerCase()
+
+              await sendDiscord({
+                title: '💬 PR 리뷰가 등록됐어요',
+                url: pullRequest.html_url,
+                description: `[#${pullRequest.number}] ${pullRequest.title}\n\n${truncate(review.body)}`,
+                color: colors.review,
+                author: {
+                  name: review.user.login,
+                  icon_url: review.user.avatar_url,
+                  url: review.user.html_url,
+                },
+                fields: [
+                  ...createPrFields(pullRequest),
+                  {
+                    name: 'Reviewer',
+                    value: `@${review.user.login}`,
+                    inline: true,
+                  },
+                  {
+                    name: 'Review Status',
+                    value: reviewState,
+                    inline: true,
+                  },
+                ],
+              })
+
+              const state = await getPullRequestState(pullRequest.number)
+
+              if (
+                reviewState === 'approved' &&
+                state.reviewDecision === 'APPROVED' &&
+                state.mergeStateStatus === 'CLEAN' &&
+                !state.isDraft
+              ) {
+                await sendDiscord({
+                  title: '🟢 PR이 머지 가능한 상태가 됐어요',
+                  url: pullRequest.html_url,
+                  description: `[#${pullRequest.number}] ${pullRequest.title}`,
+                  color: colors.mergeable,
+                  author: getAuthor(pullRequest),
+                  fields: createPrFields(pullRequest),
+                })
+              }
+            }


### PR DESCRIPTION
## 📌 Summary
> PR 생성 시 코드 리뷰어 자동 요청, PR 작성자 자동 assignee 지정, PR 제목 기반 라벨 자동 할당, Discord PR 알림 자동화를 설정했습니다.

Jira: [SIKSA-22](https://siksa.atlassian.net/browse/SIKSA-22?atlOrigin=eyJpIjoiYjZmMDBkNDk3YWQwNGUxZWI1YjliNmY5Nzg5NDlhMmIiLCJwIjoiaiJ9)

## 📚 Tasks
- CODEOWNERS 기반 오토 리뷰어 설정
- PR 작성자 자동 assignee 지정 workflow 추가
- PR 제목 타입 기반 라벨 자동 할당 workflow 추가
- PR 작성자 기준 담당자 라벨 자동 할당 설정
- Discord PR 알림 workflow 추가

## 🔍 Details

### CODEOWNERS 기반 오토 리뷰어 설정

- `.github/CODEOWNERS`를 추가해 모든 파일 변경에 대해 `@TEAM-SIKSA/siksa-client` 팀이 자동 리뷰어로 요청되도록 설정했습니다.

```txt
* @TEAM-SIKSA/siksa-client
```
- `develop` 브랜치에 머지된 이후부터 `develop`을 base로 하는 PR이 생성되면 `@TEAM-SIKSA/siksa-client` 팀이 자동으로 리뷰어로 요청될 겁니다!

### PR 작성자 자동 assignee 지정

- `.github/workflows/auto-assign-author.yml`을 추가해 PR이 생성되거나, Draft PR이 리뷰 가능한 상태가 되거나, 닫혔던 PR이 다시 열렸을 때 PR 작성자를 자동으로 assignee에 추가합니다.

동작 대상

```txt
PR opened
PR ready_for_review
PR reopened
```

예시

```txt
PR 작성자: jyeon03
→ Assignees: jyeon03
```

-> GitHub Issue는 Jira로 관리하기 때문에 issue 이벤트는 제외했습니다.

### PR 제목 기반 라벨 자동 할당

- `.github/workflows/auto-label.yml`을 추가해 PR 제목의 타입을 기준으로 작업 유형 라벨을 자동으로 붙입니다.

예시

```txt
Feat(client): 로그인 페이지 구현
→ ✨ FEAT

Fix(sds): Button 스타일 수정
→ 🩹 FIX

Init(project): GitHub 자동화 설정
→ 🌱 INIT
```

지원 타입
```txt
docs      → 📝 DOCS
feat      → ✨ FEAT
init      → 🌱 INIT
fix       → 🩹 FIX
test      → 🧪 TEST
deploy    → 🚀 DEPLOY
refactor  → ♻️ REFACTOR
style     → 🎨 STYLE
chore     → 🧹 CHORE
```

- PR 제목 타입은 대소문자를 구분하지 않도록 처리했습니다.

```txt
Feat(client):
feat(client):
FEAT(client):
```
- 위 세 경우 모두 `✨ FEAT` 라벨이 붙습니다.
- PR 제목이 수정되어 타입이 바뀌면 기존 타입 라벨은 제거되고 새 타입 라벨이 붙도록 설정했습니다!

예시

```txt
Feat(client): 로그인 페이지 구현
→ ✨ FEAT

Fix(client): 로그인 오류 수정
→ ✨ FEAT 제거
→ 🩹 FIX 추가
```

### PR 작성자 담당자 라벨 자동 할당

- PR 작성자 GitHub 계정을 기준으로 담당자 라벨도 자동으로 붙도록 설정했습니다.

```txt
gyeongbibin → 🫪 경빈
chungyo     → 🥸 충영
MinseoSONG  → 😋 민서
yurimidaH   → 😜 유림
jyeon03     → 🙄 지연
```

예시

```txt
PR 제목: Feat(client): 로그인 페이지 구현
작성자: jyeon03

자동 라벨: ✨ FEAT 🙄 지연
```

### Discord PR 알림 자동화

- `.github/workflows/discord-pr-notify.yml`을 추가해 Discord Webhook을 통해 PR 상태 변화가 있을 때 지정된 Discord 채널로 알림을 전송합니다.
- Webhook URL은 코드에 직접 넣지 않고 GitHub Secret으로 관리하도록 했습니다!

### Discord 알림 대상

현재 Discord 알림은 아래 상황에서 전송됩니다.

```txt
PR opened
PR reopened
PR ready_for_review
PR review submitted
PR mergeable
PR merged
24시간 이상 미머지 PR
```

- `review_requested` 이벤트는 별도 알림에서 제외했습니다. CODEOWNERS 리뷰어 자동 할당 직후 중복 알림이 발생할 수 있기 때문에, PR opened 알림에 `Requested Reviewers` 정보를 함께 보여주는 방식으로 처리했습니다.

- PR opened / reopened / ready_for_review 알림은 CODEOWNERS 리뷰어가 반영될 시간을 고려해 10초 대기 후 PR 정보를 다시 조회하도록 설정했습니다.

### Discord 알림 예시

#### PR opened

```txt
🆕 새 PR이 올라왔어요

#12 Feat(client): 로그인 페이지 구현

로그인 페이지 UI와 라우팅을 구현했습니다.

Author
@jyeon03

Event
opened

Requested Reviewers
@TEAM-SIKSA/siksa-client
```

#### PR reopened

```txt
🔄 PR이 다시 열렸어요

#12 Feat(client): 로그인 페이지 구현

로그인 페이지 UI와 라우팅을 구현했습니다.

Author
@jyeon03

Event
reopened

Requested Reviewers
@TEAM-SIKSA/siksa-client
```

#### PR ready_for_review

```txt
👀 Draft PR이 리뷰 준비 상태가 됐어요

#12 Feat(client): 로그인 페이지 구현

로그인 페이지 UI와 라우팅을 구현했습니다.

Author
@jyeon03

Event
ready_for_review

Requested Reviewers
@TEAM-SIKSA/siksa-client
```

#### PR review submitted

```txt
💬 PR 리뷰가 등록됐어요

#12 Feat(client): 로그인 페이지 구현

수정 필요한 부분 코멘트 남겼습니다.

Author
@jyeon03

Reviewer
@chungyo

Review Status
changes_requested
```

리뷰 상태는 아래 값 중 하나로 표시됩니다.

```txt
approved
changes_requested
commented
```

#### PR mergeable

```txt
🟢 PR이 머지 가능한 상태가 됐어요

#12 Feat(client): 로그인 페이지 구현

Author
@jyeon03
```

- 머지 가능 알림은 아래 조건을 만족했을 때 전송됩니다.

```txt
리뷰 승인 조건 충족
충돌 없음
Draft PR 아님
```

- 리뷰 승인 이후 바로 머지 가능해지는 경우와, CI/check 통과 이후 머지 가능해지는 경우를 모두 고려했습니다.

#### PR merged

```txt
✅ PR이 머지됐어요

#12 Feat(client): 로그인 페이지 구현

로그인 페이지 UI와 라우팅을 구현했습니다.

Author
@jyeon03

Event
closed
```

- 단순히 close된 PR은 알림을 보내지 않고, 실제로 merge된 PR에 대해서만 알림을 보냅니다.

#### 24시간 이상 미머지 PR

```txt
⏰ 24시간 이상 머지되지 않은 PR

- #12 Feat(client): 로그인 페이지 구현 / @jyeon03 / 2026-06-21
- #13 Fix(sds): Button 스타일 수정 / @MinseoSONG / 2026-06-21

Count
2
```

- 매일 오전 9시 KST에 열린 PR을 확인하고, 24시간 이상 머지되지 않은 PR이 있으면 알림을 보냅니다.
- GitHub Actions cron은 UTC 기준이므로 아래처럼 설정했습니다.
- Draft PR은 아직 리뷰 대상이 아니므로 24시간 미머지 알림 대상에서 제외했습니다.