### PR TITLE
Feat(client): HASHI-58 모바일 뷰포트 레이아웃 설정

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -2,7 +2,10 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>HASHI</title>
   </head>
   <body>

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -2,7 +2,7 @@ import { Button } from '@hashi/hds-ui'
 
 export const App = () => {
   return (
-    <main className="mx-auto min-h-dvh w-full max-w-[430px] bg-white">
+    <main className="mx-auto min-h-dvh w-full max-w-[var(--app-mobile-max-width)] bg-white">
       <Button type="button">Start</Button>
     </main>
   )

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -2,7 +2,7 @@ import { Button } from '@hashi/hds-ui'
 
 export const App = () => {
   return (
-    <main className="mx-auto min-h-dvh w-full max-w-[var(--app-mobile-max-width)] bg-white">
+    <main className="app-mobile-frame min-h-dvh bg-white">
       <Button type="button">Start</Button>
     </main>
   )

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -2,7 +2,7 @@ import { Button } from '@hashi/hds-ui'
 
 export const App = () => {
   return (
-    <main>
+    <main className="mx-auto min-h-dvh w-full max-w-[430px] bg-white">
       <Button type="button">Start</Button>
     </main>
   )

--- a/apps/client/src/app/styles/global.css
+++ b/apps/client/src/app/styles/global.css
@@ -7,23 +7,26 @@
   *::before,
   *::after {
     box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
   }
 
   html {
     -webkit-text-size-adjust: 100%;
-    background: #ffffff;
+    background: var(--color-cool-gray-50);
+    overflow-x: hidden;
   }
 
   body {
     min-width: 320px;
     min-height: 100dvh;
     margin: 0;
-    background: #ffffff;
+    background: var(--color-cool-gray-50);
     color: var(--color-cool-gray-900);
     font-family: var(--font-sans);
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
   }
 
   #root {

--- a/apps/client/src/app/styles/global.css
+++ b/apps/client/src/app/styles/global.css
@@ -70,3 +70,29 @@
     text-decoration: none;
   }
 }
+
+@utility app-mobile-frame {
+  width: 100%;
+  max-width: var(--app-mobile-max-width);
+  margin-inline: auto;
+}
+
+@utility app-mobile-fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  width: 100%;
+  max-width: var(--app-mobile-max-width);
+  margin-inline: auto;
+}
+
+@utility app-mobile-fixed-bottom {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  max-width: var(--app-mobile-max-width);
+  margin-inline: auto;
+}

--- a/apps/client/src/app/styles/global.css
+++ b/apps/client/src/app/styles/global.css
@@ -3,6 +3,12 @@
 @source '../../../../../packages/hds-ui/src';
 
 @layer base {
+  :root {
+    --app-mobile-max-width: 430px;
+    --safe-area-top: env(safe-area-inset-top);
+    --safe-area-bottom: env(safe-area-inset-bottom);
+  }
+
   *,
   *::before,
   *::after {


### PR DESCRIPTION
## 📌 Summary
> 데스크톱 환경에서는 모바일 화면이 가운데 정렬되어 보이도록 앱 컨테이너의 최대 너비를 지정했고, 모바일 기기의 노치/상태바/홈 인디케이터 영역 대응을 위해 safe-area CSS 변수를 전역으로 추가했습니다!

Jira: [HASHI-58](https://siksa.atlassian.net/browse/HASHI-58)

## 📚 Tasks
- 모바일 앱 컨테이너 최대 너비 설정
- 데스크톱 환경에서 모바일 뷰가 가운데 보이도록 레이아웃 설정
- safe-area 대응을 위한 전역 CSS 변수 추가
- `viewport-fit=cover` 설정으로 모바일 safe-area 사용 가능하도록 처리

## 📝 Description
- 실제 페이지 UI 구현 전에 모바일 퍼블리싱 기준이 되는 기본 레이아웃을 먼저 세팅했습니다.
- 앱 컨테이너는 모바일 최대 너비 기준으로 가운데 정렬됩니다. (430px)

```tsx
<main className="mx-auto min-h-dvh w-full max-w-[var(--app-mobile-max-width)] bg-white">
```

- 전역 CSS에는 아래 변수를 추가했어요.

```css
:root {
  --app-mobile-max-width: 430px;
  --safe-area-top: env(safe-area-inset-top);
  --safe-area-bottom: env(safe-area-inset-bottom);
}
```

- 430px
> 모바일 portrait 기준 최대 너비를 iPhone Pro Max 계열 CSS viewport 기준인 430px로 설정했습니다. 430px보다 큰 화면에서는 앱 컨테이너가 더 넓어지지 않고 중앙 정렬된 모바일 뷰로 노출되도록 했습니다!

1. `--app-mobile-max-width`는 데스크톱 환경에서도 모바일 기준 화면 너비를 유지하기 위한 값입니다.

2. `--safe-area-top`은 노치나 상태바 영역에 상단 헤더가 가려지지 않도록 사용할 수 있는 값입니다.
```tsx
<header className="pt-[var(--safe-area-top)]">
```
3. `--safe-area-bottom`은 홈 인디케이터 영역에 하단 네비게이션이나 고정 버튼이 가려지지 않도록 사용할 수 있는 값입니다.
```tsx
<nav className="pb-[var(--safe-area-bottom)]">
```
4. 하단에 fixed 버튼이나 bottom navigation이 있는 페이지에서는 본문이 하단 고정 영역에 가려지지 않도록 content bottom padding을 함께 주면 됩니다.
```tsx
<main className="pb-[calc(80px+var(--safe-area-bottom))]">
```

- 여기서 `80px`은 하단 고정 버튼 또는 네비게이션 높이에 맞게 페이지별로 조정해서 사용하시면 됩니다!!

## 📸 Screenshot
<img width="956" height="869" alt="image" src="https://github.com/user-attachments/assets/9861d1c6-bce7-457a-9dec-15761c632c61" />
