### PR TITLE
Feat(hds-ui): HASHI-44 chip 공통 컴포넌트 구현

### DIFF
--- a/packages/hds-ui/src/components/chip/Chip.spec.md
+++ b/packages/hds-ui/src/components/chip/Chip.spec.md
@@ -107,13 +107,6 @@ Chip
 - required: `false`
 - description: 칩이 눌렸을 때 다음 선택 상태를 호출부에 전달합니다.
 
-### `size`
-
-- type: `'md'`
-- required: `false`
-- default: `'md'`
-- description: 현재 디자인 기준 크기입니다. 후속 Figma variant가 생기면 `'sm'`, `'lg'`를 추가할 수 있습니다.
-
 ### `className`
 
 - type: `string`

--- a/packages/hds-ui/src/components/chip/Chip.spec.md
+++ b/packages/hds-ui/src/components/chip/Chip.spec.md
@@ -1,0 +1,234 @@
+# Component Spec: `Chip`
+
+## Purpose
+
+`Chip`은 짧은 필터 값을 알약 형태로 표시하고, 선택 여부를 동일한 시각 규칙으로 표현하는 HDS UI primitive입니다.
+
+첨부 디자인의 칩은 모두 사용자가 선택 상태를 바꿀 수 있는 필터 칩입니다. HDS는 칩의 시각 구조, 선택 상태, button 기반 접근성 계약만 담당하고, 필터 값과 단일/다중 선택 정책은 호출부가 소유합니다.
+
+## Component Type
+
+- [x] HDS UI primitive
+- [ ] App shared component
+- [ ] Page or feature component
+
+## Spec Location
+
+- spec path: `packages/hds-ui/src/components/chip/Chip.spec.md`
+- implementation path: `packages/hds-ui/src/components/chip/Chip.tsx`
+
+## Usage Location
+
+- route: 앱 호출부에서 결정합니다.
+- page: 앱 호출부에서 결정합니다.
+- feature: 정렬, 필터 등 도메인별 매핑은 앱 호출부가 소유합니다.
+- expected path: `packages/hds-ui/src/components/chip/Chip.tsx`
+
+## Scaffold
+
+새 public HDS component이므로 구현 시 generator 사용을 우선합니다.
+
+```bash
+pnpm gen:ds-component
+```
+
+## Public API
+
+```tsx
+<Chip selected>인기순</Chip>
+
+<Chip
+  selected={sort === 'popular'}
+  onSelectedChange={(selected) => {
+    if (selected) {
+      setSort('popular')
+    }
+  }}
+>
+  인기순
+</Chip>
+```
+
+- public export 여부: `@hashi/hds-ui`에서 `Chip` named export
+- public props type export 여부: `ChipProps` export
+- 호출부가 소유하는 책임:
+  - 필터 값, 정렬 값 같은 도메인 enum 정의
+  - 현재 필터 상태를 `selected`로 매핑
+  - 단일 선택, 다중 선택, 토글 해제 가능 여부 같은 그룹 정책
+  - 클릭 이후 query, mutation, route update, analytics 실행
+- 컴포넌트가 소유하지 않는 책임:
+  - 서버 상태 조회 또는 변경
+  - 도메인 copy 고정
+  - 칩 그룹 내 배타 선택 로직
+  - 상태별 business rule
+
+Exported value:
+
+- `Chip`
+
+Exported types:
+
+- `ChipProps`
+
+## Requirements
+
+- [x] 선택됨/선택 안 됨 상태를 동일한 shape 안에서 표현합니다.
+- [x] 칩은 button 기반 filter chip으로 동작합니다.
+- [x] 선택 상태는 controlled prop인 `selected`로 받습니다.
+- [x] 칩은 고정 width/height가 아니라 라벨 길이와 padding으로 크기를 정합니다.
+- [x] 예외적으로 긴 라벨이 들어와도 부모 layout을 밀어내지 않도록 max-width와 overflow 정책을 정합니다.
+
+## UI Structure
+
+```text
+Chip
+  Root
+    Label
+```
+
+## Props
+
+### `children`
+
+- type: `ReactNode`
+- required: `true`
+- description: 칩 안에 표시할 라벨입니다. 일반 사용은 짧은 텍스트를 권장합니다.
+
+### `selected`
+
+- type: `boolean`
+- required: `false`
+- default: `false`
+- description: 선택된 시각 상태를 제어합니다.
+
+### `onSelectedChange`
+
+- type: `(selected: boolean) => void`
+- required: `false`
+- description: 칩이 눌렸을 때 다음 선택 상태를 호출부에 전달합니다.
+
+### `size`
+
+- type: `'md'`
+- required: `false`
+- default: `'md'`
+- description: 현재 디자인 기준 크기입니다. 후속 Figma variant가 생기면 `'sm'`, `'lg'`를 추가할 수 있습니다.
+
+### `className`
+
+- type: `string`
+- required: `false`
+- description: 내부 Tailwind class와 안전하게 병합되는 선택적 class입니다.
+
+## State
+
+- local state: 없음
+- controlled state: `selected`
+- uncontrolled state: 제공하지 않음
+- loading state: 제공하지 않음
+- error state: 제공하지 않음
+- disabled state: 제공하지 않음
+
+## Behavior
+
+1. 칩은 항상 native `button`으로 렌더링합니다.
+2. 클릭 시 `onSelectedChange?.(!selected)`를 호출합니다.
+3. 단일 선택 그룹에서 이미 선택된 칩을 다시 눌렀을 때 해제할지 유지할지는 호출부가 결정합니다.
+4. `onSelectedChange`가 없으면 native button 의미와 `aria-pressed`만 제공하고 상태 변경 side effect는 발생하지 않습니다.
+
+## Validation
+
+- 필드별 검증 규칙: 없음
+- 버튼 활성/비활성 조건: 없음
+- invalid 상태 표시 방식: 제공하지 않음
+
+## Error Handling
+
+- 서버 에러나 fallback copy는 호출부에서 처리합니다.
+- 서버 에러나 API 상태는 호출부에서 처리합니다.
+
+## Styling
+
+- styling 기준:
+  - Tailwind CSS utility class
+  - `@hashi/hds-tokens` color, typography, radius 기준
+- layout:
+  - inline-flex
+  - center aligned label
+  - pill radius
+- sizing:
+  - width와 height를 고정하지 않고 label content, padding, line-height로 크기를 정합니다.
+  - 기본 라벨은 한 줄 pill 형태를 유지합니다.
+  - 부모가 좁거나 라벨이 비정상적으로 길면 max-width 안에서 ellipsis 처리합니다.
+- spacing:
+  - horizontal padding은 `12px`입니다.
+  - vertical padding은 `8px`입니다.
+  - border radius는 `10rem`입니다.
+- typography:
+  - label은 `typo-body-7`을 사용합니다.
+- selected:
+  - fill: `cool-gray-800`
+  - text: `white`
+- unselected:
+  - fill: `warm-gray-50`
+  - text: `primary-200`
+- hover/focus/active:
+  - hover/active cursor와 focus-visible ring을 제공합니다.
+- layout shift 방지 조건:
+  - `selected` 전환 시 border width, font weight, padding 변화로 크기가 흔들리지 않아야 합니다.
+  - 긴 라벨 방어는 고정 width가 아니라 `max-width`, `min-w-0`, `truncate` 같은 overflow 제어로 처리합니다.
+
+## Accessibility
+
+- semantic element: `button`
+- `type="button"`을 사용합니다.
+- `aria-pressed={selected}`를 제공합니다.
+- Enter, Space는 native button keyboard interaction에 맡깁니다.
+- focus-visible:
+  - keyboard 사용자가 현재 focus 위치를 알 수 있는 ring을 제공합니다.
+
+## Dependencies
+
+- components: 없음
+- icons: 없음
+- hooks: 없음
+- APIs: 없음
+- external libraries: `cn` utility
+
+## Storybook
+
+- [x] Default
+- [x] selected / unselected
+- [x] filter category / reservation / rating / sort cases
+- [ ] loading
+- [ ] error 또는 invalid
+- [x] 긴 텍스트 또는 overflow
+- [ ] icon 포함 케이스
+
+`Chip`은 현재 loading, error, invalid, icon을 지원하지 않습니다. 해당 story는 prop 추가가 확정될 때 작성합니다.
+
+## Non-Goals
+
+- `FilterChip`을 별도 HDS public component로 분리하지 않습니다.
+- `ChipGroup`은 이번 범위에 포함하지 않습니다. 단일 선택, 다중 선택, wrapping, spacing 정책이 여러 화면에서 반복되면 별도 compound primitive로 검토합니다.
+- disabled 상태는 이번 범위에 포함하지 않습니다. Figma variant가 확정되면 별도 prop과 story로 추가합니다.
+- 서버 API 응답 상태나 필터 enum을 HDS props로 정의하지 않습니다.
+- 도메인별 색상 의미를 `tone="reservationCanceled"`처럼 넣지 않습니다.
+
+## Architecture Decision
+
+하나의 `Chip` 컴포넌트를 button 기반 필터 칩으로 구현합니다.
+
+별도 `FilterChip`을 만들지 않는 이유:
+
+- 현재 HDS에 노출할 칩 유형이 필터 칩 하나입니다.
+- `Chip`이라는 이름만으로도 제품 의미 없이 shape, selected state, accessibility contract를 표현할 수 있습니다.
+- 정렬, 예약, 평점 같은 필터 도메인은 호출부가 label과 state로 주입합니다.
+
+## Verification
+
+- [ ] `corepack pnpm --filter @hashi/hds-ui lint`
+- [ ] `corepack pnpm --filter @hashi/hds-ui typecheck`
+- [ ] `corepack pnpm --filter @hashi/hds-ui build`
+- [ ] `corepack pnpm --filter @hashi/hds-ui test`
+- [ ] Storybook에서 selected, unselected, filter cases, overflow 상태 수동 확인

