### PR TITLE
Feat(client): HASHI-100 라우트 로딩 플리커링 개선

### DIFF
--- a/apps/client/src/app/router/lazy.test.tsx
+++ b/apps/client/src/app/router/lazy.test.tsx
@@ -1,26 +1,65 @@
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { appRoutes } from '@/app/router/routes'
 
-vi.mock('@/pages/loginRequired', () => new Promise(() => {}))
+vi.mock(
+  '@/pages/loginRequired',
+  () =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          default: () => <main>로그인 필요 페이지</main>,
+        })
+      }, 200)
+    }),
+)
 
 describe('route lazy fallback', () => {
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
   })
 
-  it('renders LoadingScreen without bottom navigation for a configured lazy route while its module is pending', () => {
+  it('delays LoadingScreen and keeps it visible for the minimum duration when a lazy route is pending', async () => {
+    vi.useFakeTimers()
+
     const router = createMemoryRouter(appRoutes, {
       initialEntries: ['/login-required'],
     })
 
     render(<RouterProvider router={router} />)
 
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(149)
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
     expect(screen.getByRole('status')).toHaveTextContent('로딩 중이에요')
     expect(screen.queryByText('홈')).not.toBeInTheDocument()
     expect(screen.queryByText('마이')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299)
+    })
+
+    expect(screen.getByRole('status')).toHaveTextContent('로딩 중이에요')
+    expect(screen.queryByText('로그인 필요 페이지')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
+    expect(screen.getByText('로그인 필요 페이지')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 })

--- a/apps/client/src/app/router/lazy.test.tsx
+++ b/apps/client/src/app/router/lazy.test.tsx
@@ -5,6 +5,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { appRoutes } from '@/app/router/routes'
 
+let isAuthenticated = false
+
+vi.mock('@/shared/hooks/useAuthStatus', () => ({
+  useAuthStatus: () => ({
+    isAuthenticated,
+    status: isAuthenticated ? 'authenticated' : 'unauthenticated',
+  }),
+}))
+
+vi.mock('@/pages/mypage', () => ({
+  default: () => <main>마이페이지 화면</main>,
+}))
+
 vi.mock(
   '@/pages/loginRequired',
   () =>
@@ -17,10 +30,23 @@ vi.mock(
     }),
 )
 
+vi.mock(
+  '@/pages/myReviews',
+  () =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          default: () => <main>마이 리뷰</main>,
+        })
+      }, 200)
+    }),
+)
+
 describe('route lazy fallback', () => {
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+    isAuthenticated = false
   })
 
   it('delays LoadingScreen and keeps it visible for the minimum duration when a lazy route is pending', async () => {
@@ -61,5 +87,52 @@ describe('route lazy fallback', () => {
 
     expect(screen.getByText('로그인 필요 페이지')).toBeInTheDocument()
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('renders the next page as soon as the chunk resolves when the fallback is not shown during an AuthOnly boundary navigation', async () => {
+    vi.useFakeTimers()
+    isAuthenticated = true
+
+    const router = createMemoryRouter(appRoutes, {
+      initialEntries: ['/mypage'],
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(screen.getByText('마이페이지 화면')).toBeInTheDocument()
+    expect(screen.getByText('마이')).toBeInTheDocument()
+
+    await act(async () => {
+      await router.navigate('/my-reviews')
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByText('마이페이지 화면')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(199)
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByText('마이 리뷰')).not.toBeInTheDocument()
+    expect(screen.getByText('마이페이지 화면')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+
+    expect(screen.getByText('마이 리뷰')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByText('마이페이지 화면')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+
+    expect(screen.getByText('마이 리뷰')).toBeInTheDocument()
   })
 })

--- a/apps/client/src/app/router/lazy.ts
+++ b/apps/client/src/app/router/lazy.ts
@@ -1,36 +1,102 @@
-import { createElement, lazy, Suspense, type ReactNode } from 'react'
+import {
+  createElement,
+  lazy,
+  Suspense,
+  type ComponentType,
+  type ReactNode,
+  useEffect,
+  useState,
+} from 'react'
 
 import { LoadingScreen } from '@/shared/components/loadingScreen'
 
-const SearchPage = lazy(() => import('@/pages/search'))
-const ComingSoonPage = lazy(() => import('@/pages/comingSoon'))
-const TodayRestaurantPage = lazy(() => import('@/pages/todayRestaurant'))
-const RestaurantDetailPage = lazy(() => import('@/pages/restaurantDetail'))
-const RestaurantMenuDetailPage = lazy(
+const ROUTE_LOADING_DELAY_MS = 150
+const ROUTE_LOADING_MIN_VISIBLE_MS = 300
+
+type LazyRouteModule = {
+  default: ComponentType
+}
+
+const wait = (ms: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+const applyRouteLoadingTiming = async <T extends LazyRouteModule>(
+  modulePromise: Promise<T>,
+) => {
+  const startedAt = Date.now()
+  const module = await modulePromise
+  const elapsedMs = Date.now() - startedAt
+  const minimumPendingMs = ROUTE_LOADING_DELAY_MS + ROUTE_LOADING_MIN_VISIBLE_MS
+
+  if (elapsedMs >= ROUTE_LOADING_DELAY_MS && elapsedMs < minimumPendingMs) {
+    await wait(minimumPendingMs - elapsedMs)
+  }
+
+  return module
+}
+
+const lazyRoute = <T extends LazyRouteModule>(importPage: () => Promise<T>) => {
+  return lazy(() => applyRouteLoadingTiming(importPage()))
+}
+
+const RouteLoadingFallback = () => {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setIsVisible(true)
+    }, ROUTE_LOADING_DELAY_MS)
+
+    return () => {
+      clearTimeout(timerId)
+    }
+  }, [])
+
+  if (!isVisible) {
+    return null
+  }
+
+  return createElement(LoadingScreen)
+}
+
+const SearchPage = lazyRoute(() => import('@/pages/search'))
+const ComingSoonPage = lazyRoute(() => import('@/pages/comingSoon'))
+const TodayRestaurantPage = lazyRoute(() => import('@/pages/todayRestaurant'))
+const RestaurantDetailPage = lazyRoute(() => import('@/pages/restaurantDetail'))
+const RestaurantMenuDetailPage = lazyRoute(
   () => import('@/pages/restaurantMenuDetail'),
 )
-const HashiPickPage = lazy(() => import('@/pages/hashiPick'))
-const PopularRestaurantsPage = lazy(() => import('@/pages/popularRestaurants'))
-const MagazinesPage = lazy(() => import('@/pages/magazines'))
-const MagazineDetailPage = lazy(() => import('@/pages/magazineDetail'))
-const ReviewNewPage = lazy(() => import('@/pages/reviewNew'))
-const MyReviewsPage = lazy(() => import('@/pages/myReviews'))
-const ReviewDetailPage = lazy(() => import('@/pages/reviewDetail'))
-const ReviewEditPage = lazy(() => import('@/pages/reviewEdit'))
-const MypagePage = lazy(() => import('@/pages/mypage'))
-const ProfileNewPage = lazy(() => import('@/pages/profileNew'))
-const WithdrawalPage = lazy(() => import('@/pages/withdrawal'))
-const RestaurantReservationNewPage = lazy(
+const HashiPickPage = lazyRoute(() => import('@/pages/hashiPick'))
+const PopularRestaurantsPage = lazyRoute(
+  () => import('@/pages/popularRestaurants'),
+)
+const MagazinesPage = lazyRoute(() => import('@/pages/magazines'))
+const MagazineDetailPage = lazyRoute(() => import('@/pages/magazineDetail'))
+const ReviewNewPage = lazyRoute(() => import('@/pages/reviewNew'))
+const MyReviewsPage = lazyRoute(() => import('@/pages/myReviews'))
+const ReviewDetailPage = lazyRoute(() => import('@/pages/reviewDetail'))
+const ReviewEditPage = lazyRoute(() => import('@/pages/reviewEdit'))
+const MypagePage = lazyRoute(() => import('@/pages/mypage'))
+const ProfileNewPage = lazyRoute(() => import('@/pages/profileNew'))
+const WithdrawalPage = lazyRoute(() => import('@/pages/withdrawal'))
+const RestaurantReservationNewPage = lazyRoute(
   () => import('@/pages/restaurantReservationNew'),
 )
-const AnywhereReservationPage = lazy(
+const AnywhereReservationPage = lazyRoute(
   () => import('@/pages/anywhereReservation'),
 )
-const ReservationRequestPage = lazy(() => import('@/pages/reservationRequest'))
-const MyReservationsPage = lazy(() => import('@/pages/myReservations'))
-const ReservationDetailPage = lazy(() => import('@/pages/reservationDetail'))
-const LoginRequiredPage = lazy(() => import('@/pages/loginRequired'))
-const NotFoundPage = lazy(() => import('@/pages/notFound'))
+const ReservationRequestPage = lazyRoute(
+  () => import('@/pages/reservationRequest'),
+)
+const MyReservationsPage = lazyRoute(() => import('@/pages/myReservations'))
+const ReservationDetailPage = lazyRoute(
+  () => import('@/pages/reservationDetail'),
+)
+const LoginRequiredPage = lazyRoute(() => import('@/pages/loginRequired'))
+const NotFoundPage = lazyRoute(() => import('@/pages/notFound'))
 
 const lazyPage = (Page: ReturnType<typeof lazy>) => {
   return createElement(Page)
@@ -39,7 +105,7 @@ const lazyPage = (Page: ReturnType<typeof lazy>) => {
 export const withLazyFallback = (element: ReactNode) => {
   return createElement(
     Suspense,
-    { fallback: createElement(LoadingScreen) },
+    { fallback: createElement(RouteLoadingFallback) },
     element,
   )
 }

--- a/apps/client/src/app/router/lazy.ts
+++ b/apps/client/src/app/router/lazy.ts
@@ -7,6 +7,7 @@ import {
   useEffect,
   useState,
 } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { LoadingScreen } from '@/shared/components/loadingScreen'
 
@@ -15,6 +16,16 @@ const ROUTE_LOADING_MIN_VISIBLE_MS = 300
 
 type LazyRouteModule = {
   default: ComponentType
+}
+
+let wasRouteLoadingFallbackShown = false
+
+const resetRouteLoadingFallbackShown = () => {
+  wasRouteLoadingFallbackShown = false
+}
+
+const markRouteLoadingFallbackShown = () => {
+  wasRouteLoadingFallbackShown = true
 }
 
 const wait = (ms: number) => {
@@ -31,7 +42,11 @@ const applyRouteLoadingTiming = async <T extends LazyRouteModule>(
   const elapsedMs = Date.now() - startedAt
   const minimumPendingMs = ROUTE_LOADING_DELAY_MS + ROUTE_LOADING_MIN_VISIBLE_MS
 
-  if (elapsedMs >= ROUTE_LOADING_DELAY_MS && elapsedMs < minimumPendingMs) {
+  if (
+    wasRouteLoadingFallbackShown &&
+    elapsedMs >= ROUTE_LOADING_DELAY_MS &&
+    elapsedMs < minimumPendingMs
+  ) {
     await wait(minimumPendingMs - elapsedMs)
   }
 
@@ -46,7 +61,10 @@ const RouteLoadingFallback = () => {
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
+    resetRouteLoadingFallbackShown()
+
     const timerId = setTimeout(() => {
+      markRouteLoadingFallbackShown()
       setIsVisible(true)
     }, ROUTE_LOADING_DELAY_MS)
 
@@ -60,6 +78,20 @@ const RouteLoadingFallback = () => {
   }
 
   return createElement(LoadingScreen)
+}
+
+const RouteLoadingBoundary = ({ children }: { children: ReactNode }) => {
+  const location = useLocation()
+
+  useEffect(() => {
+    resetRouteLoadingFallbackShown()
+  }, [location.key])
+
+  return createElement(
+    Suspense,
+    { fallback: createElement(RouteLoadingFallback) },
+    children,
+  )
 }
 
 const SearchPage = lazyRoute(() => import('@/pages/search'))
@@ -103,11 +135,7 @@ const lazyPage = (Page: ReturnType<typeof lazy>) => {
 }
 
 export const withLazyFallback = (element: ReactNode) => {
-  return createElement(
-    Suspense,
-    { fallback: createElement(RouteLoadingFallback) },
-    element,
-  )
+  return createElement(RouteLoadingBoundary, null, element)
 }
 
 export const lazyPages = {


### PR DESCRIPTION
## 📌 Summary

라우트 lazy loading 시 `LoadingScreen`이 너무 짧게 노출되며 깜빡이는 loading flicker 현상을 완화했습니다.

Jira: HASHI-100

## 📚 Tasks

- 라우트 lazy loading fallback 표시 정책을 추가했습니다.
- lazy route fallback이 즉시 노출되지 않도록 `150ms` 지연 후 표시되게 변경했습니다.
- fallback이 한 번 노출된 경우 최소 `300ms` 동안 유지되도록 처리했습니다.
- 기존 `LoadingScreen` UI 컴포넌트는 그대로 유지하고, 라우터 fallback 정책만 `app/router/lazy.ts`에서 관리하도록 분리했습니다.
- 라우트 lazy fallback 동작 테스트를 갱신했습니다.

## 🔎 Description

QA를 진행하면서 로딩화면이 폴백된 적이 있었는데, 해당 부분의 로딩 ms가 짧아서 플리커 현상이 발생했습니다. 
원인은 `Suspense fallback`에 `LoadingScreen`을 바로 연결하고 있어서인데, route chunk loading이 아주 짧게 발생해도 전체 화면 로딩이 순간적으로 나타났다가 사라질 수 있었습니다.

이번 작업에서는 `LoadingScreen` 자체에 delay 로직을 넣지 않고, 라우터의 lazy loading 정책으로 분리했습니다.

- `LoadingScreen`
  - 로딩 화면 UI만 담당합니다.
  - delay/min visible 정책을 알지 않습니다.

- `RouteLoadingFallback`
  - `Suspense fallback`으로 사용됩니다.
  - lazy route가 suspend되더라도 최초 `150ms` 동안은 아무것도 렌더링하지 않습니다.
  - `150ms`가 지나도 route chunk가 pending 상태이면 `LoadingScreen`을 렌더링합니다.

- `lazyRoute`
  - 기존 `React.lazy`를 감싼 route 전용 helper입니다.
  - lazy import가 `150ms` 이후 resolve된 경우, fallback이 너무 빨리 사라지지 않도록 최소 노출 시간까지 promise resolve를 지연합니다. 예를 들어 `150ms` 이후 `160ms`에 로딩된다면 결국엔 플리커 현상이 반복되기 때문에 최소 노출 시간을 보장했습니다.
  - 현재 기준은 `150ms delay + 300ms min visible = 450ms`입니다.

테스트에서는 `/login-required` lazy route를 기준으로 다음 흐름을 검증했습니다.

- `149ms` 전에는 loading status가 노출되지 않음
- `150ms` 이후 `LoadingScreen`이 노출됨
- 한 번 노출된 뒤 `300ms` 동안 유지됨
- 최소 노출 시간이 지난 뒤 lazy page가 렌더링됨
- fallback 상태에서도 Bottom Navigation은 노출되지 않음

## 👀 To Reviewer

`LoadingScreen` 컴포넌트 자체에는 delay 로직을 넣지 않았습니다.  
로딩 UI와 노출 정책을 분리하기 위해, 라우트 lazy loading에 한정된 정책은 `app/router/lazy.ts`에서 관리하도록 구현했습니다.

현재 기준값은 아래와 같습니다.

- fallback 표시 지연: `150ms`
- fallback 최소 노출 시간: `300ms`

실제 사용 중 로딩 화면이 너무 늦게 뜨거나 오래 남는 느낌이 있다면, 두 값만 조정하면 됩니다.
<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
