### PR TITLE
Chore(root): HASHI-57 Codex hook 추가

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/session_start_primer.py\"",
+            "timeout": 30,
+            "statusMessage": "Loading HASHI project context"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_use_bash_guard.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking Bash command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/pre_tool_use_bash_guard.py
+++ b/.codex/hooks/pre_tool_use_bash_guard.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Block risky Bash commands before Codex runs them."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from dataclasses import dataclass
+
+
+BLOCKED_PACKAGE_MANAGERS = {"npm", "npx", "yarn", "bun", "bunx"}
+COMMAND_SEPARATORS = {"&&", "||", ";", "|", "(", ")"}
+PNPM_SCOPE_FLAGS = {"--filter", "-F", "-w", "--workspace-root"}
+GIT_OPTIONS_WITH_VALUE = {
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--config-env",
+}
+
+
+@dataclass(frozen=True)
+class BlockDecision:
+    reason: str
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+
+
+def command_from_payload(payload: dict) -> str:
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return ""
+    command = tool_input.get("command") or tool_input.get("cmd") or ""
+    return command if isinstance(command, str) else ""
+
+
+def tokenize(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        return list(lexer)
+    except ValueError:
+        try:
+            return shlex.split(command, posix=True)
+        except ValueError:
+            return command.split()
+
+
+def command_segments(tokens: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = []
+    current: list[str] = []
+
+    for token in tokens:
+        if token in COMMAND_SEPARATORS:
+            if current:
+                segments.append(current)
+                current = []
+            continue
+        current.append(token)
+
+    if current:
+        segments.append(current)
+
+    return segments
+
+
+def binary_name(token: str) -> str:
+    return os.path.basename(token)
+
+
+def is_assignment(token: str) -> bool:
+    return re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token) is not None
+
+
+def command_index(segment: list[str]) -> int | None:
+    index = 0
+    while index < len(segment) and is_assignment(segment[index]):
+        index += 1
+
+    if index >= len(segment):
+        return None
+
+    if binary_name(segment[index]) == "env":
+        index += 1
+        while index < len(segment) and (is_assignment(segment[index]) or segment[index].startswith("-")):
+            index += 1
+
+    return index if index < len(segment) else None
+
+
+def effective_command(segment: list[str]) -> tuple[str, list[str]] | None:
+    index = command_index(segment)
+    if index is None:
+        return None
+
+    command = binary_name(segment[index])
+    args = segment[index + 1 :]
+
+    if command == "corepack" and args:
+        return binary_name(args[0]), args[1:]
+
+    return command, args
+
+
+def git_command(args: list[str]) -> tuple[str, list[str]] | None:
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            return None
+        if not token.startswith("-"):
+            return token, args[index + 1 :]
+        if token in GIT_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if any(token.startswith(f"{option}=") for option in GIT_OPTIONS_WITH_VALUE):
+            index += 1
+            continue
+        index += 1
+    return None
+
+
+def has_git_clean_force_directory(args: list[str]) -> bool:
+    if any(token in {"-n", "--dry-run"} for token in args):
+        return False
+
+    option_chars = ""
+    long_force = False
+    long_directory = False
+
+    for token in args:
+        if token.startswith("--"):
+            long_force = long_force or token == "--force"
+            long_directory = long_directory or token == "--directory"
+            continue
+        if token.startswith("-"):
+            option_chars += token.lstrip("-")
+
+    return ("f" in option_chars or long_force) and ("d" in option_chars or long_directory)
+
+
+def has_rm_force_recursive(args: list[str]) -> bool:
+    option_chars = ""
+    long_force = False
+    long_recursive = False
+
+    for token in args:
+        if token.startswith("--"):
+            long_force = long_force or token == "--force"
+            long_recursive = long_recursive or token in {"--recursive", "--dir"}
+            continue
+        if token.startswith("-"):
+            option_chars += token.lstrip("-")
+
+    return ("f" in option_chars or long_force) and ("r" in option_chars or "R" in option_chars or long_recursive)
+
+
+def has_pnpm_workspace_scope(args: list[str]) -> bool:
+    for token in args:
+        if token in PNPM_SCOPE_FLAGS:
+            return True
+        if token.startswith("--filter="):
+            return True
+    return False
+
+
+def is_force_push_token(token: str) -> bool:
+    return token in {"--force", "--force-with-lease", "-f"} or token.startswith("--force-with-lease=")
+
+
+def check_git(args: list[str]) -> BlockDecision | None:
+    parsed = git_command(args)
+    if parsed is None:
+        return None
+
+    subcommand, sub_args = parsed
+
+    if subcommand == "reset" and "--hard" in sub_args:
+        return BlockDecision("Destructive git command blocked: git reset --hard.")
+
+    if subcommand == "checkout" and "--" in sub_args:
+        return BlockDecision("Destructive git command blocked: git checkout -- can discard local changes.")
+
+    if subcommand == "clean" and has_git_clean_force_directory(sub_args):
+        return BlockDecision("Destructive git command blocked: git clean with force and directory flags.")
+
+    if subcommand == "push" and any(is_force_push_token(token) for token in sub_args):
+        return BlockDecision("Destructive git command blocked: force push requires explicit human intent.")
+
+    return None
+
+
+def check_segment(segment: list[str]) -> BlockDecision | None:
+    command_info = effective_command(segment)
+    if command_info is None:
+        return None
+
+    command, args = command_info
+
+    if command in BLOCKED_PACKAGE_MANAGERS:
+        return BlockDecision("Use pnpm in this repository instead of npm, npx, yarn, bun, or bunx.")
+
+    if command == "git":
+        return check_git(args)
+
+    if command == "rm" and has_rm_force_recursive(args):
+        return BlockDecision("Destructive shell command blocked: rm with recursive and force flags.")
+
+    if command == "pnpm" and "add" in args and not has_pnpm_workspace_scope(args):
+        return BlockDecision("Use `pnpm --filter <workspace> add ...` or `pnpm add -w ...` when adding dependencies.")
+
+    return None
+
+
+def deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def main() -> int:
+    command = command_from_payload(read_payload()).strip()
+    if not command:
+        return 0
+
+    for segment in command_segments(tokenize(command)):
+        decision = check_segment(segment)
+        if decision is not None:
+            deny(decision.reason)
+            return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/session_start_primer.py
+++ b/.codex/hooks/session_start_primer.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Inject a short HASHI project primer at Codex session start."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+PRIMER = """HASHI Client project context:
+- Use pnpm only. Do not use npm, yarn, or bun in this repository.
+- Before editing, classify the work from AGENTS.md and read only the task-relevant docs.
+- Check git status with `git status --short --branch --untracked-files=all` before changes.
+- docs/ is the human-readable source of truth. .agents/ contains agent-facing checklists, recipes, skills, and scripts that operationalize docs/.
+- If docs/ and .agents/ conflict, follow docs/ first and align .agents/ afterward.
+- For page, shared component, hook, API query/mutation, or HDS work, check whether a nearby *.spec.md is required.
+- Keep HDS packages product-agnostic: no app route, API, query, mutation, tracking, product copy, or domain data in packages/hds-ui or packages/hds-icons.
+- Before final response, report docs impact and verification commands/results."""
+
+
+def read_payload() -> dict:
+    try:
+        return json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return {}
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def main() -> int:
+    payload = read_payload()
+    repo_root = Path(__file__).resolve().parents[2]
+    cwd = Path(payload.get("cwd") or repo_root).resolve()
+
+    if not is_relative_to(cwd, repo_root):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": PRIMER,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Git Convention](./docs/conventions/git.md)
 - [Package Management](./docs/conventions/package-management.md)
 - [Agent Skills](./docs/agent/skills.md)
+- [Codex Hooks](./docs/agent/hooks.md)
 - [Serena MCP](./docs/agent/serena-mcp.md)
 
 ## Rules

--- a/docs/agent/hooks.md
+++ b/docs/agent/hooks.md
@@ -1,0 +1,61 @@
+# Codex Hooks
+
+이 문서는 HASHI Client repo-local Codex hook 운영 기준을 정리합니다.
+
+## Location
+
+Codex hook 설정은 repo-local `.codex/hooks.json`에 둡니다.
+
+```text
+.codex/hooks.json
+.codex/hooks/session_start_primer.py
+.codex/hooks/pre_tool_use_bash_guard.py
+```
+
+Repo-local hook은 프로젝트 `.codex/` layer가 trusted 상태일 때 실행됩니다.
+새 hook 또는 변경된 hook은 Codex에서 `/hooks`를 열어 review/trust 해야 합니다.
+
+## SessionStart Primer
+
+`SessionStart` hook은 `startup|resume|clear|compact`에서 실행됩니다.
+
+목적은 문서 전체를 매번 주입하는 것이 아니라, 작업 시작 시 필요한 최소 프로젝트 기준을 추가 context로 제공하는 것입니다.
+
+주입하는 기준:
+
+- `pnpm`만 사용합니다.
+- 작업 전 `AGENTS.md`로 작업 유형을 분류합니다.
+- 변경 전 `git status --short --branch --untracked-files=all`을 확인합니다.
+- `docs/`는 사람이 읽는 source of truth이고, `.agents/`는 실행 checklist, recipe, skill, script입니다.
+- 작업 유형별 필요한 문서만 추가로 읽습니다.
+- page, shared component, hook, API query/mutation, HDS 작업은 `*.spec.md` 필요 여부를 확인합니다.
+- HDS package에는 app route, API, query, mutation, tracking, product copy, domain data를 넣지 않습니다.
+- 최종 응답에는 문서 영향과 검증 결과를 포함합니다.
+
+## Bash Guard
+
+`PreToolUse` hook은 `Bash` 실행 전에 위험하거나 repo 규칙과 맞지 않는 명령을 차단합니다.
+
+차단 대상:
+
+- `git reset --hard`
+- `git checkout --`
+- `git clean`에 force와 directory flag가 함께 있는 명령
+- `git push --force`, `git push --force-with-lease`, `git push -f`
+- `rm`에 recursive와 force flag가 함께 있는 명령
+- `npm`, `npx`, `yarn`, `bun`, `bunx`
+- `pnpm add`인데 `--filter`/`-F` 또는 `-w`/`--workspace-root`가 없는 명령
+
+Dependency를 추가할 때는 workspace를 명시합니다.
+
+```bash
+pnpm --filter @hashi/client add package-name
+pnpm --filter @hashi/hds-ui add package-name
+pnpm add -D -w package-name
+```
+
+## Limit
+
+이 hook은 agent 실수 방지용 guardrail입니다.
+Codex `PreToolUse`가 모든 shell 실행 경로를 완전히 가로채는 보안 경계는 아닙니다.
+파괴적인 작업이나 예외적인 Git 작업은 사람이 의도를 명확히 확인한 뒤 별도 명령으로 수행합니다.


### PR DESCRIPTION
## 📌 Summary

Codex repo-local hook을 추가해 HASHI 프로젝트 작업 기준을 session 시작 시 주입하고, 위험한 Bash 명령을 실행 전에 차단하도록 구성했습니다.

Jira: HASHI-57

## 📚 Tasks

- `.codex/hooks.json`에 `SessionStart`, `PreToolUse` hook 설정 추가
- `SessionStart`에서 HASHI 작업 기준 primer를 `additionalContext`로 주입
- `PreToolUse`에서 위험 Git 명령, `rm -rf`, 잘못된 package manager 사용, scope 없는 `pnpm add` 차단
- Codex hook 운영 문서 추가 및 README 문서 링크 연결

## 👀 To Reviewer

- repo-local hook은 Codex에서 `/hooks`를 열어 review/trust 해야 실제로 실행됩니다.
- `PreToolUse` guard는 보안 경계가 아니라 agent 실수 방지용 guardrail입니다.
- `npm`, `yarn`, `bun` 대신 `pnpm` 사용을 강제하고, dependency 추가 시 workspace scope를 요구합니다.

## ✅ Verification

- `git diff --check`
- `python3 -m py_compile .codex/hooks/session_start_primer.py .codex/hooks/pre_tool_use_bash_guard.py`
- `bash .agents/scripts/check-harness.sh`
- `corepack pnpm format:check`