### PR TITLE
Feat(hds-ui): HASHI-54 avatar 컴포넌트 구현

### DIFF
--- a/packages/hds-ui/package.json
+++ b/packages/hds-ui/package.json
@@ -28,6 +28,7 @@
     "react-dom": ">=19.0.0 <20.0.0"
   },
   "dependencies": {
+    "@hashi/hds-icons": "workspace:*",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "react-aria-components": "catalog:",

--- a/packages/hds-ui/src/components/avatar/Avatar.spec.md
+++ b/packages/hds-ui/src/components/avatar/Avatar.spec.md
@@ -1,0 +1,89 @@
+# Avatar
+
+Jira: HASHI-54
+
+## 목적
+
+`Avatar`는 사용자 프로필 이미지를 공통으로 렌더링하는 HDS UI primitive입니다.
+
+HDS는 이미지 표시, 원형 placeholder, size, 기본 접근성 계약만 담당합니다. 사용자 이름 해석, nickname 첫 글자 fallback, ProfileLabel 조합, route, API, analytics는 App 또는 page/feature가 처리합니다.
+
+## Props
+
+### `src`
+
+- type: `string`
+- required: `false`
+- description: 프로필 이미지 URL입니다. 값이 있으면 `img`를 렌더링합니다.
+
+### `alt`
+
+- type: `string`
+- required: `false`
+- description: 이미지 대체 텍스트입니다. 전달하지 않으면 `alt=""`로 처리합니다.
+
+### `size`
+
+- type: `'sm' | 'md' | 'lg'`
+- required: `false`
+- default: `sm`
+- description: Avatar 크기입니다.
+
+### `className`
+
+- type: `string`
+- required: `false`
+- description: root element에 병합할 class입니다.
+
+## Size
+
+- `sm`: `40px` (`h-10 w-10`)
+- `md`: `42px` (`h-[42px] w-[42px]`)
+- `lg`: `90px` (`h-[90px] w-[90px]`)
+
+## Figma 근거
+
+- 리뷰 프로필 Avatar: `40px`
+- 프로필 수정 Avatar: `42px`
+- 게스트/큰 프로필 Avatar: `90px`
+
+## 40px / 42px 정책
+
+Figma에서 리뷰 프로필 Avatar는 40px, 프로필 수정 영역 Avatar는 42px로 확인되어 우선 각각 `sm`, `md` size로 반영합니다.
+
+추후 디자인 시스템에서 40px로 통일하기로 결정되면 `md` size는 제거하거나 alias 처리할 수 있습니다.
+
+## 상태
+
+- image: `src`가 있으면 원형 `img`를 렌더링합니다.
+- placeholder: `src`가 없으면 기본 원형 placeholder를 렌더링합니다.
+
+## fallback 정책
+
+`src`가 없으면 기본 원형 placeholder를 렌더링합니다.
+
+이름 첫 글자 fallback은 기획/디자인 정책이 확정되지 않았으므로 구현하지 않습니다. Figma의 체크무늬 원형은 투명 배경 표시일 가능성이 있으므로 실제 fallback 디자인으로 단정하지 않습니다.
+
+## 접근성
+
+- `src`가 있으면 `img`를 렌더링하고 `alt`를 전달할 수 있습니다.
+- `alt`가 전달되지 않으면 `alt=""`로 처리합니다.
+- 장식용 Avatar는 `alt=""`를 허용합니다.
+- placeholder는 의미 있는 이미지가 아니므로 `aria-hidden="true"`를 적용합니다.
+
+## Storybook 상태
+
+- Default
+- WithImage
+- Placeholder
+- Small
+- Medium
+- Large
+
+## 테스트 목록
+
+- 이미지 렌더링
+- alt 적용
+- placeholder 렌더링
+- size class 적용
+- className 병합

--- a/packages/hds-ui/src/components/avatar/Avatar.stories.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Avatar } from './Avatar'
+
+const avatarImageSrc =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 90"%3E%3Crect width="90" height="90" fill="%23deedf4"/%3E%3Ccircle cx="45" cy="34" r="16" fill="%232d383d"/%3E%3Cpath d="M18 83c4-18 18-28 27-28s23 10 27 28" fill="%232d383d"/%3E%3C/svg%3E'
+
+const meta = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  args: {
+    size: 'sm',
+    alt: '프로필 이미지',
+  },
+  argTypes: {
+    src: {
+      control: 'text',
+    },
+    alt: {
+      control: 'text',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+} satisfies Meta<typeof Avatar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithImage: Story = {
+  args: {
+    src: avatarImageSrc,
+  },
+}
+
+export const Placeholder: Story = {}
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+  },
+}

