### PR TITLE
Init(project): Sentry 세팅 및 디스코드 알림 연동 

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   label:

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -20,6 +20,10 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -16,6 +16,10 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
 
     steps:
       - name: Checkout

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@sentry/react": "catalog:",
     "@siksa/sds-ui": "workspace:*",
     "clsx": "catalog:",
     "react": "catalog:",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
+    "@sentry/vite-plugin": "catalog:",
     "@tailwindcss/vite": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/apps/client/src/app/main.tsx
+++ b/apps/client/src/app/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import * as Sentry from '@sentry/react'
 import { App } from '@/app/App'
+import { initSentry } from '@/shared/lib/sentry'
 import '@/app/styles/global.css'
+
+initSentry()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Sentry.ErrorBoundary fallback={<p>문제가 발생했습니다.</p>}>
+      <App />
+    </Sentry.ErrorBoundary>
   </StrictMode>,
 )

--- a/apps/client/src/shared/lib/sentry.ts
+++ b/apps/client/src/shared/lib/sentry.ts
@@ -8,7 +8,12 @@ export function initSentry() {
     dsn,
     environment: import.meta.env.VITE_VERCEL_ENV,
     release: import.meta.env.VITE_APP_VERSION,
-    integrations: [Sentry.browserTracingIntegration()],
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
     tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+    replaysSessionSampleRate: import.meta.env.PROD ? 0.1 : 0,
+    replaysOnErrorSampleRate: 1.0,
   })
 }

--- a/apps/client/src/shared/lib/sentry.ts
+++ b/apps/client/src/shared/lib/sentry.ts
@@ -8,12 +8,7 @@ export function initSentry() {
     dsn,
     environment: import.meta.env.VITE_VERCEL_ENV,
     release: import.meta.env.VITE_APP_VERSION,
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
-    ],
+    integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
-    replaysSessionSampleRate: import.meta.env.PROD ? 0.1 : 0,
-    replaysOnErrorSampleRate: 1.0,
   })
 }

--- a/apps/client/src/shared/lib/sentry.ts
+++ b/apps/client/src/shared/lib/sentry.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/react'
+
+export function initSentry() {
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_VERCEL_ENV,
+    release: import.meta.env.VITE_APP_VERSION,
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+  })
+}

--- a/apps/client/src/vite-env.d.ts
+++ b/apps/client/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SENTRY_DSN: string
+  readonly VITE_VERCEL_ENV: string
+  readonly VITE_APP_VERSION: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -1,21 +1,42 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+
+const release =
+  process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA ?? 'local'
 
 export default defineConfig({
   define: {
     'import.meta.env.VITE_VERCEL_ENV': JSON.stringify(
       process.env.VERCEL_ENV ?? 'development',
     ),
-    'import.meta.env.VITE_APP_VERSION': JSON.stringify(
-      process.env.VERCEL_GIT_COMMIT_SHA ?? 'local',
-    ),
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(release),
+  },
+  build: {
+    sourcemap: process.env.SENTRY_AUTH_TOKEN ? 'hidden' : false,
   },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    ...(process.env.SENTRY_AUTH_TOKEN
+      ? [
+          sentryVitePlugin({
+            org: process.env.SENTRY_ORG!,
+            project: process.env.SENTRY_PROJECT!,
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            release: { name: release },
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['./dist/**/*.map'],
+            },
+          }),
+        ]
+      : []),
+  ],
 })

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -4,6 +4,14 @@ import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
+  define: {
+    'import.meta.env.VITE_VERCEL_ENV': JSON.stringify(
+      process.env.VERCEL_ENV ?? 'development',
+    ),
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(
+      process.env.VERCEL_GIT_COMMIT_SHA ?? 'local',
+    ),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@sentry/react':
       specifier: ^10.60.0
       version: 10.60.0
+    '@sentry/vite-plugin':
+      specifier: ^5.3.0
+      version: 5.3.0
     '@tailwindcss/vite':
       specifier: ^4.3.1
       version: 4.3.1
@@ -150,6 +153,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
+      '@sentry/vite-plugin':
+        specifier: 'catalog:'
+        version: 5.3.0
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.0)(jiti@2.7.0)(tsx@4.21.0))
@@ -1277,6 +1283,10 @@ packages:
       rollup:
         optional: true
 
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
   '@sentry/browser-utils@10.60.0':
     resolution: {integrity: sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==}
     engines: {node: '>=18'}
@@ -1284,6 +1294,62 @@ packages:
   '@sentry/browser@10.60.0':
     resolution: {integrity: sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==}
     engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
 
   '@sentry/core@10.60.0':
     resolution: {integrity: sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==}
