### PR TITLE
Feat(hds-ui): HASHI-45 badge 공통 컴포넌트 구현

### DIFF
--- a/packages/hds-tokens/src/tokens/colors.css
+++ b/packages/hds-tokens/src/tokens/colors.css
@@ -1,8 +1,8 @@
 @theme {
   --color-primary-100: #f6f6f6;
   --color-primary-200: #4a4a4a;
-  --color-primary-400: #a64a47;
-  --color-primary-500: #ff5d5d;
+  --color-primary-400: #ff5d5d;
+  --color-primary-500: #a64a47;
 
   --color-secondary-200: #f2f3f5;
   --color-secondary-300: #faf99c;

--- a/packages/hds-ui/src/components/badge/Badge.spec.md
+++ b/packages/hds-ui/src/components/badge/Badge.spec.md
@@ -6,7 +6,7 @@ Jira: HASHI-45
 
 `Badge`는 짧은 라벨과 선택적 아이콘으로 상태, 속성, 키워드를 표시하는 HDS UI primitive입니다.
 
-HDS는 badge의 시각 구조, 선택 상태, 기본 접근성 계약만 담당합니다. 리뷰 키워드 목록, 선택 개수 제한, validation message, 저장 가능 여부, route, API, analytics는 App 또는 page/feature가 처리합니다.
+HDS는 badge의 시각 구조, interactive 상태의 선택 표현, 기본 접근성 계약만 담당합니다. 리뷰 키워드 목록, 선택 개수 제한, validation message, 저장 가능 여부, route, API, analytics는 App 또는 page/feature가 처리합니다.
 
 첨부 디자인 기준으로 같은 badge가 두 방식으로 쓰입니다.
 
@@ -70,7 +70,7 @@ Exported types:
 
 호출부가 소유하는 책임:
 
-- `label`, `icon`, `selected` 값 주입
+- `label`, `icon`, interactive Badge의 `selected` 값 주입
 - 리뷰 키워드 value와 label 매핑
 - 선택 개수 1-3개 제한
 - 필수 선택 validation message
@@ -90,6 +90,7 @@ Exported types:
 - [x] 제품 도메인 데이터, route, API, logging, analytics에 의존하지 않습니다.
 - [x] static mode와 selectable mode를 같은 시각 구조로 제공합니다.
 - [x] selectable mode는 controlled `selected` 상태를 받습니다.
+- [x] static mode에서는 `selected` 상태를 허용하지 않습니다.
 - [x] selectable mode에서 inactive badge를 누르면 `onSelectedChange(true)`를 호출합니다.
 - [x] selectable mode에서 selected badge를 누르면 `onSelectedChange(false)`를 호출합니다.
 - [x] 긴 라벨이 들어와도 badge 바깥 layout을 깨지 않습니다.
@@ -130,7 +131,7 @@ Badge
 - type: `boolean`
 - required: `false`
 - default: `false`
-- description: 선택 상태입니다. static mode에서도 selected visual을 표시할 수 있지만, 주 사용처는 selectable mode입니다.
+- description: interactive Badge의 선택 상태입니다. static Badge에서는 타입상 허용하지 않으며 런타임에서도 selected visual을 적용하지 않습니다.
 
 ### `onSelectedChange`
 
@@ -149,14 +150,15 @@ Badge
 - static: `interactive=false`, `span`으로 렌더링하고 클릭 동작이 없습니다.
 - interactive: `interactive=true`, `button type="button"`으로 렌더링합니다.
 - default: 흰 배경, 회색 border, 기본 텍스트 색상을 표시합니다.
-- selected: primary border로 선택 상태를 표시합니다.
+- selected: interactive Badge에서만 primary border와 primary background로 선택 상태를 표시합니다.
 
 ## Behavior
 
 1. `interactive=false`이면 root를 `span`으로 렌더링하고 click handler를 연결하지 않습니다.
-2. `interactive=true`이면 root를 `button type="button"`으로 렌더링합니다.
-3. selectable badge를 누르면 현재 `selected`의 반대 값을 `onSelectedChange`에 전달합니다.
-4. selected 상태여도 같은 badge를 다시 눌러 해제할 수 있습니다.
+2. `interactive=false`이면 `selected`가 전달되어도 선택 스타일을 적용하지 않습니다.
+3. `interactive=true`이면 root를 `button type="button"`으로 렌더링합니다.
+4. selectable badge를 누르면 현재 `selected`의 반대 값을 `onSelectedChange`에 전달합니다.
+5. selected 상태여도 같은 badge를 다시 눌러 해제할 수 있습니다.
 
 ## Validation
 
@@ -173,7 +175,7 @@ HDS는 validation을 수행하지 않습니다.
 - icon size: `24px * 24px`, `shrink-0`
 - icon / text gap: `4px`
 - radius: `0.5rem`
-- border: weight `1px`, color `warm-gray-100`
+- border: weight `1.4px`, default color `warm-gray-100`
 - background: `white`
 - text: typography `typo-body-8`, color `black`
 - selected stroke: weight `1.4px`, color `primary-400`

--- a/packages/hds-ui/src/components/badge/Badge.spec.md
+++ b/packages/hds-ui/src/components/badge/Badge.spec.md
@@ -1,0 +1,248 @@
+# Component Spec: `Badge`
+
+Jira: HASHI-45
+
+## Purpose
+
+`Badge`는 짧은 라벨과 선택적 아이콘으로 상태, 속성, 키워드를 표시하는 HDS UI primitive입니다.
+
+HDS는 badge의 시각 구조, 선택 상태, 기본 접근성 계약만 담당합니다. 리뷰 키워드 목록, 선택 개수 제한, validation message, 저장 가능 여부, route, API, analytics는 App 또는 page/feature가 처리합니다.
+
+첨부 디자인 기준으로 같은 badge가 두 방식으로 쓰입니다.
+
+- 리뷰 상세, 식당 상세 리뷰 목록: 리뷰에 포함된 키워드를 보여주는 non-clickable static badge
+- 리뷰 작성, 리뷰 수정: 사용자가 1-3개 키워드를 고르는 clickable selectable badge
+
+## Component Type
+
+- [x] HDS UI primitive
+- [ ] App shared component
+- [ ] Page or feature component
+
+제품 도메인 문구와 키워드 데이터는 HDS 밖에서 주입하므로 `packages/hds-ui`에 둘 수 있습니다.
+
+## Spec Location
+
+- spec path: `packages/hds-ui/src/components/badge/Badge.spec.md`
+- implementation path: `packages/hds-ui/src/components/badge/Badge.tsx`
+
+## Usage Location
+
+- expected path: `packages/hds-ui/src/components/badge/Badge.tsx`
+- expected stories: `packages/hds-ui/src/components/badge/Badge.stories.tsx`
+- expected tests: `packages/hds-ui/src/components/badge/Badge.test.tsx`
+- app examples:
+  - 리뷰 상세의 키워드 표시 영역
+  - 식당 상세 리뷰 목록의 키워드 표시 영역
+  - 리뷰 작성/수정 form의 키워드 선택 영역
+
+## Scaffold
+
+새 public HDS component이므로 구현 시 generator 사용을 우선합니다.
+
+```bash
+corepack pnpm gen:ds-component
+```
+
+## Public API
+
+```tsx
+<Badge icon={<SmileIcon />} label="친절해요" />
+
+<Badge
+  interactive
+  selected={selectedKeywords.includes('kind')}
+  icon={<SmileIcon />}
+  label="친절해요"
+  onSelectedChange={(nextSelected) => {
+    updateKeyword('kind', nextSelected)
+  }}
+/>
+```
+
+Exported value:
+
+- `Badge`
+
+Exported types:
+
+- `BadgeProps`
+
+호출부가 소유하는 책임:
+
+- `label`, `icon`, `selected` 값 주입
+- 리뷰 키워드 value와 label 매핑
+- 선택 개수 1-3개 제한
+- 필수 선택 validation message
+- form submit 가능 여부
+- 리뷰 상세/목록에서 어떤 키워드를 노출할지 결정
+
+컴포넌트가 소유하지 않는 책임:
+
+- 리뷰 도메인 enum 또는 서버 응답 shape
+- 키워드별 icon 자동 매핑
+- 선택 개수 제한
+- form validation 문구
+- route, query, mutation, analytics
+
+## Requirements
+
+- [x] 제품 도메인 데이터, route, API, logging, analytics에 의존하지 않습니다.
+- [x] static mode와 selectable mode를 같은 시각 구조로 제공합니다.
+- [x] selectable mode는 controlled `selected` 상태를 받습니다.
+- [x] selectable mode에서 inactive badge를 누르면 `onSelectedChange(true)`를 호출합니다.
+- [x] selectable mode에서 selected badge를 누르면 `onSelectedChange(false)`를 호출합니다.
+- [x] 긴 라벨이 들어와도 badge 바깥 layout을 깨지 않습니다.
+- [x] token 또는 Tailwind theme 기준을 우선 사용합니다.
+
+## UI Structure
+
+```text
+Badge
+  root span | button
+    icon slot
+    label
+```
+
+## Props
+
+### `label`
+
+- type: `ReactNode`
+- required: `true`
+- description: badge에 표시할 짧은 라벨입니다. 일반 사용은 문자열을 권장합니다.
+
+### `icon`
+
+- type: `ReactNode`
+- required: `false`
+- description: 라벨 앞에 표시할 아이콘입니다. 아이콘 자체의 시각 디테일은 호출부가 주입합니다.
+
+### `interactive`
+
+- type: `boolean`
+- required: `false`
+- default: `false`
+- description: `true`이면 native `button`, `false`이면 non-interactive `span`으로 렌더링합니다.
+
+### `selected`
+
+- type: `boolean`
+- required: `false`
+- default: `false`
+- description: 선택 상태입니다. static mode에서도 selected visual을 표시할 수 있지만, 주 사용처는 selectable mode입니다.
+
+### `onSelectedChange`
+
+- type: `(selected: boolean) => void`
+- required: `false`
+- description: selectable badge를 눌렀을 때 다음 선택 상태를 전달합니다. `interactive=true`일 때만 호출합니다.
+
+### `className`
+
+- type: `string`
+- required: `false`
+- description: root element에 병합할 class입니다.
+
+## States
+
+- static: `interactive=false`, `span`으로 렌더링하고 클릭 동작이 없습니다.
+- interactive: `interactive=true`, `button type="button"`으로 렌더링합니다.
+- default: 흰 배경, 회색 border, 기본 텍스트 색상을 표시합니다.
+- selected: primary border로 선택 상태를 표시합니다.
+
+## Behavior
+
+1. `interactive=false`이면 root를 `span`으로 렌더링하고 click handler를 연결하지 않습니다.
+2. `interactive=true`이면 root를 `button type="button"`으로 렌더링합니다.
+3. selectable badge를 누르면 현재 `selected`의 반대 값을 `onSelectedChange`에 전달합니다.
+4. selected 상태여도 같은 badge를 다시 눌러 해제할 수 있습니다.
+
+## Validation
+
+HDS는 validation을 수행하지 않습니다.
+
+- 리뷰 작성/수정의 "키워드를 선택해주세요." 문구는 page form이 표시합니다.
+- 1-3개 선택 제한은 page form state가 관리합니다.
+- 제한 초과 시 추가 선택을 막는 정책은 호출부가 결정합니다.
+
+## Styling
+
+- root layout: `inline-flex`, 가운데 정렬, `shrink-0`
+- padding: horizontal `10px`, vertical `4px`
+- icon size: `24px * 24px`, `shrink-0`
+- icon / text gap: `4px`
+- radius: `0.5rem`
+- border: weight `1px`, color `warm-gray-100`
+- background: `white`
+- text: typography `typo-body-8`, color `black`
+- selected stroke: weight `1.4px`, color `primary-400`
+- selected background: `primary-400 / 20%`
+- label overflow: `min-w-0 truncate`
+- responsive: badge 자체는 layout을 소유하지 않습니다. 줄바꿈, horizontal scroll, grid 배치는 호출부 container가 처리합니다.
+
+Figma 값과 token이 다를 때는 token을 우선합니다. 정확한 radius, padding, border color가 Figma와 반복적으로 어긋나면 token 승격 후보로 별도 기록합니다.
+
+## Accessibility
+
+- static mode: root는 `span`이며 visible label이 그대로 읽힙니다.
+- interactive mode: root는 native `button type="button"`입니다.
+- selectable mode: button에 `aria-pressed={selected}`를 제공합니다.
+- icon은 장식 목적일 때 `aria-hidden`이 적용된 icon을 주입하는 것을 권장합니다.
+- accessible name은 visible label을 기준으로 합니다.
+- keyboard interaction은 native button 동작을 따릅니다.
+- focus-visible outline을 제공합니다.
+
+## Dependencies
+
+- components: none
+- icons: 호출부가 `@hashi/hds-icons`의 icon component를 주입합니다.
+- hooks: none
+- APIs: none
+- external libraries:
+  - `class-variance-authority`
+  - HDS `cn` utility
+
+## Storybook
+
+- [x] Static default badge
+- [x] Static badge with icon
+- [x] Selectable default
+- [x] Selectable selected
+- [x] Long label overflow
+- [x] Review keyword wrap example with multiple badges
+- [x] 393px mobile viewport wrapper
+
+Storybook 예시는 HDS public API와 상태를 보여주기 위한 샘플이어야 하며, app route, API 호출, query, mutation, tracking, 실제 리뷰 데이터 의존성을 넣지 않습니다.
+
+## 테스트
+
+- `interactive=false`이면 정적 `span`으로 렌더링합니다.
+- `interactive=true`이면 `button type="button"`으로 렌더링합니다.
+- 선택되지 않은 interactive badge를 누르면 `onSelectedChange(true)`를 호출합니다.
+- 선택된 interactive badge를 누르면 `onSelectedChange(false)`를 호출합니다.
+- 선택 상태를 `aria-pressed`로 노출합니다.
+- 화면에 보이는 label을 accessible name으로 유지합니다.
+
+## 범위 제외
+
+- 리뷰 키워드 enum, label, icon 매핑
+- badge group 검증
+- 최소/최대 선택 개수 제한
+- form error message 렌더링
+- 비동기 loading 또는 server error handling
+- routing 또는 navigation
+- analytics event 전송
+- `href`, `Link`, `asChild` 또는 polymorphic element API
+- badge가 직접 소유하는 tooltip, popover, menu 동작
+
+## Verification
+
+- [ ] `corepack pnpm format:check`
+- [ ] `git diff --check`
+- [ ] `bash .agents/scripts/check-harness.sh`
+- [ ] `corepack pnpm --filter @hashi/hds-ui lint`
+- [ ] `corepack pnpm --filter @hashi/hds-ui typecheck`
+- [ ] `corepack pnpm --filter @hashi/hds-ui build`
+- [ ] `corepack pnpm --filter @hashi/hds-ui test`
+- [ ] `corepack pnpm --filter @hashi/hds-ui build-storybook`

--- a/packages/hds-ui/src/components/badge/Badge.stories.tsx
+++ b/packages/hds-ui/src/components/badge/Badge.stories.tsx
@@ -1,0 +1,175 @@
+import {
+  CameraIcon,
+  CleanIcon,
+  DeliciousIcon,
+  FastIcon,
+  LeafIcon,
+  MoneyIcon,
+  PeopleIcon,
+  SmileIcon,
+  SoloIcon,
+  TalkIcon,
+} from '@hashi/hds-icons'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { ComponentProps, ReactNode } from 'react'
+import { useState } from 'react'
+import { Badge } from './Badge'
+
+const reviewKeywordItems = [
+  { value: 'kind', label: '친절해요', icon: <SmileIcon /> },
+  { value: 'delicious', label: '음식이 맛있어요', icon: <DeliciousIcon /> },
+  { value: 'solo', label: '혼밥하기 좋아요', icon: <SoloIcon /> },
+  { value: 'fast', label: '음식이 빨리 나와요', icon: <FastIcon /> },
+  { value: 'mildSpice', label: '향신료가 강하지 않아요', icon: <LeafIcon /> },
+  { value: 'spacious', label: '매장이 넓어요', icon: <PeopleIcon /> },
+  { value: 'clean', label: '매장이 청결해요', icon: <CleanIcon /> },
+  { value: 'photo', label: '사진이 잘 나와요', icon: <CameraIcon /> },
+  { value: 'value', label: '가성비가 좋아요', icon: <MoneyIcon /> },
+  { value: 'talk', label: '대화하기 좋아요', icon: <TalkIcon /> },
+]
+
+const mobileFrameDecorator = (Story: () => ReactNode) => (
+  <div className="w-[393px] bg-white p-5">
+    <Story />
+  </div>
+)
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  decorators: [mobileFrameDecorator],
+  args: {
+    label: '친절해요',
+    icon: <SmileIcon />,
+  },
+  argTypes: {
+    icon: {
+      control: false,
+    },
+    interactive: {
+      control: 'boolean',
+    },
+    selected: {
+      control: 'boolean',
+    },
+    onSelectedChange: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof Badge>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+type BadgePropsForStory = ComponentProps<typeof Badge>
+
+const StatefulBadge = (args: BadgePropsForStory) => {
+  const [selected, setSelected] = useState(Boolean(args.selected))
+
+  return (
+    <Badge
+      {...args}
+      interactive
+      onSelectedChange={setSelected}
+      selected={selected}
+    />
+  )
+}
+
+const KeywordWrap = ({
+  interactive = false,
+  selectedValues = [],
+}: {
+  interactive?: boolean
+  selectedValues?: string[]
+}) => {
+  const [selectedKeywordValues, setSelectedKeywordValues] =
+    useState(selectedValues)
+
+  return (
+    <div className="flex max-w-[353px] flex-wrap gap-2">
+      {reviewKeywordItems.map((item) => {
+        const isSelected = selectedKeywordValues.includes(item.value)
+
+        return (
+          <Badge
+            icon={item.icon}
+            interactive={interactive}
+            key={item.value}
+            label={item.label}
+            onSelectedChange={(nextSelected) => {
+              setSelectedKeywordValues((currentValues) => {
+                if (nextSelected) {
+                  return [...currentValues, item.value]
+                }
+
+                return currentValues.filter((value) => value !== item.value)
+              })
+            }}
+            selected={isSelected}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+export const Default: Story = {}
+
+export const WithIcon: Story = {
+  args: {
+    icon: <SmileIcon />,
+    label: '친절해요',
+  },
+}
+
+export const Selectable: Story = {
+  args: {
+    icon: <DeliciousIcon />,
+    interactive: true,
+    label: '음식이 맛있어요',
+  },
+  render: StatefulBadge,
+}
+
+export const Selected: Story = {
+  args: {
+    icon: <LeafIcon />,
+    interactive: true,
+    label: '향신료가 강하지 않아요',
+    selected: true,
+  },
+  render: StatefulBadge,
+}
+
+export const StaticReviewKeywords: Story = {
+  render: () => <KeywordWrap />,
+}
+
+export const SelectedReviewKeywords: Story = {
+  render: () => (
+    <KeywordWrap selectedValues={['delicious', 'mildSpice', 'value']} />
+  ),
+}
+
+export const SelectableReviewKeywords: Story = {
+  render: () => (
+    <KeywordWrap
+      interactive
+      selectedValues={['delicious', 'mildSpice', 'value']}
+    />
+  ),
+}
+
+export const LongText: Story = {
+  args: {
+    icon: <LeafIcon />,
+    label: '향신료가 강하지 않아요',
+  },
+  render: (args) => (
+    <div className="w-[140px]">
+      <Badge {...args} />
+    </div>
+  ),
+}

--- a/packages/hds-ui/src/components/badge/Badge.stories.tsx
+++ b/packages/hds-ui/src/components/badge/Badge.stories.tsx
@@ -63,6 +63,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 type BadgePropsForStory = ComponentProps<typeof Badge>
+type ReviewKeywordItem = (typeof reviewKeywordItems)[number]
 
 const StatefulBadge = (args: BadgePropsForStory) => {
   const [selected, setSelected] = useState(Boolean(args.selected))
@@ -92,27 +93,43 @@ const KeywordWrap = ({
       {reviewKeywordItems.map((item) => {
         const isSelected = selectedKeywordValues.includes(item.value)
 
-        return (
-          <Badge
-            icon={item.icon}
-            interactive={interactive}
-            key={item.value}
-            label={item.label}
-            onSelectedChange={(nextSelected) => {
-              setSelectedKeywordValues((currentValues) => {
-                if (nextSelected) {
-                  return [...currentValues, item.value]
-                }
+        if (interactive) {
+          return (
+            <Badge
+              icon={item.icon}
+              interactive
+              key={item.value}
+              label={item.label}
+              onSelectedChange={(nextSelected) => {
+                setSelectedKeywordValues((currentValues) =>
+                  getNextSelectedKeywordValues(
+                    currentValues,
+                    item,
+                    nextSelected,
+                  ),
+                )
+              }}
+              selected={isSelected}
+            />
+          )
+        }
 
-                return currentValues.filter((value) => value !== item.value)
-              })
-            }}
-            selected={isSelected}
-          />
-        )
+        return <Badge icon={item.icon} key={item.value} label={item.label} />
       })}
     </div>
   )
+}
+
+const getNextSelectedKeywordValues = (
+  currentValues: string[],
+  item: ReviewKeywordItem,
+  nextSelected: boolean,
+) => {
+  if (nextSelected) {
+    return [...currentValues, item.value]
+  }
+
+  return currentValues.filter((value) => value !== item.value)
 }
 
 export const Default: Story = {}
@@ -145,12 +162,6 @@ export const Selected: Story = {
 
 export const StaticReviewKeywords: Story = {
   render: () => <KeywordWrap />,
-}
-
-export const SelectedReviewKeywords: Story = {
-  render: () => (
-    <KeywordWrap selectedValues={['delicious', 'mildSpice', 'value']} />
-  ),
 }
 
 export const SelectableReviewKeywords: Story = {

--- a/packages/hds-ui/src/components/badge/Badge.test.tsx
+++ b/packages/hds-ui/src/components/badge/Badge.test.tsx
@@ -80,6 +80,28 @@ describe('Badge', () => {
     )
   })
 
+  it('미선택 상태에도 border 두께를 1.4px로 유지합니다', () => {
+    render(<Badge interactive label="선택 라벨" />)
+
+    expect(screen.getByRole('button', { name: '선택 라벨' })).toHaveClass(
+      'border-[1.4px]',
+      'border-warm-gray-100',
+    )
+  })
+
+  it('정적 Badge에는 기본 스타일을 적용합니다', () => {
+    render(<Badge label="정적 라벨" />)
+
+    expect(screen.getByText('정적 라벨').parentElement).toHaveClass(
+      'border-warm-gray-100',
+      'bg-white',
+    )
+    expect(screen.getByText('정적 라벨').parentElement).not.toHaveClass(
+      'border-primary-400',
+      'bg-primary-400/20',
+    )
+  })
+
   it('아이콘은 accessible name에 포함하지 않고 visible label을 이름으로 사용합니다', () => {
     render(
       <Badge

--- a/packages/hds-ui/src/components/badge/Badge.test.tsx
+++ b/packages/hds-ui/src/components/badge/Badge.test.tsx
@@ -1,0 +1,96 @@
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Badge } from './Badge'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Badge', () => {
+  it('interactive가 false이면 정적 span으로 렌더링합니다', () => {
+    render(<Badge label="정적 라벨" />)
+
+    expect(screen.getByText('정적 라벨').closest('span')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('interactive가 true이면 button으로 렌더링합니다', () => {
+    render(<Badge interactive label="선택 라벨" />)
+
+    expect(screen.getByRole('button', { name: '선택 라벨' })).toHaveAttribute(
+      'type',
+      'button',
+    )
+  })
+
+  it('선택되지 않은 interactive badge를 누르면 true를 전달합니다', () => {
+    const handleSelectedChange = vi.fn()
+
+    render(
+      <Badge
+        interactive
+        label="선택 라벨"
+        onSelectedChange={handleSelectedChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '선택 라벨' }))
+
+    expect(handleSelectedChange).toHaveBeenCalledTimes(1)
+    expect(handleSelectedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('선택된 interactive badge를 누르면 false를 전달합니다', () => {
+    const handleSelectedChange = vi.fn()
+
+    render(
+      <Badge
+        interactive
+        label="선택 라벨"
+        onSelectedChange={handleSelectedChange}
+        selected
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '선택 라벨' }))
+
+    expect(handleSelectedChange).toHaveBeenCalledTimes(1)
+    expect(handleSelectedChange).toHaveBeenCalledWith(false)
+  })
+
+  it('선택 상태를 aria-pressed로 노출합니다', () => {
+    render(<Badge interactive label="선택 라벨" selected />)
+
+    expect(screen.getByRole('button', { name: '선택 라벨' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  })
+
+  it('선택 상태 스타일을 적용합니다', () => {
+    render(<Badge interactive label="선택 라벨" selected />)
+
+    expect(screen.getByRole('button', { name: '선택 라벨' })).toHaveClass(
+      'border-primary-400',
+      'border-[1.4px]',
+      'bg-primary-400/20',
+    )
+  })
+
+  it('아이콘은 accessible name에 포함하지 않고 visible label을 이름으로 사용합니다', () => {
+    render(
+      <Badge
+        icon={<span data-testid="badge-icon">아이콘 텍스트</span>}
+        interactive
+        label="선택 라벨"
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: '선택 라벨' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/hds-ui/src/components/badge/Badge.tsx
+++ b/packages/hds-ui/src/components/badge/Badge.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react'
+import { cva } from 'class-variance-authority'
+import { cn } from '../../utils'
+
+export type BadgeProps = {
+  label: ReactNode
+  icon?: ReactNode
+  interactive?: boolean
+  selected?: boolean
+  onSelectedChange?: (selected: boolean) => void
+  className?: string
+}
+
+const badgeVariants = cva(
+  'typo-body-8 inline-flex max-w-full shrink-0 items-center gap-1 rounded-lg px-2.5 py-1 font-sans text-black whitespace-nowrap',
+  {
+    variants: {
+      interactive: {
+        true: 'appearance-none focus-visible:outline-cool-gray-900 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2',
+        false: null,
+      },
+      selected: {
+        true: 'border-primary-400 bg-primary-400/20 border-[1.4px]',
+        false: 'border-warm-gray-100 border bg-white',
+      },
+    },
+  },
+)
+
+const BadgeContent = ({ icon, label }: Pick<BadgeProps, 'icon' | 'label'>) => {
+  return (
+    <>
+      {icon ? (
+        <span
+          aria-hidden="true"
+          className="flex size-6 shrink-0 items-center justify-center text-[24px]"
+        >
+          {icon}
+        </span>
+      ) : null}
+      <span className="min-w-0 truncate">{label}</span>
+    </>
+  )
+}
+
+export const Badge = (props: BadgeProps) => {
+  const {
+    icon,
+    interactive = false,
+    label,
+    onSelectedChange,
+    selected = false,
+    className,
+  } = props
+
+  if (interactive) {
+    const handleClick = () => {
+      onSelectedChange?.(!selected)
+    }
+
+    return (
+      <button
+        aria-pressed={selected}
+        className={cn(
+          badgeVariants({ interactive: true, selected }),
+          className,
+        )}
+        onClick={handleClick}
+        type="button"
+      >
+        <BadgeContent icon={icon} label={label} />
+      </button>
+    )
+  }
+
+  return (
+    <span
+      className={cn(badgeVariants({ interactive: false, selected }), className)}
+    >
+      <BadgeContent icon={icon} label={label} />
+    </span>
+  )
+}

--- a/packages/hds-ui/src/components/badge/Badge.tsx
+++ b/packages/hds-ui/src/components/badge/Badge.tsx
@@ -2,17 +2,28 @@ import type { ReactNode } from 'react'
 import { cva } from 'class-variance-authority'
 import { cn } from '../../utils'
 
-export type BadgeProps = {
+type BadgeBaseProps = {
   label: ReactNode
   icon?: ReactNode
-  interactive?: boolean
-  selected?: boolean
-  onSelectedChange?: (selected: boolean) => void
   className?: string
 }
 
+type BadgeStaticProps = BadgeBaseProps & {
+  interactive?: false
+  selected?: never
+  onSelectedChange?: never
+}
+
+type BadgeInteractiveProps = BadgeBaseProps & {
+  interactive: true
+  selected?: boolean
+  onSelectedChange?: (selected: boolean) => void
+}
+
+export type BadgeProps = BadgeStaticProps | BadgeInteractiveProps
+
 const badgeVariants = cva(
-  'typo-body-8 inline-flex max-w-full shrink-0 items-center gap-1 rounded-lg px-2.5 py-1 font-sans text-black whitespace-nowrap',
+  'typo-body-8 inline-flex max-w-full shrink-0 items-center gap-1 rounded-lg border-[1.4px] px-2.5 py-1 font-sans text-black whitespace-nowrap',
   {
     variants: {
       interactive: {
@@ -20,8 +31,8 @@ const badgeVariants = cva(
         false: null,
       },
       selected: {
-        true: 'border-primary-400 bg-primary-400/20 border-[1.4px]',
-        false: 'border-warm-gray-100 border bg-white',
+        true: 'border-primary-400 bg-primary-400/20',
+        false: 'border-warm-gray-100 bg-white',
       },
     },
   },
@@ -44,18 +55,12 @@ const BadgeContent = ({ icon, label }: Pick<BadgeProps, 'icon' | 'label'>) => {
 }
 
 export const Badge = (props: BadgeProps) => {
-  const {
-    icon,
-    interactive = false,
-    label,
-    onSelectedChange,
-    selected = false,
-    className,
-  } = props
+  const { icon, interactive = false, label, className } = props
+  const selected = interactive ? (props.selected ?? false) : false
 
   if (interactive) {
     const handleClick = () => {
-      onSelectedChange?.(!selected)
+      props.onSelectedChange?.(!selected)
     }
 
     return (

--- a/packages/hds-ui/src/components/badge/index.ts
+++ b/packages/hds-ui/src/components/badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge'
+export type { BadgeProps } from './Badge'

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -1,5 +1,8 @@
 export { Button } from './button/Button'
 
+export { Badge } from './badge'
+export type { BadgeProps } from './badge'
+
 export { BottomNavigation } from './bottomNavigation'
 export type {
   BottomNavigationItem,


### PR DESCRIPTION
## 📌 Summary
> 리뷰 키워드 영역에서 공통으로 사용할 수 있는 아이콘 기반 Badge UI를 구현했습니다. Badge는 리뷰 상세/목록에서는 non-clickable 상태형 뱃지로, 리뷰 작성/수정에서는 `selected`로 선택 여부를 제어하는 controlled selectable badge로 사용할 수 있게 만들었어요.

Jira: [HASHI-45](https://siksa.atlassian.net/browse/HASHI-45)

## 📚 Tasks
- Badge 공통 컴포넌트 구현
- Badge Storybook 케이스 추가
- Badge 테스트 코드 추가
- Badge 컴포넌트 spec 문서 추가
- `@hashi/hds-ui` public export 추가

## 🔧 Props
**Badge props**
- label: Badge에 표시할 텍스트입니다.
- icon: label 앞에 표시할 아이콘입니다.
- interactive: 클릭 가능한 선택형 Badge로 렌더링할지 여부입니다.
- selected: 현재 Badge가 선택된 상태인지 나타냅니다.
- onSelectedChange: Badge를 클릭했을 때 다음 선택 상태와 함께 호출되는 콜백입니다.
- className: 사용처에서 Badge 스타일을 확장할 때 사용합니다.

## 🧩 Usage
- 리뷰 상세/식당 상세 리뷰 목록에서는 `interactive` 없이 사용해 선택 불가능한 상태형 Badge로 렌더링합니다.
- 리뷰 작성/수정에서는 `interactive`와 `selected`를 함께 사용해 선택 가능한 Badge로 렌더링합니다.
- 리뷰 키워드 목록, 선택 개수 제한, validation message, 저장 가능 여부는 사용처에서 제어합니다.

**예시 1. 리뷰 상세 키워드 Badge**

```tsx
import { Badge } from '@hashi/hds-ui'
import { SmileIcon } from '@hashi/hds-icons'

<Badge icon={<SmileIcon />} label="친절해요" />
```

**예시 2. 리뷰 작성 키워드 선택 Badge**

```tsx
import { useState } from 'react'
import { Badge } from '@hashi/hds-ui'
import { DeliciousIcon } from '@hashi/hds-icons'

export const ReviewKeywordBadge = () => {
  const [selected, setSelected] = useState(false)

  return (
    <Badge
      interactive
      selected={selected}
      icon={<DeliciousIcon />}
      label="음식이 맛있어요"
      onSelectedChange={setSelected}
    />
  )
}
```

## 🧪 Test Cases
> Badge.test.tsx에서는 컴포넌트의 핵심 동작을 아래 기준으로 검증했습니다.

- `interactive=false`일 때 정적 `span`으로 렌더링되는지 확인
- `interactive=true`일 때 `button type="button"`으로 렌더링되는지 확인
- 선택되지 않은 Badge 클릭 시 `onSelectedChange(true)`가 호출되는지 확인
- 선택된 Badge 클릭 시 `onSelectedChange(false)`가 호출되는지 확인
- 선택 상태에서 `aria-pressed="true"`가 적용되는지 확인
- 선택 상태 스타일 클래스가 적용되는지 확인
- 아이콘은 accessible name에 포함하지 않고 visible label을 이름으로 사용하는지 확인

## ✅ Verification

- corepack pnpm format:check
- git diff --check
- bash .agents/scripts/check-harness.sh
- corepack pnpm --filter @hashi/hds-ui lint
- corepack pnpm --filter @hashi/hds-ui typecheck
- corepack pnpm --filter @hashi/hds-ui test
- corepack pnpm --filter @hashi/hds-ui build
- corepack pnpm --filter @hashi/hds-ui build-storybook

## 👀 To Reviewer
- Badge는 UI와 선택 상태 표현만 담당하도록 구현했습니다. 리뷰 키워드 데이터, 선택 개수 제한, validation, 저장 로직은 사용처에서 처리하면 됩니다.
- 현재 디자인 기준에는 disabled 상태가 없어 이번 범위에는 포함하지 않았습니다.
- 선택 상태는 스펙 기준으로 `primary-400` stroke, `primary-400/20` background를 사용했습니다. 현재 token 값이 400/500 반대로 등록된 이슈는 다른 PR에서 수정 예정이라, 이 PR에서는 스펙의 token name을 기준으로 적용했습니다.
- Storybook에는 실제 서비스에서 사용하는 리뷰 키워드 10개를 기준으로 static/selected/selectable 케이스를 추가했습니다.

## 📸 Screenshot
<img width="1122" height="465" alt="image" src="https://github.com/user-attachments/assets/08228824-9358-4c87-b51f-75986a1b768d" />
