### PR TITLE
Feat(hds-ui): HASHI-54 Avatar 공통 컴포넌트 구현

### DIFF
--- a/packages/hds-ui/src/components/avatar/Avatar.spec.md
+++ b/packages/hds-ui/src/components/avatar/Avatar.spec.md
@@ -1,0 +1,89 @@
+# Avatar
+
+Jira: HASHI-54
+
+## 목적
+
+`Avatar`는 사용자 프로필 이미지를 공통으로 렌더링하는 HDS UI primitive입니다.
+
+HDS는 이미지 표시, 원형 placeholder, size, 기본 접근성 계약만 담당합니다. 사용자 이름 해석, nickname 첫 글자 fallback, ProfileLabel 조합, route, API, analytics는 App 또는 page/feature가 처리합니다.
+
+## Props
+
+### `src`
+
+- type: `string`
+- required: `false`
+- description: 프로필 이미지 URL입니다. 값이 있으면 `img`를 렌더링합니다.
+
+### `alt`
+
+- type: `string`
+- required: `false`
+- description: 이미지 대체 텍스트입니다. 전달하지 않으면 `alt=""`로 처리합니다.
+
+### `size`
+
+- type: `'sm' | 'md' | 'lg'`
+- required: `false`
+- default: `sm`
+- description: Avatar 크기입니다.
+
+### `className`
+
+- type: `string`
+- required: `false`
+- description: root element에 병합할 class입니다.
+
+## Size
+
+- `sm`: `40px` (`h-10 w-10`)
+- `md`: `42px` (`h-[42px] w-[42px]`)
+- `lg`: `90px` (`h-[90px] w-[90px]`)
+
+## Figma 근거
+
+- 리뷰 프로필 Avatar: `40px`
+- 프로필 수정 Avatar: `42px`
+- 게스트/큰 프로필 Avatar: `90px`
+
+## 40px / 42px 정책
+
+Figma에서 리뷰 프로필 Avatar는 40px, 프로필 수정 영역 Avatar는 42px로 확인되어 우선 각각 `sm`, `md` size로 반영합니다.
+
+추후 디자인 시스템에서 40px로 통일하기로 결정되면 `md` size는 제거하거나 alias 처리할 수 있습니다.
+
+## 상태
+
+- image: `src`가 있으면 원형 `img`를 렌더링합니다.
+- placeholder: `src`가 없으면 기본 원형 placeholder를 렌더링합니다.
+
+## fallback 정책
+
+`src`가 없으면 기본 원형 placeholder를 렌더링합니다.
+
+이름 첫 글자 fallback은 기획/디자인 정책이 확정되지 않았으므로 구현하지 않습니다. Figma의 체크무늬 원형은 투명 배경 표시일 가능성이 있으므로 실제 fallback 디자인으로 단정하지 않습니다.
+
+## 접근성
+
+- `src`가 있으면 `img`를 렌더링하고 `alt`를 전달할 수 있습니다.
+- `alt`가 전달되지 않으면 `alt=""`로 처리합니다.
+- 장식용 Avatar는 `alt=""`를 허용합니다.
+- placeholder는 의미 있는 이미지가 아니므로 `aria-hidden="true"`를 적용합니다.
+
+## Storybook 상태
+
+- Default
+- WithImage
+- Placeholder
+- Small
+- Medium
+- Large
+
+## 테스트 목록
+
+- 이미지 렌더링
+- alt 적용
+- placeholder 렌더링
+- size class 적용
+- className 병합

--- a/packages/hds-ui/src/components/avatar/Avatar.stories.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Avatar } from './Avatar'
+
+const avatarImageSrc =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 90"%3E%3Crect width="90" height="90" fill="%23deedf4"/%3E%3Ccircle cx="45" cy="34" r="16" fill="%232d383d"/%3E%3Cpath d="M18 83c4-18 18-28 27-28s23 10 27 28" fill="%232d383d"/%3E%3C/svg%3E'
+
+const meta = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  args: {
+    size: 'sm',
+    alt: '프로필 이미지',
+  },
+  argTypes: {
+    src: {
+      control: 'text',
+    },
+    alt: {
+      control: 'text',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+} satisfies Meta<typeof Avatar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithImage: Story = {
+  args: {
+    src: avatarImageSrc,
+  },
+}
+
+export const Placeholder: Story = {}
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+  },
+}

--- a/packages/hds-ui/src/components/avatar/Avatar.stories.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.stories.tsx
@@ -38,6 +38,13 @@ export const WithImage: Story = {
   },
 }
 