@@ -1306,6 +1372,19 @@ packages:
   '@sentry/replay@10.60.0':
     resolution: {integrity: sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==}
     engines: {node: '>=18'}
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
+    engines: {node: '>= 18'}
 
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
@@ -1673,6 +1752,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1897,6 +1980,10 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2209,6 +2296,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2734,6 +2825,10 @@ packages:
   pretty-ms@7.0.1:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   promisepipe@3.0.0:
     resolution: {integrity: sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==}
@@ -3933,6 +4028,8 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.4
 
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
   '@sentry/browser-utils@10.60.0':
     dependencies:
       '@sentry/core': 10.60.0
@@ -3944,6 +4041,63 @@ snapshots:
       '@sentry/feedback': 10.60.0
       '@sentry/replay': 10.60.0
       '@sentry/replay-canvas': 10.60.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/core@10.60.0': {}
 
@@ -3966,6 +4120,23 @@ snapshots:
     dependencies:
       '@sentry/browser-utils': 10.60.0
       '@sentry/core': 10.60.0
+
+  '@sentry/rollup-plugin@5.3.0':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.3.0':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/rollup-plugin': 5.3.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
   '@sinclair/typebox@0.25.24': {}
 
@@ -4526,6 +4697,12 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv@6.15.0:
@@ -4691,6 +4868,8 @@ snapshots:
   depd@1.1.2: {}
 
   detect-libc@2.1.2: {}
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5108,6 +5287,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -5494,6 +5680,8 @@ snapshots:
   pretty-ms@7.0.1:
     dependencies:
       parse-ms: 2.1.0
+
+  progress@2.0.3: {}
 
   promisepipe@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@eslint/js':
       specifier: ^10.0.1
       version: 10.0.1
+    '@sentry/react':
+      specifier: ^10.60.0
+      version: 10.60.0
     '@tailwindcss/vite':
       specifier: ^4.3.1
       version: 4.3.1
@@ -119,6 +122,9 @@ importers:
 
   apps/client:
     dependencies:
+      '@sentry/react':
+        specifier: 'catalog:'
+        version: 10.60.0(react@19.2.7)
       '@siksa/sds-ui':
         specifier: workspace:*
         version: link:../../packages/sds-ui
