### PR TITLE
Chore(hds): HASHI-35 HDS 패키지 entry 설정 보강

### DIFF
--- a/packages/hds-icons/package.json
+++ b/packages/hds-icons/package.json
@@ -3,9 +3,13 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "types": "./src/index.ts",
+      "import": "./src/index.ts",
       "default": "./src/index.ts"
     }
   },

--- a/packages/hds-ui/package.json
+++ b/packages/hds-ui/package.json
@@ -3,9 +3,13 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "types": "./src/index.ts",
+      "import": "./src/index.ts",
       "default": "./src/index.ts"
     }
   },


### PR DESCRIPTION
## 📌 Summary
> HDS 패키지를 client에서 사용할 때 public entry를 더 명확하게 인식할 수 있도록 package entry 설정을 보강했습니다.

Jira: [HASHI-35](https://siksa.atlassian.net/browse/HASHI-35?atlOrigin=eyJpIjoiNDNmMTJhNDljMGQzNGFkMzg0ZWJhNTI4MjkzMGQzMzMiLCJwIjoiaiJ9)

## 📚 Tasks
- `@hashi/hds-ui` package entry 설정 보강
  - `main`
  - `module`
  - `types`
  - `exports.import`
- `@hashi/hds-icons` package entry 설정 보강
  - `main`
  - `module`
  - `types`
  - `exports.import`
- client에서 `Button`, `CheckIcon`, `IconProps` public import가 타입 체크되는지 확인

## 👀 To Reviewer
기존에는 HDS 패키지의 `exports`에 `types`와 `default`만 명시되어 있어, client/IDE가 패키지의 public entry를 안정적으로 해석하기 어려운 상태였습니다. client에서 HDS component/icon을 사용할 때 자동 import 후보가 누락되거나 자동완성이 잡히지 않는 문제가 있었어요...!