+export const BrokenImage: Story = {
+  args: {
+    src: '/broken-avatar-image.png',
+    alt: '깨진 프로필 이미지',
+  },
+}
+
 export const Placeholder: Story = {}
 
 export const Small: Story = {

--- a/packages/hds-ui/src/components/avatar/Avatar.test.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.test.tsx
@@ -37,6 +37,15 @@ describe('Avatar', () => {
     render(<Avatar />)
 
     expect(screen.getByTestId('avatar-placeholder')).toBeInTheDocument()
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass('block')
+  })
+
+  it('applies placeholder background class', () => {
+    render(<Avatar />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass(
+      'bg-cool-gray-100',
+    )
   })
 
   it('hides placeholder from assistive technologies', () => {

--- a/packages/hds-ui/src/components/avatar/Avatar.test.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.test.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Avatar } from './Avatar'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Avatar', () => {
+  it('renders an image when src is provided', () => {
+    render(<Avatar src="/avatar.png" alt="프로필 이미지" />)
+
+    expect(screen.getByRole('img', { name: '프로필 이미지' })).toHaveAttribute(
+      'src',
+      '/avatar.png',
+    )
+  })
+
+  it('applies alt text to the image', () => {
+    render(<Avatar src="/avatar.png" alt="사용자 프로필" />)
+
+    expect(screen.getByRole('img', { name: '사용자 프로필' })).toHaveAttribute(
+      'alt',
+      '사용자 프로필',
+    )
+  })
+
+  it('uses empty alt text when alt is not provided', () => {
+    const { container } = render(<Avatar src="/avatar.png" />)
+    const image = container.querySelector('img')
+
+    expect(image).toHaveAttribute('alt', '')
+  })
+
+  it('renders a placeholder when src is not provided', () => {
+    render(<Avatar />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toBeInTheDocument()
+  })
+
+  it('hides placeholder from assistive technologies', () => {
+    render(<Avatar />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    )
+  })
+
+  it('applies sm size classes', () => {
+    render(<Avatar size="sm" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass('h-10', 'w-10')
+  })
+
+  it('applies md size classes', () => {
+    render(<Avatar size="md" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass(
+      'h-[42px]',
+      'w-[42px]',
+    )
+  })
+
+  it('applies lg size classes', () => {
+    render(<Avatar size="lg" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass(
+      'h-[90px]',
+      'w-[90px]',
+    )
+  })
+
+  it('merges className', () => {
+    render(<Avatar className="ring-2" />)
+
+    expect(screen.getByTestId('avatar-placeholder')).toHaveClass('ring-2')
+  })
+
+  it('merges className when src is provided', () => {
+    render(<Avatar src="/avatar.png" alt="프로필 이미지" className="ring-2" />)
+
+    expect(screen.getByRole('img', { name: '프로필 이미지' })).toHaveClass(
+      'ring-2',
+    )
+  })
+})

--- a/packages/hds-ui/src/components/avatar/Avatar.test.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { Avatar } from './Avatar'
 
@@ -38,6 +38,36 @@ describe('Avatar', () => {
 
     expect(screen.getByTestId('avatar-placeholder')).toBeInTheDocument()
     expect(screen.getByTestId('avatar-placeholder')).toHaveClass('block')
+  })
+
+  it('renders a placeholder when image loading fails', () => {
+    render(<Avatar src="/broken-avatar.png" alt="프로필 이미지" />)
+
+    const image = screen.getByRole('img', { name: '프로필 이미지' })
+
+    fireEvent.error(image)
+
+    expect(
+      screen.queryByRole('img', { name: '프로필 이미지' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('avatar-placeholder')).toBeInTheDocument()
+  })
+
+  it('resets image error state when src changes', () => {
+    const { rerender } = render(
+      <Avatar src="/broken-avatar.png" alt="프로필 이미지" />,
+    )
+
+    fireEvent.error(screen.getByRole('img', { name: '프로필 이미지' }))
+
+    expect(screen.getByTestId('avatar-placeholder')).toBeInTheDocument()
+
+    rerender(<Avatar src="/avatar.png" alt="프로필 이미지" />)
+
+    expect(screen.getByRole('img', { name: '프로필 이미지' })).toHaveAttribute(
+      'src',
+      '/avatar.png',
+    )
   })
 
   it('applies placeholder background class', () => {

--- a/packages/hds-ui/src/components/avatar/Avatar.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.tsx
@@ -1,0 +1,43 @@
+import { cn } from '../../utils'
+
+export type AvatarSize = 'sm' | 'md' | 'lg'
+
+export interface AvatarProps {
+  src?: string
+  alt?: string
+  size?: AvatarSize
+  className?: string
+}
+
+const avatarSizeClassName: Record<AvatarSize, string> = {
+  sm: 'h-10 w-10',
+  md: 'h-[42px] w-[42px]',
+  lg: 'h-[90px] w-[90px]',
+}
+
+export const Avatar = ({
+  src,
+  alt = '',
+  size = 'sm',
+  className,
+}: AvatarProps) => {
+  const avatarClassName = cn(
+    'bg-cool-gray-100 shrink-0 overflow-hidden rounded-full',
+    avatarSizeClassName[size],
+    className,
+  )
+
+  if (!src) {
+    return (
+      <span
+        aria-hidden="true"
+        className={avatarClassName}
+        data-testid="avatar-placeholder"
+      />
+    )
+  }
+
+  return (
+    <img src={src} alt={alt} className={cn(avatarClassName, 'object-cover')} />
+  )
+}

--- a/packages/hds-ui/src/components/avatar/Avatar.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.tsx
@@ -22,7 +22,7 @@ export const Avatar = ({
   className,
 }: AvatarProps) => {
   const avatarClassName = cn(
-    'bg-cool-gray-100 shrink-0 overflow-hidden rounded-full',
+    'block shrink-0 overflow-hidden rounded-full',
     avatarSizeClassName[size],
     className,
   )
@@ -31,7 +31,7 @@ export const Avatar = ({
     return (
       <span
         aria-hidden="true"
-        className={avatarClassName}
+        className={cn('bg-cool-gray-100', avatarClassName)}
         data-testid="avatar-placeholder"
       />
     )

--- a/packages/hds-ui/src/components/avatar/Avatar.tsx
+++ b/packages/hds-ui/src/components/avatar/Avatar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { cn } from '../../utils'
 
 export type AvatarSize = 'sm' | 'md' | 'lg'
@@ -21,13 +22,21 @@ export const Avatar = ({
   size = 'sm',
   className,
 }: AvatarProps) => {
+  const [hasImageError, setHasImageError] = useState(false)
+
+  useEffect(() => {
+    setHasImageError(false)
+  }, [src])
+
   const avatarClassName = cn(
     'block shrink-0 overflow-hidden rounded-full',
     avatarSizeClassName[size],
     className,
   )
 
-  if (!src) {
+  const shouldShowPlaceholder = !src || hasImageError
+
+  if (shouldShowPlaceholder) {
     return (
       <span
         aria-hidden="true"
@@ -38,6 +47,13 @@ export const Avatar = ({
   }
 
   return (
-    <img src={src} alt={alt} className={cn(avatarClassName, 'object-cover')} />
+    <img
+      src={src}
+      alt={alt}
+      className={cn(avatarClassName, 'object-cover')}
+      onError={() => {
+        setHasImageError(true)
+      }}
+    />
   )
 }

--- a/packages/hds-ui/src/components/avatar/index.ts
+++ b/packages/hds-ui/src/components/avatar/index.ts
@@ -1,0 +1,2 @@
+export { Avatar } from './Avatar'
+export type { AvatarProps, AvatarSize } from './Avatar'

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -1,3 +1,6 @@
+export { Avatar } from './avatar'
+export type { AvatarProps, AvatarSize } from './avatar'
+
 export { Button } from './button'
 export type {
   ButtonProps,


### PR DESCRIPTION
## 📌 Summary

HDS UI 패키지에 사용자 프로필 이미지를 공통으로 렌더링할 수 있는 `Avatar` 컴포넌트를 구현했습니다.

Jira: HASHI-54

## 📚 Tasks

- `Avatar` 공통 컴포넌트 추가
- `src` 유무에 따라 이미지 또는 기본 placeholder 렌더링
- `sm`, `md`, `lg` size variant 추가
  - `sm`: 40px
  - `md`: 42px
  - `lg`: 90px
- `alt` 기본 처리 및 placeholder 접근성 처리
- 외부 `className` 병합 지원
- Avatar Storybook 문서 및 상태 추가
  - Default
  - WithImage
  - Placeholder
  - Small
  - Medium
  - Large
- Avatar 테스트 코드 추가
  - 이미지 렌더링
  - alt 적용
  - placeholder 렌더링
  - size class 적용
  - className 병합
- `Avatar.spec.md`에 Figma 기준 size와 fallback 정책 문서화

## 👀 To Reviewer

Figma에서 리뷰 프로필 Avatar는 40px, 프로필 수정 영역 Avatar는 42px로 확인되어 우선 각각 `sm`, `md` size로 반영했습니다.

추후 디자인 시스템에서 42px 피드백 시, `md` size는 제거하거나 alias 처리할 수 있습니다.

또한 fallback은 `src`가 없을 때 기본 원형 placeholder만 렌더링하도록 했습니다.

## 📸 Screenshot
<img width="200" height="658" alt="스크린샷 2026-07-02 오전 3 04 27" src="https://github.com/user-attachments/assets/83568487-f86b-4704-92f1-9559685bccf5" />
<img width="206" height="695" alt="스크린샷 2026-07-02 오전 3 05 28" src="https://github.com/user-attachments/assets/2f71010e-43c3-45bb-8ddf-c8d8ba00dd6c" />