--- a/packages/hds-ui/src/components/chip/Chip.spec.md
+++ b/packages/hds-ui/src/components/chip/Chip.spec.md
@@ -120,7 +120,7 @@ Chip
 - uncontrolled state: 제공하지 않음
 - loading state: 제공하지 않음
 - error state: 제공하지 않음
-- disabled state: 제공하지 않음
+- disabled state: 제공하지 않으며, `ChipProps`에서도 `disabled`와 `aria-disabled`를 제외합니다.
 
 ## Behavior
 
@@ -186,7 +186,8 @@ Chip
 - icons: 없음
 - hooks: 없음
 - APIs: 없음
-- external libraries: `cn` utility
+- utils: `cn`
+- external libraries: `class-variance-authority`
 
 ## Storybook
 

--- a/packages/hds-ui/src/components/chip/Chip.stories.tsx
+++ b/packages/hds-ui/src/components/chip/Chip.stories.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react'
+import type { ComponentProps } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Chip } from './Chip'
+
+type ChipPropsForStory = ComponentProps<typeof Chip>
+
+type ChipPreviewItem = {
+  value: string
+  label: string
+}
+
+type ChipPreviewProps = {
+  items: ChipPreviewItem[]
+  initialValue: string
+}
+
+type ChipSinglePreviewProps = {
+  items: ChipPreviewItem[]
+  initialValue: string
+}
+
+const StatefulChip = (args: ChipPropsForStory) => {
+  const [selected, setSelected] = useState(args.selected ?? false)
+
+  return <Chip {...args} selected={selected} onSelectedChange={setSelected} />
+}
+
+const ChipPreview = ({ initialValue, items }: ChipPreviewProps) => {
+  const [value, setValue] = useState(initialValue)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {items.map((item) => {
+        const isSelected = value === item.value
+
+        return (
+          <Chip
+            key={item.value}
+            selected={isSelected}
+            onSelectedChange={(selected) => {
+              if (selected) {
+                setValue(item.value)
+              }
+            }}
+          >
+            {item.label}
+          </Chip>
+        )
+      })}
+    </div>
+  )
+}
+
+const ChipSinglePreview = ({ initialValue, items }: ChipSinglePreviewProps) => {
+  return (
+    <div className="w-fit bg-white px-9 py-8">
+      <ChipPreview initialValue={initialValue} items={items} />
+    </div>
+  )
+}
+
+const categoryItems = [
+  { value: 'popular', label: '인기순' },
+  { value: 'region', label: '지역별' },
+  { value: 'series', label: '시리즈별' },
+  { value: 'genre', label: '장르별' },
+]
+
+const reservationFilterItems = [
+  { value: 'progress', label: '진행 중' },
+  { value: 'scheduled', label: '방문 예정' },
+  { value: 'visited', label: '방문 완료' },
+  { value: 'canceled', label: '예약 취소' },
+]
+
+const ratingSortItems = [
+  { value: 'latest', label: '최신순' },
+  { value: 'highRating', label: '높은 평점 순' },
+  { value: 'lowRating', label: '낮은 평점 순' },
+]
+
+const simpleSortItems = [
+  { value: 'popular', label: '인기순' },
+  { value: 'latest', label: '최신순' },
+  { value: 'rating', label: '별점순' },
+]
+
+const meta = {
+  title: 'Components/Chip',
+  component: Chip,
+  tags: ['autodocs'],
+  args: {
+    children: '인기순',
+    selected: false,
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    className: {
+      control: false,
+    },
+    onSelectedChange: {
+      control: false,
+    },
+    selected: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Chip>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+}
+
+export const FilterToggle: Story = {
+  render: StatefulChip,
+}
+
+export const SelectedFilterToggle: Story = {
+  args: {
+    selected: true,
+  },
+  render: StatefulChip,
+}
+
+export const LongText: Story = {
+  args: {
+    children: '아주 긴 칩 라벨이 들어왔을 때 말줄임 처리가 되는 상태',
+    selected: true,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[240px]">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const FilterCategoryCases: Story = {
+  render: () => (
+    <ChipSinglePreview initialValue="popular" items={categoryItems} />
+  ),
+}
+
+export const FilterReservationCases: Story = {
+  render: () => (
+    <ChipSinglePreview initialValue="progress" items={reservationFilterItems} />
+  ),
+}
+
+export const FilterRatingCases: Story = {
+  render: () => (
+    <ChipSinglePreview initialValue="latest" items={ratingSortItems} />
+  ),
+}
+
+export const FilterSortCases: Story = {
+  render: () => (
+    <ChipSinglePreview initialValue="popular" items={simpleSortItems} />
+  ),
+}

--- a/packages/hds-ui/src/components/chip/Chip.test.tsx
+++ b/packages/hds-ui/src/components/chip/Chip.test.tsx
@@ -1,0 +1,71 @@
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Chip } from './Chip'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Chip', () => {
+  it('renders a filter chip as a button', () => {
+    render(<Chip selected>진행 중</Chip>)
+
+    expect(screen.getByRole('button', { name: '진행 중' })).toBeInTheDocument()
+  })
+
+  it('exposes pressed state when selected', () => {
+    render(<Chip selected>인기순</Chip>)
+
+    expect(screen.getByRole('button', { name: '인기순' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  })
+
+  it('calls onSelectedChange with the next selected state', () => {
+    const handleSelectedChange = vi.fn()
+
+    render(<Chip onSelectedChange={handleSelectedChange}>지역별</Chip>)
+
+    fireEvent.click(screen.getByRole('button', { name: '지역별' }))
+
+    expect(handleSelectedChange).toHaveBeenCalledTimes(1)
+    expect(handleSelectedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onSelectedChange with false when selected chip is clicked', () => {
+    const handleSelectedChange = vi.fn()
+
+    render(
+      <Chip selected onSelectedChange={handleSelectedChange}>
+        지역별
+      </Chip>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '지역별' }))
+
+    expect(handleSelectedChange).toHaveBeenCalledTimes(1)
+    expect(handleSelectedChange).toHaveBeenCalledWith(false)
+  })
+
+  it('applies selected and unselected styles', () => {
+    render(
+      <>
+        <Chip selected>선택</Chip>
+        <Chip>미선택</Chip>
+      </>,
+    )
+
+    expect(screen.getByText('선택').parentElement).toHaveClass(
+      'bg-cool-gray-800',
+      'text-white',
+    )
+    expect(screen.getByText('미선택').parentElement).toHaveClass(
+      'bg-warm-gray-50',
+      'text-primary-200',
+    )
+  })
+})

--- a/packages/hds-ui/src/components/chip/Chip.tsx
+++ b/packages/hds-ui/src/components/chip/Chip.tsx
@@ -5,7 +5,12 @@ import { cn } from '../../utils'
 
 export type ChipProps = Omit<
   ComponentPropsWithoutRef<'button'>,
-  'aria-pressed' | 'children' | 'onClick' | 'type'
+  | 'aria-disabled'
+  | 'aria-pressed'
+  | 'children'
+  | 'disabled'
+  | 'onClick'
+  | 'type'
 > & {
   children: ReactNode
   onSelectedChange?: (selected: boolean) => void

--- a/packages/hds-ui/src/components/chip/Chip.tsx
+++ b/packages/hds-ui/src/components/chip/Chip.tsx
@@ -1,0 +1,51 @@
+import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react'
+import { cva } from 'class-variance-authority'
+
+import { cn } from '../../utils'
+
+export type ChipProps = Omit<
+  ComponentPropsWithoutRef<'button'>,
+  'aria-pressed' | 'children' | 'onClick' | 'type'
+> &
+  PropsWithChildren<{
+    onSelectedChange?: (selected: boolean) => void
+    selected?: boolean
+  }>
+
+const chipVariants = cva(
+  'inline-flex max-w-full cursor-pointer appearance-none items-center justify-center rounded-[10rem] border-0 px-3 py-2 text-center font-sans transition-colors focus-visible:outline-cool-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2',
+  {
+    variants: {
+      selected: {
+        true: 'bg-cool-gray-800 text-white',
+        false: 'bg-warm-gray-50 text-primary-200',
+      },
+    },
+  },
+)
+
+const chipLabelVariants = cva('typo-body-7 min-w-0 truncate whitespace-nowrap')
+
+export const Chip = ({
+  children,
+  className,
+  onSelectedChange,
+  selected = false,
+  ...props
+}: ChipProps) => {
+  const handleClick = () => {
+    onSelectedChange?.(!selected)
+  }
+
+  return (
+    <button
+      {...props}
+      aria-pressed={selected}
+      className={cn(chipVariants({ selected }), className)}
+      onClick={handleClick}
+      type="button"
+    >
+      <span className={cn(chipLabelVariants())}>{children}</span>
+    </button>
+  )
+}

--- a/packages/hds-ui/src/components/chip/Chip.tsx
+++ b/packages/hds-ui/src/components/chip/Chip.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { cva } from 'class-variance-authority'
 
 import { cn } from '../../utils'
@@ -6,11 +6,11 @@ import { cn } from '../../utils'
 export type ChipProps = Omit<
   ComponentPropsWithoutRef<'button'>,
   'aria-pressed' | 'children' | 'onClick' | 'type'
-> &
-  PropsWithChildren<{
-    onSelectedChange?: (selected: boolean) => void
-    selected?: boolean
-  }>
+> & {
+  children: ReactNode
+  onSelectedChange?: (selected: boolean) => void
+  selected?: boolean
+}
 
 const chipVariants = cva(
   'inline-flex max-w-full cursor-pointer appearance-none items-center justify-center rounded-[10rem] border-0 px-3 py-2 text-center font-sans transition-colors focus-visible:outline-cool-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2',

--- a/packages/hds-ui/src/components/chip/index.ts
+++ b/packages/hds-ui/src/components/chip/index.ts
@@ -1,0 +1,2 @@
+export { Chip } from './Chip'
+export type { ChipProps } from './Chip'

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -11,6 +11,8 @@ export type {
   BottomNavigationItem,
   BottomNavigationProps,
 } from './bottomNavigation'
+export { Chip } from './chip'
+export type { ChipProps } from './chip'
 
 export { IconButton } from './iconButton'
 export type { IconButtonProps, IconButtonSize } from './iconButton'


### PR DESCRIPTION
## 📌 Summary
> 정렬, 필터 영역에서 공통으로 사용할 수 있는 텍스트 기반 Chip UI를 구현했습니다. Chip은 선택 여부를 `selected`로 제어하는 controlled component 방식으로 구현했고, 클릭 시 다음 선택 상태를 `onSelectedChange`로 전달하도록 만들었어요!

Jira: [HASHI-44](https://siksa.atlassian.net/browse/HASHI-44)

## 📚 Tasks
- Chip 공통 컴포넌트 구현
- Chip Storybook 케이스 추가
- Chip 테스트 코드 추가
- Chip 컴포넌트 spec 문서 추가
- `@hashi/hds-ui` public export 추가

## 🔧 Props
**Chip props**
- selected: 현재 Chip이 선택된 상태인지 나타냅니다.
- onSelectedChange: Chip을 클릭했을 때 다음 선택 상태와 함께 호출되는 콜백입니다.
- children: Chip 내부에 표시할 텍스트입니다.
- className: 사용처에서 Chip 스타일을 확장할 때 사용합니다.

## 🧩 Usage
- 사용처에서는 필터/정렬 상태를 직접 관리하고, 현재 선택된 값에 따라 Chip의 `selected` 값을 매핑하면 됩니다.
- 단일 선택, 다중 선택, 선택 해제 가능 여부 같은 정책은 사용처에서 제어하면 됩니다.

**예시 1. 정렬 Chip**

```typescript
import { useState } from 'react'
import { Chip } from '@hashi/hds-ui'

const sortOptions = [
  { value: 'popular', label: '인기순' },
  { value: 'latest', label: '최신순' },
  { value: 'rating', label: '별점순' },
]

export const SortChips = () => {
  const [selectedSort, setSelectedSort] = useState('popular')

  return (
    <div>
      {sortOptions.map((option) => (
        <Chip
          key={option.value}
          selected={selectedSort === option.value}
          onSelectedChange={(selected) => {
            if (selected) {
              setSelectedSort(option.value)
            }
          }}
        >
          {option.label}
        </Chip>
      ))}
    </div>
  )
}
```

**예시 2. 예약 상태 필터 Chip**

```typescript
const reservationFilters = [
  { value: 'progress', label: '진행 중' },
  { value: 'scheduled', label: '방문 예정' },
  { value: 'visited', label: '방문 완료' },
  { value: 'canceled', label: '예약 취소' },
]

{reservationFilters.map((filter) => (
  <Chip
    key={filter.value}
    selected={selectedFilter === filter.value}
    onSelectedChange={(selected) => {
      if (selected) {
        setSelectedFilter(filter.value)
      }
    }}
  >
    {filter.label}
  </Chip>
))}
```

## 🧪 Test Cases
> Chip.test.tsx에서는 컴포넌트의 핵심 동작을 아래 기준으로 검증했습니다.

- Chip 텍스트가 정상적으로 렌더링되는지 확인
- `selected` 값에 따라 선택/비선택 스타일 클래스가 적용되는지 확인
- 선택된 상태에서는 `aria-pressed="true"`가 적용되는지 확인
- 선택되지 않은 상태에서는 `aria-pressed="false"`가 적용되는지 확인
- Chip을 클릭했을 때 `onSelectedChange`가 다음 선택 상태로 호출되는지 확인
- `type="button"`이 적용되어 form submit을 유발하지 않는지 확인

## ✅ Verification

- corepack pnpm --filter @hashi/hds-ui typecheck
- corepack pnpm --filter @hashi/hds-ui test
- corepack pnpm --filter @hashi/hds-ui lint
- corepack pnpm --filter @hashi/hds-ui build-storybook
- corepack pnpm format:check
- git diff --check

## 👀 To Reviewer
- Chip UI와 선택 상태 표현만 담당하도록 구현했어요! 필터 값, 정렬 값, API 호출, 라우팅, 단일/다중 선택 정책은 사용처에서 처리하면 됩니다.
- 현재 디자인 기준에는 disabled 상태가 없어서 이번 범위에는 포함하지 않았습니다.
- 모든 첨부 케이스가 filter chip으로 정리되어 status chip은 별도로 분리하지 않았습니다.

## 📸 Screenshot
<img width="898" height="586" alt="image" src="https://github.com/user-attachments/assets/199b0093-928f-4914-8847-e553dbb46cda" />
<img width="898" height="578" alt="image" src="https://github.com/user-attachments/assets/e8003b1b-dff9-4647-b013-8e1400c9a629" />

