### PR TITLE
Chore(client): HASHI-93 Vite 빌드 청크 최적화 및 vendor chunk 분리

### DIFF
--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -5,6 +5,30 @@ import { alias, plugins as basePlugins } from './vite.shared'
 const release =
   process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA ?? 'local'
 
+const getManualChunk = (id: string) => {
+  if (!id.includes('node_modules')) {
+    return undefined
+  }
+
+  if (id.includes('/react/') || id.includes('/react-dom/')) {
+    return 'vendor-react'
+  }
+
+  if (id.includes('/react-router/') || id.includes('/react-router-dom/')) {
+    return 'vendor-router'
+  }
+
+  if (id.includes('/@sentry/')) {
+    return 'vendor-sentry'
+  }
+
+  if (id.includes('/@tanstack/')) {
+    return 'vendor-query'
+  }
+
+  return 'vendor'
+}
+
 export default defineConfig({
   define: {
     'import.meta.env.VITE_VERCEL_ENV': JSON.stringify(
@@ -14,6 +38,11 @@ export default defineConfig({
   },
   build: {
     sourcemap: process.env.SENTRY_AUTH_TOKEN ? 'hidden' : false,
+    rollupOptions: {
+      output: {
+        manualChunks: getManualChunk,
+      },
+    },
   },
   resolve: {
     alias,


### PR DESCRIPTION
## 📌 Summary

- Vite 빌드 시 발생하던 main index chunk 크기 경고를 개선하기 위해 vendor chunk 분리를 적용했습니다.

Jira: HASHI-93

## 📚 Tasks
- Vite build 시 발생하던 chunk size warning 원인 확인
- 빌드 결과에서 main index chunk 크기 확인
- sourcemap 기반으로 main chunk에 포함된 주요 의존성 확인
- apps/client/vite.config.ts에 manualChunks 설정 추가

- 주요 외부 라이브러리를 vendor chunk로 분리
1. react, react-dom → vendor-react
2. react-router, react-router-dom → vendor-router
3. @sentry/* → vendor-sentry
4. @tanstack/* → vendor-query
그 외 node_modules → vendor

빌드 결과 비교
Vite chunk size warning 해소 확인
typecheck, lint, build 검증 수행

## 🔎 Description

기존 빌드에서는 main index chunk가 Vite 기본 경고 기준인 500kB를 초과하고 있었습니다.
`index-*.js 653.17 kB │ gzip: 211.36 kB`

sourcemap 기반으로 확인했을 때, main chunk에는 React, React Router, Sentry, React Query 등 외부 라이브러리 코드가 함께 묶여 있었습니다.
이번 작업은 main index chunk에 몰려 있던 외부 라이브러리 코드를 vendor chunk로 분리해 빌드 경고를 해소하고, 앱 코드와 vendor 코드의 캐시 경계를 나누기 위한 작업입니다.

### Chunk / Vendor 기준
이번 작업에서 말하는 chunk는 빌드 후 생성되는 JavaScript 파일 조각입니다.
예를 들어 변경 전에는 앱 코드와 외부 라이브러리 코드가 main chunk에 크게 묶여 있었습니다.

```
index.js
= 앱 시작 코드 + React + React Router + Sentry + React Query + 기타 vendor 코드
```

vendor는 우리가 직접 작성한 앱 코드가 아니라 외부 라이브러리 코드를 의미합니다.
예를 들면 아래와 같습니다.
```
react
react-dom
react-router-dom
@tanstack/react-query
@sentry/react
```
이번 작업은 이 vendor 코드를 앱 코드와 분리해 별도 chunk로 나누는 작업입니다.

vendor 코드를 앱 코드와 분리해서 별도 chunk로 나누는 이유는 크게 캐싱 효율과 초기 로딩 최적화 때문입니다.
앱 코드는 우리가 기능을 추가하거나 수정할 때 자주 바뀌지만, `react, react-dom, react-router, @tanstack/react-query `같은 vendor 라이브러리는 상대적으로 자주 바뀌지 않습니다.
만약 앱 코드와 vendor 코드가 한 번들에 같이 묶여 있으면, 앱 코드 한 줄만 바뀌어도 전체 번들 해시가 바뀌어서 브라우저가 vendor 코드까지 다시 다운로드해야 합니다.
반대로 vendor chunk를 분리하면:
```
app chunk: 자주 바뀜
vendor chunk: 거의 안 바뀜
```
이렇게 나뉘기 때문에, 배포 후 앱 코드가 바뀌어도 사용자는 기존에 받아둔 vendor chunk를 브라우저 캐시에서 재사용할 수 있습니다.
결과적으로:
- 재방문 시 다운로드 용량 감소
- 초기/반복 로딩 속도 개선
- 앱 코드 변경 시 캐시 무효화 범위 축소
- 번들 구조 파악과 성능 분석이 쉬워짐
이런 장점이 있습니다.

### Implementation

`apps/client/vite.config.ts`에 manualChunks 함수를 추가했습니다.
`node_modules `내부 모듈을 기준으로 주요 vendor를 아래처럼 분리했습니다.

```
react / react-dom
→ vendor-react

react-router / react-router-dom
→ vendor-router

@sentry/*
→ vendor-sentry

@tanstack/*
→ vendor-query

그 외 node_modules
→ vendor
```

변경 후 빌드 결과:
```
index-*.js          111.03 kB │ gzip: 35.93 kB
vendor-react-*.js   278.32 kB │ gzip: 89.31 kB
vendor-*.js         130.92 kB │ gzip: 41.39 kB
vendor-router-*.js   95.96 kB │ gzip: 31.78 kB
vendor-sentry-*.js   42.87 kB │ gzip: 15.04 kB
vendor-query-*.js    33.82 kB │ gzip: 10.21 kB
```
main index chunk가 653kB에서 111kB로 줄었고, Vite chunk size warning도 해소되었습니다.

### 전체 용량은 안줄었는데, 뭐가 좋은 건가? 

이번 작업은 전체 JavaScript 총량을 크게 줄이는 변경은 아닙니다.
변경 전에는 큰 파일 하나에 묶여 있던 코드가, 변경 후에는 여러 vendor chunk로 분리됩니다.

따라서 첫 방문 시 전체 다운로드 총량이 크게 줄어드는 작업은 아닙니다.
첫 방문 사용자는 앱 실행에 필요한 vendor chunk를 함께 받아야 할 수 있습니다.

다만 다음과 같은 장점이 있습니다.

#### main index chunk 크기 감소
앱 코드가 들어있는 main index chunk가 작아졌습니다.
`653.17 kB → 111.03 kB`
큰 chunk 하나에 모든 코드가 몰려 있던 구조를 피할 수 있습니다.
#### 캐시 효율 개선
React, Router, Sentry 같은 vendor 코드는 앱 코드보다 변경 빈도가 낮습니다.
앱 코드만 수정되는 배포에서는 index chunk만 바뀌고, vendor chunk는 브라우저 캐시를 재사용할 가능성이 커집니다.
#### 재다운로드 범위 축소
기존에는 앱 코드 일부만 바뀌어도 큰 index chunk 전체 hash가 바뀔 수 있었습니다.
vendor 분리 후에는 앱 코드 변경과 외부 라이브러리 변경의 캐시 경계가 분리됩니다.
#### 빌드 경고 해소
Vite의 500kB chunk warning이 해소되어 이후 실제 번들 증가 문제가 발생했을 때 더 잘 감지할 수 있습니다.
#### 번들 구조 가시성 개선
기존에는 index chunk 하나가 커서 원인을 파악하기 어려웠습니다.
분리 후에는 vendor-react, vendor-router, vendor-sentry, vendor-query처럼 어떤 영역이 어느 정도 크기인지 더 쉽게 확인할 수 있습니다.
#### Scope
**이번 작업은 chunk splitting 최적화입니다.**
다음 목표는 

- main chunk 크기 감소
- vendor 캐시 경계 분리
- Vite chunk size warning 해소
- 빌드 산출물 구조 개선


**반대로 이번 작업의 목표가 아닌 것은 다음과 같습니다.**

- 전체 JS 총량 자체 감소
- 첫 방문 다운로드 총량의 극적인 감소
- Sentry 지연 로딩
- HDS / React Aria import 최적화
전체 번들 총량을 실제로 줄이려면 후속으로 아래 작업을 검토할 수 있습니다.
- Sentry 초기 로딩 영향 축소 또는 지연 로딩
- 초기 화면에서 사용하지 않는 HDS / React Aria 의존성 분리
- HDS barrel import 및 tree-shaking 확인
- 아이콘 import 최적화
- 실제 bundle analyzer 기반 세부 분석

## 👀 To Reviewer

이번 작업은 기능/UI 변경 없이 Vite 빌드 산출물의 chunk 분리 기준만 조정한 작업입니다.
첫 방문 시 전체 다운로드 총량을 크게 줄이는 작업은 아니며, main chunk 크기 감소, Vite warning 해소, vendor 캐시 효율 개선을 목적으로 합니다.
실제 JS 총량 감소가 필요하다면 Sentry 지연 로딩, HDS/React Aria import 최적화, 초기 화면 의존성 분리 등을 후속 작업으로 검토하면 좋겠습니다.


## 📸 Screenshot

### 개선 전 

<img width="575" height="249" alt="스크린샷 2026-07-09 오후 9 25 45" src="https://github.com/user-attachments/assets/6cd1b386-0b19-45fa-9297-c421cbafc7cb" />

### 개선 후 

<img width="569" height="218" alt="image" src="https://github.com/user-attachments/assets/73482388-10a8-4b2f-8833-24e6a60e0c2d" />
