### PR TITLE
Feat(hds-ui): HASHI 63 textarea 공통 컴포넌트 구현

### DIFF
--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -18,6 +18,9 @@ export type { IconButtonProps, IconButtonSize } from './iconButton'
 export { Tabs } from './tabs'
 export type { TabsItem, TabsProps } from './tabs'
 
+export { Textarea } from './textarea'
+export type { TextareaProps } from './textarea'
+
 export { Dialog } from './dialog'
 export type {
   DialogBodyProps,

--- a/packages/hds-ui/src/components/textarea/Textarea.spec.md
+++ b/packages/hds-ui/src/components/textarea/Textarea.spec.md
@@ -94,6 +94,12 @@ Exported type:
 - Counter uses `aria-live="polite"` when rendered.
 - Disabled state uses native `disabled`.
 
+## Storybook
+
+- [x] Default
+- [x] Review example
+- [x] Disabled
+
 ## Verification
 
 - `corepack pnpm --filter @hashi/hds-ui lint`

--- a/packages/hds-ui/src/components/textarea/Textarea.spec.md
+++ b/packages/hds-ui/src/components/textarea/Textarea.spec.md
@@ -21,6 +21,7 @@ HDS는 textarea box, helper text, character counter, disabled state, className m
 - [x] counter는 `value`, `defaultValue`, 사용자 입력 이벤트를 기준으로 내부 계산합니다.
 - [x] `showCounter={false}`로 counter를 숨길 수 있습니다.
 - [x] HTML `maxLength` attribute로 입력 길이 제한을 위임합니다.
+- [x] 입력 이벤트나 controlled value가 `maxLength`를 초과해도 컴포넌트가 `maxLength`까지만 표시합니다.
 - [x] resize를 막습니다.
 - [x] error / invalid 상태와 minLength 검증은 1차 구현에서 제외합니다.
 
@@ -70,8 +71,9 @@ Exported type:
 1. The root renders a fixed design-system width with `max-width: 100%`.
 2. The textarea renders native attributes and event handlers.
 3. `onChange` updates the internal counter and then calls the provided handler.
-4. When `value` changes in controlled usage, the counter syncs to that value.
+4. When `value` changes in controlled usage, the rendered value and counter are limited to `maxLength`.
 5. `maxLength` is passed to the native textarea.
+6. If an input event produces a value longer than `maxLength`, the DOM value is trimmed to `maxLength` before the counter is updated.
 
 ## Styling
 

--- a/packages/hds-ui/src/components/textarea/Textarea.spec.md
+++ b/packages/hds-ui/src/components/textarea/Textarea.spec.md
@@ -1,0 +1,102 @@
+# Component Spec: `Textarea`
+
+Jira: HASHI-63
+
+## Purpose
+
+`Textarea`는 여러 줄 텍스트 입력을 제공하는 HDS form primitive입니다.
+
+HDS는 textarea box, helper text, character counter, disabled state, className merge, native textarea attribute forwarding, baseline accessibility만 담당합니다. 리뷰, 식당, 후기, 문의, 신고, route, API, analytics, 제출 가능 여부, 제품별 검증 정책은 호출부가 처리합니다.
+
+## Usage Location
+
+- `packages/hds-ui/src/components/textarea/Textarea.tsx`
+
+## Requirements
+
+- [x] 제품 도메인 copy나 검증 정책을 하드코딩하지 않습니다.
+- [x] native `textarea` props를 전달합니다.
+- [x] `placeholder`, `helperText`, `maxLength`, `disabled`, `className`을 지원합니다.
+- [x] `maxLength`가 있으면 counter를 기본 표시합니다.
+- [x] counter는 `value`, `defaultValue`, 사용자 입력 이벤트를 기준으로 내부 계산합니다.
+- [x] `showCounter={false}`로 counter를 숨길 수 있습니다.
+- [x] HTML `maxLength` attribute로 입력 길이 제한을 위임합니다.
+- [x] resize를 막습니다.
+- [x] error / invalid 상태와 minLength 검증은 1차 구현에서 제외합니다.
+
+## Figma Reference
+
+| Node         | Name                   | Size / Style                                                                           |
+| ------------ | ---------------------- | -------------------------------------------------------------------------------------- |
+| `1735:39329` | `input_textbox_review` | width `353px`, box min-height `230px`, padding `20px`, radius `10px`, helper gap `8px` |
+
+Figma의 `리뷰를 작성해 주세요.`, `10자 이상`, `0 / 1000` 문구는 HDS 내부에 하드코딩하지 않고 Storybook 예시에서만 사용합니다.
+
+## Public API
+
+```tsx
+<Textarea
+  placeholder="리뷰를 작성해 주세요."
+  helperText="10자 이상"
+  maxLength={1000}
+/>
+```
+
+Exported value:
+
+- `Textarea`
+
+Exported type:
+
+- `TextareaProps`
+
+## Props
+
+- `helperText`: `string`, optional helper text rendered below the textarea.
+- `showCounter`: `boolean`, optional. Defaults to `true` when `maxLength` exists.
+- `className`: `string`, optional wrapper className.
+- native `textarea` props except `children` and inner textarea `className`.
+
+## States
+
+- default: editable textarea with placeholder, helper text, and optional counter.
+- focused: browser focus is visible with HDS token outline and border.
+- disabled: native disabled textarea with disabled visual treatment.
+- controlled: `value` drives the input and counter.
+- uncontrolled: `defaultValue` and user input drive the counter.
+
+## Behavior
+
+1. The root renders a fixed design-system width with `max-width: 100%`.
+2. The textarea renders native attributes and event handlers.
+3. `onChange` updates the internal counter and then calls the provided handler.
+4. When `value` changes in controlled usage, the counter syncs to that value.
+5. `maxLength` is passed to the native textarea.
+
+## Styling
+
+- root width: `353px`
+- root gap: `8px`
+- textarea min-height: `230px`
+- textarea padding: `20px`
+- border: `1px`, `warm-gray-100`
+- border radius: `10px`
+- input text: `font-sans`, `typo-body-4`, `primary-200`
+- placeholder: `warm-gray-300`
+- helper/counter: `font-sans`, `typo-body-6`, `line-height: 1.36`
+- helper text: `warm-gray-300`
+- current count: `primary-200`
+- max count: `warm-gray-300`
+
+## Accessibility
+
+- Consumers provide a visible label, `aria-label`, or `aria-labelledby`.
+- Counter uses `aria-live="polite"` when rendered.
+- Disabled state uses native `disabled`.
+
+## Verification
+
+- `corepack pnpm --filter @hashi/hds-ui lint`
+- `corepack pnpm --filter @hashi/hds-ui typecheck`
+- `corepack pnpm --filter @hashi/hds-ui build`
+- `corepack pnpm --filter @hashi/hds-ui test`

--- a/packages/hds-ui/src/components/textarea/Textarea.stories.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Textarea } from './Textarea'
+
+const meta = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  args: {
+    placeholder: '내용을 입력해 주세요.',
+    helperText: '도움말을 입력할 수 있습니다.',
+    maxLength: 1000,
+    disabled: false,
+    showCounter: undefined,
+  },
+  argTypes: {
+    placeholder: {
+      control: 'text',
+    },
+    helperText: {
+      control: 'text',
+    },
+    maxLength: {
+      control: 'number',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    showCounter: {
+      control: 'boolean',
+    },
+    value: {
+      control: false,
+    },
+    defaultValue: {
+      control: 'text',
+    },
+    onChange: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof Textarea>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const ReviewExample: Story = {
+  args: {
+    placeholder: '리뷰를 작성해 주세요.',
+    helperText: '10자 이상',
+    maxLength: 1000,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    placeholder: '비활성 상태입니다.',
+    helperText: '입력할 수 없습니다.',
+    maxLength: 1000,
+    disabled: true,
+  },
+}

--- a/packages/hds-ui/src/components/textarea/Textarea.test.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.test.tsx
@@ -37,6 +37,19 @@ describe('Textarea', () => {
     expect(screen.getByText('3')).toBeTruthy()
   })
 
+  it('limits user input to maxLength', () => {
+    render(<Textarea aria-label="memo" maxLength={5} />)
+
+    const textarea = screen.getByRole('textbox', {
+      name: 'memo',
+    }) as HTMLTextAreaElement
+
+    fireEvent.change(textarea, { target: { value: 'abcdef' } })
+
+    expect(textarea.value).toBe('abcde')
+    expect(screen.getByText('5')).toBeTruthy()
+  })
+
   it('uses controlled value for the counter', () => {
     const { rerender } = render(
       <Textarea aria-label="review" value="처음" maxLength={1000} readOnly />,
@@ -53,6 +66,17 @@ describe('Textarea', () => {
       />,
     )
 
+    expect(screen.getByText('5')).toBeTruthy()
+  })
+
+  it('limits controlled value to maxLength', () => {
+    render(<Textarea aria-label="memo" value="abcdef" maxLength={5} readOnly />)
+
+    const textarea = screen.getByRole('textbox', {
+      name: 'memo',
+    }) as HTMLTextAreaElement
+
+    expect(textarea.value).toBe('abcde')
     expect(screen.getByText('5')).toBeTruthy()
   })
 

--- a/packages/hds-ui/src/components/textarea/Textarea.test.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Textarea } from './Textarea'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Textarea', () => {
+  it('renders placeholder and helper text', () => {
+    render(
+      <Textarea
+        aria-label="review"
+        placeholder="리뷰를 작성해 주세요."
+        helperText="10자 이상"
+      />,
+    )
+
+    expect(screen.getByPlaceholderText('리뷰를 작성해 주세요.')).toBeTruthy()
+    expect(screen.getByText('10자 이상')).toBeTruthy()
+  })
+
+  it('shows a counter when maxLength is provided', () => {
+    render(<Textarea aria-label="review" maxLength={1000} />)
+
+    expect(screen.getByText('0')).toBeTruthy()
+    expect(screen.getByText('/1000')).toBeTruthy()
+  })
+
+  it('updates the counter from user input', () => {
+    render(<Textarea aria-label="review" maxLength={1000} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'review' }), {
+      target: { value: '좋아요' },
+    })
+
+    expect(screen.getByText('3')).toBeTruthy()
+  })
+
+  it('uses controlled value for the counter', () => {
+    const { rerender } = render(
+      <Textarea aria-label="review" value="처음" maxLength={1000} readOnly />,
+    )
+
+    expect(screen.getByText('2')).toBeTruthy()
+
+    rerender(
+      <Textarea
+        aria-label="review"
+        value="다음 내용"
+        maxLength={1000}
+        readOnly
+      />,
+    )
+
+    expect(screen.getByText('5')).toBeTruthy()
+  })
+
+  it('allows hiding the counter', () => {
+    render(<Textarea aria-label="memo" maxLength={1000} showCounter={false} />)
+
+    expect(screen.queryByText('0')).toBeNull()
+    expect(screen.queryByText('/1000')).toBeNull()
+  })
+
+  it('passes native textarea props', () => {
+    render(<Textarea aria-label="memo" name="memo" maxLength={5} disabled />)
+
+    const textarea = screen.getByRole('textbox', { name: 'memo' })
+
+    expect(textarea.getAttribute('name')).toBe('memo')
+    expect(textarea.getAttribute('maxlength')).toBe('5')
+    expect(textarea.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('calls the provided change handler', () => {
+    const handleChange = vi.fn()
+
+    render(<Textarea aria-label="memo" maxLength={5} onChange={handleChange} />)
+
+    const textarea = screen.getByRole('textbox', { name: 'memo' })
+
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+
+    expect(handleChange).toHaveBeenCalledOnce()
+    expect(screen.getByText('5')).toBeTruthy()
+  })
+})

--- a/packages/hds-ui/src/components/textarea/Textarea.test.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.test.tsx
@@ -69,6 +69,31 @@ describe('Textarea', () => {
     expect(screen.getByText('5')).toBeTruthy()
   })
 
+  it('keeps counter in sync with controlled value when parent does not update value', () => {
+    const handleChange = vi.fn()
+
+    render(
+      <Textarea
+        aria-label="review"
+        value=""
+        maxLength={1000}
+        onChange={handleChange}
+      />,
+    )
+
+    const textarea = screen.getByRole('textbox', {
+      name: 'review',
+    }) as HTMLTextAreaElement
+
+    fireEvent.change(textarea, {
+      target: { value: '좋아요' },
+    })
+
+    expect(handleChange).toHaveBeenCalledOnce()
+    expect(textarea.value).toBe('')
+    expect(screen.getByText('0')).toBeTruthy()
+  })
+
   it('limits controlled value to maxLength', () => {
     render(<Textarea aria-label="memo" value="abcdef" maxLength={5} readOnly />)
 
@@ -85,6 +110,46 @@ describe('Textarea', () => {
 
     expect(screen.queryByText('0')).toBeNull()
     expect(screen.queryByText('/1000')).toBeNull()
+  })
+
+  it('connects helper text and counter with aria-describedby', () => {
+    render(
+      <Textarea aria-label="review" helperText="10자 이상" maxLength={1000} />,
+    )
+
+    const textarea = screen.getByRole('textbox', { name: 'review' })
+    const helperText = screen.getByText('10자 이상')
+    const counter = screen.getByText('0').closest('p')
+
+    expect(helperText).toHaveAttribute('id')
+    expect(counter).toHaveAttribute('id')
+    expect(textarea).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining(helperText.id),
+    )
+    expect(textarea).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining(counter?.id ?? ''),
+    )
+  })
+
+  it('preserves external aria-describedby', () => {
+    render(
+      <>
+        <p id="external-description">외부 설명</p>
+        <Textarea
+          aria-label="review"
+          aria-describedby="external-description"
+          helperText="10자 이상"
+          maxLength={1000}
+        />
+      </>,
+    )
+
+    expect(screen.getByRole('textbox', { name: 'review' })).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining('external-description'),
+    )
   })
 
   it('passes native textarea props', () => {

--- a/packages/hds-ui/src/components/textarea/Textarea.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.tsx
@@ -112,9 +112,7 @@ export const Textarea = ({
   }
 
   return (
-    <div
-      className={cn('flex w-[22.0625rem] max-w-full flex-col gap-2', className)}
-    >
+    <div className={cn('flex w-full flex-col gap-2', className)}>
       <textarea
         {...props}
         id={textareaId}

--- a/packages/hds-ui/src/components/textarea/Textarea.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.tsx
@@ -2,7 +2,7 @@ import {
   type ChangeEvent,
   type ComponentPropsWithRef,
   type InputEvent as ReactInputEvent,
-  useEffect,
+  useId,
   useState,
 } from 'react'
 import { cn } from '../../utils'
@@ -45,21 +45,34 @@ export const Textarea = ({
   disabled = false,
   onBeforeInput,
   onChange,
+  id,
+  'aria-describedby': ariaDescribedBy,
   ...props
 }: TextareaProps) => {
+  const generatedId = useId()
+  const textareaId = id ?? generatedId
+  const helperTextId = `${textareaId}-helper-text`
+  const counterId = `${textareaId}-counter`
+
+  const isControlled = value !== undefined
   const limitedValue = limitText(value, maxLength)
   const limitedDefaultValue = limitText(defaultValue, maxLength)
-  const [count, setCount] = useState(() =>
-    getTextLength(limitedValue ?? limitedDefaultValue),
+  const [uncontrolledValue, setUncontrolledValue] = useState(
+    () => limitedDefaultValue,
   )
+  const currentValue = isControlled ? limitedValue : uncontrolledValue
+  const count = getTextLength(currentValue)
   const shouldShowCounter = showCounter ?? maxLength !== undefined
-  const hasSupportRow = helperText || shouldShowCounter
+  const hasHelperText = helperText != null && helperText !== ''
+  const hasSupportRow = hasHelperText || shouldShowCounter
 
-  useEffect(() => {
-    if (limitedValue !== undefined) {
-      setCount(getTextLength(limitedValue))
-    }
-  }, [limitedValue])
+  const describedBy = [
+    ariaDescribedBy,
+    hasHelperText ? helperTextId : undefined,
+    shouldShowCounter ? counterId : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   const handleBeforeInput = (event: ReactInputEvent<HTMLTextAreaElement>) => {
     onBeforeInput?.(event)
@@ -91,7 +104,10 @@ export const Textarea = ({
       event.currentTarget.value = nextValue
     }
 
-    setCount(nextValue.length)
+    if (!isControlled) {
+      setUncontrolledValue(nextValue)
+    }
+
     onChange?.(event)
   }
 
@@ -101,8 +117,9 @@ export const Textarea = ({
     >
       <textarea
         {...props}
-        value={limitedValue}
-        defaultValue={limitedDefaultValue}
+        id={textareaId}
+        aria-describedby={describedBy || undefined}
+        value={isControlled ? limitedValue : uncontrolledValue}
         maxLength={maxLength}
         disabled={disabled}
         onBeforeInput={handleBeforeInput}
@@ -116,13 +133,22 @@ export const Textarea = ({
       />
       {hasSupportRow ? (
         <div className="typo-body-6 flex w-full items-center justify-between gap-3 font-sans leading-[1.36] whitespace-nowrap">
-          {helperText ? (
-            <p className="text-warm-gray-300 min-w-0 truncate">{helperText}</p>
+          {hasHelperText ? (
+            <p
+              id={helperTextId}
+              className="text-warm-gray-300 min-w-0 truncate"
+            >
+              {helperText}
+            </p>
           ) : (
             <span aria-hidden="true" />
           )}
           {shouldShowCounter ? (
-            <p aria-live="polite" className="flex shrink-0 items-end gap-[2px]">
+            <p
+              id={counterId}
+              aria-live="polite"
+              className="flex shrink-0 items-end gap-[2px]"
+            >
               <span className="text-primary-200">{count}</span>
               {maxLength !== undefined ? (
                 <span className="text-warm-gray-300">/{maxLength}</span>

--- a/packages/hds-ui/src/components/textarea/Textarea.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.tsx
@@ -1,0 +1,89 @@
+import {
+  type ChangeEvent,
+  type ComponentPropsWithRef,
+  useEffect,
+  useState,
+} from 'react'
+import { cn } from '../../utils'
+
+const getTextLength = (value: ComponentPropsWithRef<'textarea'>['value']) => {
+  if (value === undefined || value === null) {
+    return 0
+  }
+
+  return String(value).length
+}
+
+export interface TextareaProps extends Omit<
+  ComponentPropsWithRef<'textarea'>,
+  'children' | 'className'
+> {
+  helperText?: string
+  showCounter?: boolean
+  className?: string
+}
+
+export const Textarea = ({
+  helperText,
+  showCounter,
+  className,
+  value,
+  defaultValue,
+  maxLength,
+  disabled = false,
+  onChange,
+  ...props
+}: TextareaProps) => {
+  const [count, setCount] = useState(() => getTextLength(value ?? defaultValue))
+  const shouldShowCounter = showCounter ?? maxLength !== undefined
+  const hasSupportRow = helperText || shouldShowCounter
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setCount(getTextLength(value))
+    }
+  }, [value])
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setCount(event.currentTarget.value.length)
+    onChange?.(event)
+  }
+
+  return (
+    <div
+      className={cn('flex w-[22.0625rem] max-w-full flex-col gap-2', className)}
+    >
+      <textarea
+        {...props}
+        value={value}
+        defaultValue={defaultValue}
+        maxLength={maxLength}
+        disabled={disabled}
+        onChange={handleChange}
+        className={cn(
+          'border-warm-gray-100 min-h-[230px] w-full resize-none rounded-[10px] border bg-white p-5',
+          'typo-body-4 text-primary-200 placeholder:text-warm-gray-300 font-sans',
+          'focus-visible:border-cool-gray-500 focus-visible:outline-cool-gray-500 focus-visible:outline-2 focus-visible:outline-offset-0',
+          'disabled:bg-secondary-200 disabled:text-warm-gray-300 disabled:cursor-not-allowed',
+        )}
+      />
+      {hasSupportRow ? (
+        <div className="typo-body-6 flex w-full items-center justify-between gap-3 font-sans leading-[1.36] whitespace-nowrap">
+          {helperText ? (
+            <p className="text-warm-gray-300 min-w-0 truncate">{helperText}</p>
+          ) : (
+            <span aria-hidden="true" />
+          )}
+          {shouldShowCounter ? (
+            <p aria-live="polite" className="flex shrink-0 items-end gap-[2px]">
+              <span className="text-primary-200">{count}</span>
+              {maxLength !== undefined ? (
+                <span className="text-warm-gray-300">/{maxLength}</span>
+              ) : null}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/hds-ui/src/components/textarea/Textarea.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.tsx
@@ -1,6 +1,7 @@
 import {
   type ChangeEvent,
   type ComponentPropsWithRef,
+  type InputEvent as ReactInputEvent,
   useEffect,
   useState,
 } from 'react'
@@ -12,6 +13,17 @@ const getTextLength = (value: ComponentPropsWithRef<'textarea'>['value']) => {
   }
 
   return String(value).length
+}
+
+const limitText = (
+  value: ComponentPropsWithRef<'textarea'>['value'],
+  maxLength: ComponentPropsWithRef<'textarea'>['maxLength'],
+) => {
+  if (value === undefined || value === null || maxLength === undefined) {
+    return value
+  }
+
+  return String(value).slice(0, maxLength)
 }
 
 export interface TextareaProps extends Omit<
@@ -31,21 +43,55 @@ export const Textarea = ({
   defaultValue,
   maxLength,
   disabled = false,
+  onBeforeInput,
   onChange,
   ...props
 }: TextareaProps) => {
-  const [count, setCount] = useState(() => getTextLength(value ?? defaultValue))
+  const limitedValue = limitText(value, maxLength)
+  const limitedDefaultValue = limitText(defaultValue, maxLength)
+  const [count, setCount] = useState(() =>
+    getTextLength(limitedValue ?? limitedDefaultValue),
+  )
   const shouldShowCounter = showCounter ?? maxLength !== undefined
   const hasSupportRow = helperText || shouldShowCounter
 
   useEffect(() => {
-    if (value !== undefined) {
-      setCount(getTextLength(value))
+    if (limitedValue !== undefined) {
+      setCount(getTextLength(limitedValue))
     }
-  }, [value])
+  }, [limitedValue])
+
+  const handleBeforeInput = (event: ReactInputEvent<HTMLTextAreaElement>) => {
+    onBeforeInput?.(event)
+
+    if (event.defaultPrevented || maxLength === undefined) {
+      return
+    }
+
+    const textarea = event.currentTarget
+    const inputEvent = event.nativeEvent as globalThis.InputEvent
+    const selectedLength = textarea.selectionEnd - textarea.selectionStart
+
+    if (
+      selectedLength === 0 &&
+      textarea.value.length >= maxLength &&
+      inputEvent.data
+    ) {
+      event.preventDefault()
+    }
+  }
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setCount(event.currentTarget.value.length)
+    const nextValue =
+      maxLength === undefined
+        ? event.currentTarget.value
+        : event.currentTarget.value.slice(0, maxLength)
+
+    if (event.currentTarget.value !== nextValue) {
+      event.currentTarget.value = nextValue
+    }
+
+    setCount(nextValue.length)
     onChange?.(event)
   }
 
@@ -55,10 +101,11 @@ export const Textarea = ({
     >
       <textarea
         {...props}
-        value={value}
-        defaultValue={defaultValue}
+        value={limitedValue}
+        defaultValue={limitedDefaultValue}
         maxLength={maxLength}
         disabled={disabled}
+        onBeforeInput={handleBeforeInput}
         onChange={handleChange}
         className={cn(
           'border-warm-gray-100 min-h-[230px] w-full resize-none rounded-[10px] border bg-white p-5',

--- a/packages/hds-ui/src/components/textarea/index.ts
+++ b/packages/hds-ui/src/components/textarea/index.ts
@@ -1,0 +1,2 @@
+export { Textarea } from './Textarea'
+export type { TextareaProps } from './Textarea'


### PR DESCRIPTION
## 📌 Summary

HDS 공통 UI 패키지에 `Textarea` 컴포넌트를 구현했습니다.

Jira: HASHI-63

## 📚 Tasks

- Figma `input_textbox_review` 디자인을 기준으로 Textarea UI를 구현했습니다.
- `placeholder`, `helperText`, `maxLength`, `disabled`, `showCounter` 등 공통 컴포넌트용 props를 추가했습니다.
- 현재 글자 수는 props로 받지 않고 `value`, `defaultValue`, 사용자 입력값을 기준으로 내부에서 계산하도록 구현했습니다.
- `maxLength` 도달 이후에는 추가 입력이 반영되지 않도록 입력값을 제한했습니다.
- 리뷰/식당/후기 등 도메인 문구나 검증 정책은 컴포넌트 내부에 하드코딩하지 않았습니다.
- **모바일 앱 화면**에서 사용하는 폼 입력 컴포넌트라는 맥락을 고려해 고정 디자인 폭에 `max-width: 100%`를 적용하고, textarea는 resize 없이 내부 스크롤되는 구조로 구성했습니다.
- Storybook에 `Default`, `ReviewExample`, `Disabled` 3가지상황의 케이스를 추가했습니다.
- Textarea spec과 테스트를 추가하고 HDS public export를 정리했습니다.

## 👀 To Reviewer

- `Textarea`는 리뷰 작성 화면에서 사용될 예정이지만, HDS 공통 primitive로 유지하기 위해 도메인별 copy/검증/error 상태는 포함하지 않았습니다.
- 글자 수 제한은 native `maxLength`와 컴포넌트 내부 clamp를 함께 사용해 Storybook 환경에서도 초과 입력이 보이지 않도록 처리했습니다.
- 내부스크롤로 구현하였습니다.

## 📸 Screenshot

<img width="379" height="274" alt="스크린샷 2026-07-02 오전 5 14 22" src="https://github.com/user-attachments/assets/c1717892-1e4c-4b1f-b29a-a38abcaff0f8" />
<img width="286" height="156" alt="스크린샷 2026-07-02 오전 5 15 02" src="https://github.com/user-attachments/assets/b680f8d0-d1e3-418a-b7ee-6bd13bec614f" />
<img width="159" height="64" alt="image" src="https://github.com/user-attachments/assets/af510086-ca11-4567-ac22-805afcefe301" />
지금 코드의 min-h-[230px] 구현 완료.