--- a/packages/hds-ui/src/components/avatar/Avatar.test.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.test.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Avatar } from './Avatar'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Avatar', () => {
+  it('renders an image when src is provided', () => {
+    render(<Avatar src="/avatar.png" alt="프로필 이미지" />)
+
+    expect(screen.getByRole('img', { name: '프로필 이미지' })).toHaveAttribute(
+      'src',
+      '/avatar.png',
+    )
+  })
+
+  it('applies alt text to the image', () => {
+    render(<Avatar src="/avatar.png" alt="사용자 프로필" />)
+
+    expect(screen.getByRole('img', { name: '사용자 프로필' })).toHaveAttribute(
+      'alt',
+      '사용자 프로필',
+    )
+  })
+
+  it('uses empty alt text when alt is not provided', () => {
+    const { container } = render(<Avatar src="/avatar.png" />)
+    const image = container.querySelector('img')
+
+    expect(image).toHaveAttribute('alt', '')
+  })
+
+  it('renders a placeholder when src is not provided', () => {
+    render(<Avatar />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toBeInTheDocument()
+  })
+
+  it('hides placeholder from assistive technologies', () => {
+    render(<Avatar />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    )
+  })
+
+  it('applies sm size classes', () => {
+    render(<Avatar size="sm" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass('h-10', 'w-10')
+  })
+
+  it('applies md size classes', () => {
+    render(<Avatar size="md" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass(
+      'h-[42px]',
+      'w-[42px]',
+    )
+  })
+
+  it('applies lg size classes', () => {
+    render(<Avatar size="lg" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass(
+      'h-[90px]',
+      'w-[90px]',
+    )
+  })
+
+  it('merges className', () => {
+    render(<Avatar className="ring-2" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass('ring-2')
+  })
+
+  it('merges className when src is provided', () => {
+    render(<Avatar src="/avatar.png" alt="프로필 이미지" className="ring-2" />)
+
+    expect(screen.getByRole('img', { name: '프로필 이미지' })).toHaveClass(
+      'ring-2',
+    )
+  })
+})

--- a/packages/hds-ui/src/components/avatar/Avatar.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.tsx
@@ -1,0 +1,43 @@
+import { cn } from '../../utils'
+
+export type AvatarSize = 'sm' | 'md' | 'lg'
+
+export interface AvatarProps {
+  src?: string
+  alt?: string
+  size?: AvatarSize
+  className?: string
+}
+
+const avatarSizeClassName: Record<AvatarSize, string> = {
+  sm: 'h-10 w-10',
+  md: 'h-[42px] w-[42px]',
+  lg: 'h-[90px] w-[90px]',
+}
+
+export const Avatar = ({
+  src,
+  alt = '',
+  size = 'sm',
+  className,
+}: AvatarProps) => {
+  const avatarClassName = cn(
+    'bg-cool-gray-100 shrink-0 overflow-hidden rounded-full',
+    avatarSizeClassName[size],
+    className,
+  )
+
+  if (!src) {
+    return (
+      <span
+        aria-hidden="true"
+        className={avatarClassName}
+        data-testid="avatar-placeholder"
+      />
+    )
+  }
+
+  return (
+    <img src={src} alt={alt} className={cn(avatarClassName, 'object-cover')} />
+  )
+}

--- a/packages/hds-ui/src/components/avatar/index.ts
+++ b/packages/hds-ui/src/components/avatar/index.ts
@@ -1,0 +1,2 @@
+export { Avatar } from './Avatar'
+export type { AvatarProps, AvatarSize } from './Avatar'

--- a/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
@@ -13,6 +13,7 @@ Jira: HASHI-53
 HDS가 담당하는 것:
 
 - native checkbox input 렌더링
+- native input ref 전달
 - checkbox icon의 시각 구조
 - checked 상태에 따른 CheckIcon 색상 표현
 - disabled 상태의 기본 interaction 차단
@@ -44,15 +45,15 @@ Exported value:
 
 Exported types:
 
-- none
+- `CheckboxProps`
 
 ## Props
 
 ### native checkbox input props
 
-- type: `Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>`
+- type: `Omit<ComponentPropsWithRef<'input'>, 'type'>`
 - required: `false`
-- description: React native checkbox input props를 전달합니다. `type`은 내부에서 `checkbox`로 고정합니다.
+- description: React native checkbox input props를 전달합니다. `type`은 내부에서 `checkbox`로 고정합니다. React 19 ref prop 방식으로 native input ref도 전달할 수 있습니다.
 
 ### `children`
 
@@ -93,12 +94,15 @@ Figma Dev Mode의 `2.6rem` 값은 사용하지 않고 px 기준 `h-[26px] w-[26p
 - root를 `label`로 감싸 label과 children 클릭 시 토글됩니다.
 - input은 `sr-only`로 숨겨 keyboard 접근성을 유지합니다.
 - keyboard interaction은 native checkbox 동작을 따릅니다.
+- CheckIcon은 장식 요소이므로 `aria-hidden="true"`와 `focusable="false"`를 적용합니다.
 - `role="checkbox"`, `aria-checked`, `tabIndex`를 중복 추가하지 않습니다.
 
 ## Storybook
 
 - [x] Default
+- [x] Checked
 - [x] Disabled
+- [x] DisabledChecked
 
 Controls:
 
@@ -112,8 +116,10 @@ Controls:
 
 - [x] label children 렌더링
 - [x] native checkbox input 렌더링
+- [x] native checkbox input ref 전달
 - [x] click 시 checked 상태 토글
 - [x] disabled 상태에서 click 시 checked 상태 유지
+- [x] CheckIcon `aria-hidden` 처리
 
 ## Verification
 

--- a/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
@@ -1,0 +1,124 @@
+# Component Spec: `Checkbox`
+
+Jira: HASHI-53
+
+## Purpose
+
+`Checkbox`는 HASHI Design System의 checkbox icon형 HDS UI primitive입니다.
+
+이번 `icon_checkbox` 디자인은 일반적인 "빈 박스에서 체크 아이콘이 나타나는 checkbox"가 아니라, 체크 아이콘이 항상 보이고 checked 여부에 따라 아이콘 색상만 바뀌는 UI입니다.
+
+## HDS Responsibilities
+
+HDS가 담당하는 것:
+
+- native checkbox input 렌더링
+- checkbox icon의 시각 구조
+- checked 상태에 따른 CheckIcon 색상 표현
+- disabled 상태의 기본 interaction 차단
+- label 클릭과 keyboard interaction을 포함한 기본 접근성 계약
+
+HDS가 담당하지 않는 것:
+
+- 탈퇴 페이지 문구
+- 동의 여부 validation
+- 버튼 활성화 조건
+- form submit
+- route 이동
+- API 호출
+- analytics
+
+## Public API
+
+```tsx
+<Checkbox defaultChecked>동의합니다</Checkbox>
+
+<Checkbox checked={checked} onChange={handleChange}>
+  동의합니다
+</Checkbox>
+```
+
+Exported value:
+
+- `Checkbox`
+
+Exported types:
+
+- none
+
+## Props
+
+### native checkbox input props
+
+- type: `Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>`
+- required: `false`
+- description: React native checkbox input props를 전달합니다. `type`은 내부에서 `checkbox`로 고정합니다.
+
+### `children`
+
+- type: `ReactNode`
+- required: `false`
+- description: checkbox 옆에 렌더링할 label content입니다.
+
+### `className`
+
+- type: `string`
+- required: `false`
+- description: root label에 병합할 class입니다.
+
+## States
+
+- unchecked: Cool_Gray_100 배경과 흰색 CheckIcon을 표시합니다.
+- checked: Cool_Gray_100 배경과 Cool_Gray_800 CheckIcon을 표시합니다.
+- disabled: native input disabled 상태를 사용하고 `cursor-not-allowed`만 적용합니다.
+- controlled: 호출부가 `checked`와 `onChange`로 상태를 관리합니다.
+- uncontrolled: native input이 `defaultChecked` 기반으로 상태를 관리합니다.
+
+## Styling
+
+- box size: `26px * 26px`
+- icon size: `26px * 26px`
+- radius: `3px`
+- background: `bg-cool-gray-100`
+- unchecked icon color: `text-white`
+- checked icon color: `peer-checked:text-cool-gray-800`
+- disabled: `cursor-not-allowed`
+- focus-visible: native input focus를 `peer-focus-visible` outline으로 visual box에 표시합니다.
+
+Figma Dev Mode의 `2.6rem` 값은 사용하지 않고 px 기준 `h-[26px] w-[26px]`를 사용합니다. `CheckIcon`은 `@hashi/hds-icons`에서 import하고, SVG viewBox가 26x26이므로 `h-[26px] w-[26px]`로 렌더링합니다.
+
+## Accessibility
+
+- 실제 `input type="checkbox"`를 유지합니다.
+- root를 `label`로 감싸 label과 children 클릭 시 토글됩니다.
+- input은 `sr-only`로 숨겨 keyboard 접근성을 유지합니다.
+- keyboard interaction은 native checkbox 동작을 따릅니다.
+- `role="checkbox"`, `aria-checked`, `tabIndex`를 중복 추가하지 않습니다.
+
+## Storybook
+
+- [x] Default
+- [x] Disabled
+
+Controls:
+
+- `children`
+- `defaultChecked`
+- `disabled`
+
+`checked` control은 controlled/read-only 혼선을 피하기 위해 기본 control로 노출하지 않습니다.
+
+## Test
+
+- [x] label children 렌더링
+- [x] native checkbox input 렌더링
+- [x] click 시 checked 상태 토글
+- [x] disabled 상태에서 click 시 checked 상태 유지
+
+## Verification
+
+- [ ] `pnpm --filter @hashi/hds-ui lint`
+- [ ] `pnpm --filter @hashi/hds-ui typecheck`
+- [ ] `pnpm --filter @hashi/hds-ui build-storybook`
+- [ ] `pnpm --filter @hashi/hds-ui test`
+- [ ] `git diff --check`

--- a/packages/hds-ui/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.stories.tsx
@@ -27,8 +27,21 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
+export const Checked: Story = {
+  args: {
+    defaultChecked: true,
+  },
+}
+
 export const Disabled: Story = {
   args: {
+    disabled: true,
+  },
+}
+
+export const DisabledChecked: Story = {
+  args: {
+    defaultChecked: true,
     disabled: true,
   },
 }

--- a/packages/hds-ui/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Checkbox } from './Checkbox'
+
+const meta = {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  args: {
+    children: 'Checkbox',
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+    defaultChecked: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Checkbox>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}

--- a/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Checkbox } from './Checkbox'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Checkbox', () => {
+  it('renders label children', () => {
+    render(<Checkbox>Checkbox</Checkbox>)
+
+    expect(screen.getByText('Checkbox')).toBeInTheDocument()
+  })
+
+  it('renders a native checkbox input', () => {
+    render(<Checkbox>Checkbox</Checkbox>)
+
+    expect(screen.getByRole('checkbox', { name: 'Checkbox' })).toHaveAttribute(
+      'type',
+      'checkbox',
+    )
+  })
+
+  it('toggles checked state when clicked', () => {
+    render(<Checkbox>Checkbox</Checkbox>)
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Checkbox' })
+
+    expect(checkbox).not.toBeChecked()
+
+    fireEvent.click(checkbox)
+
+    expect(checkbox).toBeChecked()
+
+    fireEvent.click(checkbox)
+
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('does not toggle checked state when disabled', () => {
+    const handleChange = vi.fn()
+
+    render(
+      <Checkbox checked disabled onChange={handleChange}>
+        Checkbox
+      </Checkbox>,
+    )
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Checkbox' })
+
+    expect(checkbox).toBeChecked()
+
+    fireEvent.click(screen.getByText('Checkbox'))
+
+    expect(checkbox).toBeChecked()
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+})

--- a/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Checkbox } from './Checkbox'
 
@@ -21,6 +22,14 @@ describe('Checkbox', () => {
       'type',
       'checkbox',
     )
+  })
+
+  it('passes ref to the native checkbox input', () => {
+    const ref = createRef<HTMLInputElement>()
+
+    render(<Checkbox ref={ref}>Checkbox</Checkbox>)
+
+    expect(ref.current).toBe(screen.getByRole('checkbox', { name: 'Checkbox' }))
   })
 
   it('toggles checked state when clicked', () => {
@@ -56,5 +65,13 @@ describe('Checkbox', () => {
 
     expect(checkbox).toBeChecked()
     expect(handleChange).not.toHaveBeenCalled()
+  })
+
+  it('hides CheckIcon from assistive technologies', () => {
+    const { container } = render(<Checkbox>Checkbox</Checkbox>)
+    const icon = container.querySelector('svg')
+
+    expect(icon).toHaveAttribute('aria-hidden', 'true')
+    expect(icon).toHaveAttribute('focusable', 'false')
   })
 })

--- a/packages/hds-ui/src/components/checkbox/Checkbox.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.tsx
@@ -1,15 +1,16 @@
-import type { InputHTMLAttributes, PropsWithChildren } from 'react'
+import type { ComponentPropsWithRef, PropsWithChildren } from 'react'
 import { CheckIcon } from '@hashi/hds-icons'
 import { cn } from '../../utils'
 
-type CheckboxProps = PropsWithChildren<
-  Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+export type CheckboxProps = PropsWithChildren<
+  Omit<ComponentPropsWithRef<'input'>, 'type'>
 >
 
 export const Checkbox = ({
   children,
   className,
   disabled,
+  ref,
   ...props
 }: CheckboxProps) => {
   return (
@@ -21,13 +22,18 @@ export const Checkbox = ({
       )}
     >
       <input
+        ref={ref}
         className="peer sr-only"
         type="checkbox"
         disabled={disabled}
         {...props}
       />
       <span className="bg-cool-gray-100 peer-focus-visible:outline-cool-gray-800 peer-checked:text-cool-gray-800 flex h-[26px] w-[26px] items-center justify-center rounded-[3px] text-white peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2">
-        <CheckIcon className="h-[26px] w-[26px]" />
+        <CheckIcon
+          aria-hidden="true"
+          className="h-[26px] w-[26px]"
+          focusable="false"
+        />
       </span>
       {children ? <span>{children}</span> : null}
     </label>

--- a/packages/hds-ui/src/components/checkbox/Checkbox.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.tsx
@@ -1,0 +1,35 @@
+import type { InputHTMLAttributes, PropsWithChildren } from 'react'
+import { CheckIcon } from '@hashi/hds-icons'
+import { cn } from '../../utils'
+
+type CheckboxProps = PropsWithChildren<
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>
+>
+
+export const Checkbox = ({
+  children,
+  className,
+  disabled,
+  ...props
+}: CheckboxProps) => {
+  return (
+    <label
+      className={cn(
+        'group inline-flex items-center gap-2',
+        disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+        className,
+      )}
+    >
+      <input
+        className="peer sr-only"
+        type="checkbox"
+        disabled={disabled}
+        {...props}
+      />
+      <span className="bg-cool-gray-100 peer-focus-visible:outline-cool-gray-800 peer-checked:text-cool-gray-800 flex h-[26px] w-[26px] items-center justify-center rounded-[3px] text-white peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2">
+        <CheckIcon className="h-[26px] w-[26px]" />
+      </span>
+      {children ? <span>{children}</span> : null}
+    </label>
+  )
+}

--- a/packages/hds-ui/src/components/checkbox/index.ts
+++ b/packages/hds-ui/src/components/checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox'

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -22,3 +22,4 @@ export type {
   DialogTriggerProps,
   DialogType,
 } from './dialog'
+export { Checkbox } from './checkbox/Checkbox'

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -1,5 +1,8 @@
 export { Button } from './button/Button'
 
+export { Avatar } from './avatar'
+export type { AvatarProps, AvatarSize } from './avatar'
+
 export { BottomNavigation } from './bottomNavigation'
 export type {
   BottomNavigationItem,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
 
   packages/hds-ui:
     dependencies:
+      '@hashi/hds-icons':
+        specifier: workspace:*
+        version: link:../hds-icons
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
@@ -351,9 +354,6 @@ importers:
         specifier: 'catalog:'
         version: 3.6.0
     devDependencies:
-      '@hashi/hds-icons':
-        specifier: workspace:*
-        version: link:../hds-icons
       '@hashi/hds-tokens':
         specifier: workspace:*
         version: link:../hds-tokens


### PR DESCRIPTION
## 📌 Summary

HDS UI 패키지에 사용자 프로필 이미지를 공통으로 렌더링할 수 있는 `Avatar` 컴포넌트를 추가했습니다.

Jira: HASHI-54

## 📚 Tasks

- `Avatar` 공통 컴포넌트 추가
- `src` 유무에 따라 이미지 또는 기본 placeholder 렌더링
- `sm`, `md`, `lg` size variant 추가
  - `sm`: 40px
  - `md`: 42px
  - `lg`: 90px
- `alt` 기본 처리 및 placeholder 접근성 처리
- 외부 `className` 병합 지원
- Avatar Storybook 문서 및 상태 추가
  - Default
  - WithImage
  - Placeholder
  - Small
  - Medium
  - Large
- Avatar 테스트 코드 추가
  - 이미지 렌더링
  - alt 적용
  - placeholder 렌더링
  - size class 적용
  - className 병합
- `Avatar.spec.md`에 Figma 기준 size와 fallback 정책 문서화

## 👀 To Reviewer

Figma에서 리뷰 프로필 Avatar는 40px, 프로필 수정 영역 Avatar는 42px로 확인되어 우선 각각 `sm`, `md` size로 반영했습니다.

추후 디자인 시스템에서 42px 피드백 시, `md` size는 제거하거나 alias 처리할 수 있습니다.

또한 fallback은 `src`가 없을 때 기본 원형 placeholder만 렌더링하도록 했습니다.

## 📸 Screenshot
(placeholder 스토리북으로 안보여서 추후업로드예정)