@@ -761,6 +767,36 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@sentry/browser-utils@10.60.0':
+    resolution: {integrity: sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.60.0':
+    resolution: {integrity: sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.60.0':
+    resolution: {integrity: sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.60.0':
+    resolution: {integrity: sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.60.0':
+    resolution: {integrity: sha512-ALRIDOj7T1Vk9t9IyI12Tq2t3MKoV2F/mKn140AiUBk3WzQhq2gXQUFpcsaDYA2FBsrYoYc6qdqrny6mMbA0Xg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.60.0':
+    resolution: {integrity: sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.60.0':
+    resolution: {integrity: sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==}
+    engines: {node: '>=18'}
 
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
@@ -2107,6 +2143,40 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@sentry/browser-utils@10.60.0':
+    dependencies:
+      '@sentry/core': 10.60.0
+
+  '@sentry/browser@10.60.0':
+    dependencies:
+      '@sentry/browser-utils': 10.60.0
+      '@sentry/core': 10.60.0
+      '@sentry/feedback': 10.60.0
+      '@sentry/replay': 10.60.0
+      '@sentry/replay-canvas': 10.60.0
+
+  '@sentry/core@10.60.0': {}
+
+  '@sentry/feedback@10.60.0':
+    dependencies:
+      '@sentry/core': 10.60.0
+
+  '@sentry/react@10.60.0(react@19.2.7)':
+    dependencies:
+      '@sentry/browser': 10.60.0
+      '@sentry/core': 10.60.0
+      react: 19.2.7
+
+  '@sentry/replay-canvas@10.60.0':
+    dependencies:
+      '@sentry/core': 10.60.0
+      '@sentry/replay': 10.60.0
+
+  '@sentry/replay@10.60.0':
+    dependencies:
+      '@sentry/browser-utils': 10.60.0
+      '@sentry/core': 10.60.0
 
   '@tailwindcss/node@4.3.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 
 catalog:
   '@eslint/js': ^10.0.1
+  '@sentry/react': ^10.60.0
   '@tailwindcss/vite': ^4.3.1
   '@turbo/gen': ^2.7.2
   '@types/node': ^24.12.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 catalog:
   '@eslint/js': ^10.0.1
   '@sentry/react': ^10.60.0
+  '@sentry/vite-plugin': ^5.3.0
   '@tailwindcss/vite': ^4.3.1
   '@turbo/gen': ^2.7.2
   '@types/node': ^24.12.3


### PR DESCRIPTION
## 📌 Summary
Jira: [SIKSA-25](https://siksa.atlassian.net/browse/SIKSA-25?atlOrigin=eyJpIjoiMzk4YjI4ZDAyMWQ1NDczZjg3MTZjN2Y1ZTk2ODg4ZWMiLCJwIjoiaiJ9
)
클라이언트 앱(apps/client)에 Sentry 에러 모니터링을 연동했습니다.

- @sentry/react 의존성 추가 및 catalog 등록
- shared/lib/sentry.ts에서 initSentry()로 초기화
- environment / release는 Vite define으로 Vercel 빌드 정보 주입
- Sentry.ErrorBoundary 설정
- apps/client/.env 에 VITE_SENTRY_DSN 설정

```
apps/client/
  src/
    app/
      main.tsx              # initSentry + ErrorBoundary
    shared/
      lib/
        sentry.ts           # Sentry 설정
    vite-env.d.ts             # env 타입
  vite.config.ts              # VERCEL_ENV / commit SHA 주입
  .env                        # 로컬 DSN
```

## 📚 Tasks

### Sentry란?
#### 운영 중인 서비스에서 발생하는 에러를 실시간으로 수집하고, 원인을 분석하고, 팀에게 알려주는 플랫폼

운영 환경에서 발생하는 프론트엔드 에러를 실시간으로 수집하고 모니터링하기 위해 Sentry를 연동했습니다.
에러 발생 시 Sentry에서 자동으로 수집해서 Discord 알림을 통해 여러분들이 즉시 확인할 수 있도록 구성했어요.
어느 파일 몇번째에서 왜 터졌는지 명확하게 확인할 수 있는 장점이 있습니다.
디코 연동 확인을 위해서 
<img width="463" height="182" alt="image" src="https://github.com/user-attachments/assets/ef7152fc-2c30-40f9-a9b5-fa3468685ce6" />
 Alert 하나를 푸시해보았습니다.  현재는 무분별한 에러 푸시 알림을 막기 위해서 Alert 조건이 "10번 이상 발생"으로 되어 있어요. 해당 부분은 설정 하나만 바꿔주면되어서 추후에 바로 수정 가능합니다.

에러 트래킹이 잘 되고 있는지 테스트를 아래와 같이 해보았고요. Sentry 앱에서는 
<img width="1172" height="541" alt="image" src="https://github.com/user-attachments/assets/4d34ee15-ea04-4d70-9561-b82a3b213f3c" />


해당 이슈페이지에서 확인할 수 있습니다. 확인해보니 같은 에러에는 하나의 이슈만 생성이 되고 이벤트 수·마지막 발생 시각만 갱신되는 형식입니다.

 ### Preview / Production 환경 구분

Vercel preview·production 배포에 맞춰 Sentry environment / release를 설정했습니다.
<img width="458" height="185" alt="image" src="https://github.com/user-attachments/assets/c1b26eb1-ba86-43bf-a2fe-c9287ad678f1" />
Sentry 프로젝트·DSN은 하나이고, preview/production은 environment 태그로 구분합니다.

Sentry에 대해서 추가적으로 공부하는 게 좋을 것같아서 아래 링크 추가합니다.
[React Sentry 공식 문서](https://docs.sentry.io/platforms/javascript/guides/react/?utm_source=chatgpt.com)
[카카오페이 기술 블로그](https://tech.kakaopay.com/post/frontend-sentry-monitoring/?utm_source=chatgpt.com)


### Source Map 업로드 자동화

@sentry/vite-plugin 추가

```
vercel build
↓
Source Map 생성
↓
Sentry 업로드
↓
에러와 Source Map 매핑
```
4. Release 기반 에러 매핑

Release 값을 다음 우선순위로 생성합니다.

```
VERCEL_GIT_COMMIT_SHA
↓
GITHUB_SHA
↓
local
```
SDK와 Vite Plugin이 동일한 Release 값을 사용하도록 설정했고 이를 통해 어느 배포 버전에서 발생한 에러인지 정확히 추적할 수 있습니다. 추가적으로 apps/client/src/app/App.tsx:12 식으로 정확한 에러 위치 파악이 가능합니다. 
또 추가한 속성으로는 
`sourcemap: 'hidden'` : 브라우저에 Source Map 참조 노출 방지

`filesToDeleteAfterUpload: [ './dist/**/*.map',]` : 업로드 후 Source Map 제거

이외에도 제외해도 될 것같긴한 부분인데 Session Replay 추가해서 사용자 행동을 트래킹하도록 설정했습니다. 근데 투머치인거같긴해요.


## 👀 To Reviewer
- Sentry 초대 금방해드릴게요 ! env에 DSN 가져와서 설정해두시면 됩니다
- ErrorBoundary fallback를 넣어두긴했는데 제외할까요?
<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
