### PR TITLE
Fix(client): HASHI-94 홈 및 검색 페이지 QA 반영

### DIFF
--- a/apps/client/src/pages/home/HomePage.spec.md
+++ b/apps/client/src/pages/home/HomePage.spec.md
@@ -107,22 +107,23 @@ export const HomeLogo = () => {
 
 ## Requirements
 
-- [ ] 상단 상태바 영역 아래에 Hashi 로고를 노출합니다.
-- [ ] 검색 진입 영역을 노출하고, 탭 또는 클릭 시 `ROUTES.search`로 이동합니다.
-- [ ] 메인 배너 섹션 타이틀 `맛집 큐레이션을 둘러보세요!`를 노출합니다.
-- [ ] 메인 배너는 여러 장 carousel로 노출합니다.
+- [x] 상단 상태바 영역 아래에 Hashi 로고를 노출합니다.
+- [x] 검색 진입 영역을 노출하고, 탭 또는 클릭 시 `ROUTES.search`로 이동합니다.
+- [x] Hashi 로고와 검색 진입 영역, 검색바 아래 여백은 홈 본문 스크롤과 무관하게 상단에 고정합니다.
+- [x] 메인 배너 섹션 타이틀 `맛집 큐레이션을 둘러보세요!`를 노출합니다.
+- [x] 메인 배너는 여러 장 carousel로 노출합니다.
 - [ ] 메인 배너 데이터는 최종적으로 서버에서 받은 이미지와 인스타그램 이동 대상 정보로 구성합니다.
-- [ ] 퀵 버튼 4개를 노출합니다.
+- [x] 퀵 버튼 4개를 노출합니다.
   - 하시 PICK: `ROUTES.hashiPickRestaurants`
   - 인기 맛집: `ROUTES.popularRestaurants`
   - 매거진: `ROUTES.magazines`
   - 오늘의 식당: `ROUTES.todayRestaurant`
-- [ ] 어디든 예약 CTA를 노출하고, `예약하기` 버튼 클릭 시에만 `ROUTES.anywhereReservation`으로 이동합니다.
-- [ ] `SNS에서 핫한 일본 식당` 섹션을 노출합니다.
-- [ ] SNS 기반 맛집 콘텐츠는 이미지, 식당명, 한 줄 요약을 리스트 형태로 보여주고, 항목 클릭 시 식당 상세 화면으로 이동합니다.
-- [ ] 하단 네비게이션은 홈, 저장, 지도, 내 예약, 마이 탭을 제공합니다.
-- [ ] 저장과 지도는 MVP 범위에서 준비중/임시 화면일 수 있으며, 홈 페이지 내부에서는 별도 구현하지 않습니다.
-- [ ] 이미지나 API 데이터가 아직 없을 때 최종 구현처럼 보이는 임시 체크보드 placeholder를 남기지 않습니다.
+- [x] 어디든 예약 CTA를 노출하고, `예약하기` 버튼 클릭 시에만 `ROUTES.anywhereReservation`으로 이동합니다.
+- [x] `SNS에서 핫한 일본 식당` 섹션을 노출합니다.
+- [x] SNS 기반 맛집 콘텐츠는 이미지, 식당명, 한 줄 요약을 리스트 형태로 보여주고, 항목 클릭 시 식당 상세 화면으로 이동합니다.
+- [x] 하단 네비게이션은 홈, 저장, 지도, 내 예약, 마이 탭을 제공합니다.
+- [x] 저장과 지도는 MVP 범위에서 준비중/임시 화면일 수 있으며, 홈 페이지 내부에서는 별도 구현하지 않습니다.
+- [x] 이미지나 API 데이터가 아직 없을 때 최종 구현처럼 보이는 임시 체크보드 placeholder를 남기지 않습니다.
 
 ## Data Dependencies
 
@@ -453,6 +454,9 @@ BottomNavigationLayout
   - 최소 320px 폭에서도 검색 placeholder, CTA 문구, 버튼 텍스트가 겹치지 않아야 합니다.
   - `--app-mobile-max-width: 430px` 안에서 자연스럽게 확장됩니다.
 - fixed area:
+  - Hashi 로고와 검색 진입 영역은 `app-mobile-fixed-top z-fixed bg-white` wrapper 안에서 고정합니다.
+  - 검색바 아래 `16px` 여백까지 fixed wrapper에 포함해 스크롤 콘텐츠가 검색바 바로 아래로 비치지 않게 합니다.
+  - 고정 상단 영역이 본문을 덮지 않도록 본문은 상단 영역 높이만큼 padding을 확보합니다.
   - 하단 네비게이션은 `BottomNavigationLayout`의 `app-mobile-fixed-bottom`이 담당합니다.
 - scroll area:
   - 홈 본문만 세로 스크롤됩니다.
@@ -501,12 +505,12 @@ BottomNavigationLayout
 
 ## Verification
 
-- [ ] `corepack pnpm --filter @hashi/client lint`
-- [ ] `corepack pnpm --filter @hashi/client typecheck`
-- [ ] `corepack pnpm --filter @hashi/client build`
+- [x] `corepack pnpm --filter @hashi/client lint`
+- [x] `corepack pnpm --filter @hashi/client typecheck`
+- [x] `corepack pnpm --filter @hashi/client build`
 - [ ] `corepack pnpm --filter @hashi/client test`
-- [ ] `corepack pnpm format:check`
-- [ ] `git diff --check`
+- [x] `corepack pnpm format:check`
+- [x] `git diff --check`
 - [ ] `/` 직접 진입 확인
 - [ ] 비로그인 상태에서 브라우저 세션 첫 홈 진입 시 `AuthGateBottomSheet` 표시 확인
 - [ ] 같은 브라우저 세션에서 새로고침 또는 재진입 시 `AuthGateBottomSheet` 반복 미표시 확인

--- a/apps/client/src/pages/home/HomePage.test.tsx
+++ b/apps/client/src/pages/home/HomePage.test.tsx
@@ -38,6 +38,12 @@ describe('HomePage', () => {
     expect(
       screen.getByRole('link', { name: '식당 또는 메뉴 검색하기' }),
     ).toHaveAttribute('href', ROUTES.search)
+    expect(screen.getByRole('banner', { name: '홈 상단 영역' })).toHaveClass(
+      'app-mobile-fixed-top',
+      'z-fixed',
+      'bg-white',
+      'pb-4',
+    )
     expect(
       screen.getByRole('region', { name: '맛집 큐레이션 배너' }),
     ).toBeInTheDocument()

--- a/apps/client/src/pages/home/HomePage.tsx
+++ b/apps/client/src/pages/home/HomePage.tsx
@@ -20,10 +20,15 @@ export const HomePage = () => {
 
   return (
     <>
-      <div className="px-5 pt-[18px] pb-8">
+      <div className="px-5 pt-[100px] pb-8">
         <h1 className="sr-only">Hashi 홈</h1>
-        <HomeLogo />
-        <HomeSearchEntry to={searchPath} />
+        <header
+          aria-label="홈 상단 영역"
+          className="app-mobile-fixed-top z-fixed bg-white px-5 pt-[18px] pb-4"
+        >
+          <HomeLogo />
+          <HomeSearchEntry to={searchPath} />
+        </header>
         <HomeCurationSection banners={homeBanners} />
         <HomeQuickMenuSection quickLinks={quickLinks} />
         <AnywhereReservationCta

--- a/apps/client/src/pages/search/SearchPage.spec.md
+++ b/apps/client/src/pages/search/SearchPage.spec.md
@@ -61,34 +61,37 @@
 
 ## Requirements
 
-- [ ] 상단 영역은 페이지 내 스크롤과 무관하게 고정합니다.
-- [ ] 상단 영역은 뒤로가기 버튼과 검색창을 같은 행에 배치합니다.
-- [ ] 뒤로가기 버튼을 누르면 이전 화면으로 돌아갑니다.
-- [ ] 검색창 placeholder는 `식당 혹은 메뉴를 검색해보세요`를 사용합니다.
-- [ ] 홈 검색 CTA에서 진입하면 검색창에 자동 focus를 주어 키보드가 노출됩니다.
-- [ ] `/search` 직접 진입 시에도 검색창에 focus를 줄 수 있지만, 브라우저/OS 정책으로 자동 키보드 노출이 제한될 수 있음을 허용합니다.
-- [ ] 검색 전에는 식당 리스트와 필터 바 대신 최근 검색어와 추천 검색어 영역을 보여줍니다.
-- [ ] 최근 검색어가 있으면 최근 검색어 영역은 사용자가 최근에 검색한 키워드를 보여줍니다.
-- [ ] 최근 검색어를 탭하면 해당 키워드를 검색어로 채우고 검색 결과 상태로 전환합니다.
-- [ ] 추천 검색어 영역은 운영팀이 지정한 키워드 또는 제품이 제공하는 추천 키워드를 보여줍니다.
-- [ ] 추천 검색어를 탭하면 해당 키워드를 검색어로 채우고 검색 결과 상태로 전환합니다.
-- [ ] 검색창 Enter 또는 검색 제출 시 현재 검색어, 정렬값, 음식 장르값 기준으로 결과를 조회합니다.
-- [ ] 검색 제출에 성공하면 trim 처리한 검색어를 최근 검색어 목록에 저장합니다.
-- [ ] 정렬 필터 trigger는 현재 적용된 정렬 label을 보여줍니다.
-- [ ] 정렬 필터 기본값은 `기본순`입니다.
-- [ ] 음식 장르 필터 trigger는 현재 적용된 음식 장르 label을 보여줍니다.
-- [ ] 음식 장르 필터 기본값은 `전체`이며, 기본 상태에서는 trigger label을 `음식 장르 선택`으로 보여줍니다.
-- [ ] 필터 trigger 클릭 시 해당 바텀시트를 엽니다.
-- [ ] 바텀시트에서 옵션을 선택해도 즉시 결과에 반영하지 않고, `적용` 버튼 클릭 시에만 적용합니다.
-- [ ] 바텀시트의 `초기화` 버튼은 해당 필터를 기본값으로 적용하고 바텀시트를 닫습니다.
-- [ ] 화면에 노출되는 닫기 컨트롤은 바텀시트의 `X` 버튼입니다.
-- [ ] HDS `BottomSheet`의 기본 접근성 계약에 따라 overlay click과 Escape key 닫기는 허용합니다.
-- [ ] 식당 리스트에는 식당 사진, 식당명, 별점, 음식 종류 태그, 당일 영업시간을 보여줍니다.
-- [ ] 검색 결과가 없으면 결과 리스트 대신 empty state를 보여줍니다.
-- [ ] empty state에서도 검색어와 적용된 필터값은 유지합니다.
-- [ ] 좁은 viewport에서 긴 식당명은 최대 2줄까지 보여주고 카드 레이아웃을 깨지 않습니다.
-- [ ] 모든 버튼성 요소는 `button` 또는 접근 가능한 interactive element로 구현합니다.
-- [ ] 텍스트 없는 아이콘 버튼에는 `aria-label`을 제공합니다.
+- [x] 상단 영역은 페이지 내 스크롤과 무관하게 고정합니다.
+- [x] 상단 영역은 뒤로가기 버튼과 검색창을 같은 행에 배치합니다.
+- [x] 검색 결과 상태에서는 정렬/음식 장르 필터 바까지 상단 고정 영역에 포함합니다.
+- [x] 뒤로가기 버튼은 24px 아이콘을 유지하고 44px 터치 영역을 제공합니다.
+- [x] 뒤로가기 버튼을 누르면 이전 화면으로 돌아갑니다.
+- [x] 검색창 placeholder는 `식당 혹은 메뉴를 검색해보세요`를 사용합니다.
+- [x] 홈 검색 CTA에서 진입하면 검색창에 자동 focus를 주어 키보드가 노출됩니다.
+- [x] `/search` 직접 진입 시에도 검색창에 focus를 줄 수 있지만, 브라우저/OS 정책으로 자동 키보드 노출이 제한될 수 있음을 허용합니다.
+- [x] 검색 전에는 식당 리스트와 필터 바 대신 최근 검색어와 추천 검색어 영역을 보여줍니다.
+- [x] 최근 검색어가 있으면 최근 검색어 영역은 사용자가 최근에 검색한 키워드를 보여줍니다.
+- [x] 최근 검색어를 탭하면 해당 키워드를 검색어로 채우고 검색 결과 상태로 전환합니다.
+- [x] 추천 검색어 영역은 운영팀이 지정한 키워드 또는 제품이 제공하는 추천 키워드를 보여줍니다.
+- [x] 추천 검색어를 탭하면 해당 키워드를 검색어로 채우고 검색 결과 상태로 전환합니다.
+- [x] 검색창 Enter 또는 검색 제출 시 현재 검색어, 정렬값, 음식 장르값 기준으로 결과를 조회합니다.
+- [x] 검색 제출에 성공하면 trim 처리한 검색어를 최근 검색어 목록에 저장합니다.
+- [x] 정렬 필터 trigger는 현재 적용된 정렬 label을 보여줍니다.
+- [x] 정렬 필터 기본값은 `기본순`입니다.
+- [x] 음식 장르 필터 trigger는 현재 적용된 음식 장르 label을 보여줍니다.
+- [x] 음식 장르 필터 기본값은 `전체`이며, 기본 상태에서는 trigger label을 `음식 장르 선택`으로 보여줍니다.
+- [x] 필터 trigger 클릭 시 해당 바텀시트를 엽니다.
+- [x] 바텀시트에서 옵션을 선택해도 즉시 결과에 반영하지 않고, `적용` 버튼 클릭 시에만 적용합니다.
+- [x] 바텀시트의 `초기화` 버튼은 해당 필터를 기본값으로 적용하고 바텀시트를 닫습니다.
+- [x] 화면에 노출되는 닫기 컨트롤은 바텀시트의 `X` 버튼입니다.
+- [x] HDS `BottomSheet`의 기본 접근성 계약에 따라 overlay click과 Escape key 닫기는 허용합니다.
+- [x] 식당 리스트에는 식당 사진, 식당명, 별점, 음식 종류 태그, 당일 영업시간을 보여줍니다.
+- [x] 식당 이미지가 없으면 임시 placeholder 대신 공통 `DefaultImage` fallback을 사용합니다.
+- [x] 검색 결과가 없으면 결과 리스트 대신 empty state를 보여줍니다.
+- [x] empty state에서도 검색어와 적용된 필터값은 유지합니다.
+- [x] 좁은 viewport에서 긴 식당명은 최대 2줄까지 보여주고 카드 레이아웃을 깨지 않습니다.
+- [x] 모든 버튼성 요소는 `button` 또는 접근 가능한 interactive element로 구현합니다.
+- [x] 텍스트 없는 아이콘 버튼에는 `aria-label`을 제공합니다.
 
 ## Data Dependencies
 
@@ -279,7 +282,7 @@ SearchPage
 ## Reuse Audit
 
 - `SearchField`를 사용합니다. 검색 실행, 최근 검색어, 추천 검색어, query 동기화는 HDS 범위가 아니므로 page가 소유합니다.
-- `IconButton size="xs"`와 `BackIcon`을 조합해 뒤로가기 버튼을 구현합니다.
+- `IconButton size="xs"`와 `BackIcon`을 조합해 뒤로가기 버튼을 구현합니다. 호출부에서 `44px` 터치 영역을 확보하고 아이콘은 `24px`로 유지합니다.
 - `Chip`을 최근 검색어와 추천 검색어 pill에 사용합니다. 칩 목록의 horizontal scroll과 키워드 선택 동작은 page-local `KeywordChipList`가 소유합니다.
 - `FilterBottomSheet`를 정렬/음식 장르 필터에 사용합니다. 옵션 목록, pending 값, 초기화/적용 동작은 `useSearchPage`가 주입합니다.
 - 검색/필터/바텀시트 상태와 이동 로직은 `SearchPage`에 직접 두지 않고 `useSearchPage`가 주입합니다.
@@ -367,7 +370,7 @@ SearchPage
 - validation error:
   - 이번 범위에서는 검색어 validation error를 노출하지 않습니다.
 - exceptional case:
-  - 식당 이미지가 없으면 fallback image 또는 placeholder 영역을 사용합니다.
+  - 식당 이미지가 없으면 공통 `DefaultImage` fallback을 사용합니다.
   - 별점 또는 영업시간이 없으면 API/제품 정책에 따라 숨김 또는 대체 문구를 선택합니다.
 - user-facing message:
   - empty: `검색된 식당이 없습니다.`
@@ -408,18 +411,19 @@ SearchPage
   - 첨부 설계는 모바일 viewport 기준입니다.
   - 넓은 viewport에서는 콘텐츠 폭을 모바일 기준으로 제한하거나 기존 RootLayout 정책을 따릅니다.
 - fixed area:
-  - 검색창을 포함한 상단 검색 영역만 고정합니다.
-  - 검색 영역은 `app-mobile-fixed-top z-fixed bg-white`로 렌더링해 스크롤 중 결과 리스트보다 위에 표시합니다.
-  - filter bar는 고정 영역에 포함하지 않고 검색 결과 콘텐츠 흐름 안에서 렌더링합니다.
-  - fixed 검색 영역은 SearchField 아래 여백까지 포함하며, 본문을 덮지 않도록 본문은 `pt-[83px]`로 보정합니다.
+  - 검색창을 포함한 상단 검색 영역은 항상 고정합니다.
+  - 검색 결과 상태에서는 filter bar도 같은 `app-mobile-fixed-top z-fixed bg-white` 영역에 포함해 스크롤 중 결과 리스트보다 위에 표시합니다.
+  - 검색 전 본문은 `pt-[83px]`, 검색 결과 본문은 filter bar 높이까지 반영해 `pt-[122px]`로 보정합니다.
 - search header:
   - top padding은 `30px`입니다.
   - bottom padding은 `9px`입니다.
   - 뒤로가기 아이콘은 `24px`입니다.
+  - 뒤로가기 버튼 터치 영역은 `44px * 44px`입니다.
   - 뒤로가기 버튼과 `SearchField` 사이 간격은 `10px`입니다.
 - filter bar:
   - filter trigger는 page-local component로 조합합니다.
   - `SearchField`와 filter section 사이 간격은 fixed search header의 bottom padding `9px`로 확보합니다.
+  - 검색 결과 상태에서 fixed search header 아래에 렌더링합니다.
   - filter section 내부 vertical padding은 `9px`입니다.
   - trigger text는 `typo-sub-header-3 text-primary-200`입니다.
   - text와 chevron icon 사이 간격은 `12px`입니다.
@@ -429,6 +433,7 @@ SearchPage
   - list item 사이 간격은 `30px`입니다.
   - 결과 리스트 하단 padding은 `30px`입니다.
   - 식당 이미지는 `92px * 92px`, radius `5px`입니다.
+  - 식당 이미지가 없으면 `DefaultImage`를 같은 크기와 radius로 렌더링합니다.
   - 이미지와 내용 사이 간격은 `12px`입니다.
   - 오른쪽 내용 영역은 이미지 높이 기준 vertical center로 정렬합니다.
   - title은 `typo-sub-header-2 text-cool-gray-900`이며 최대 2줄입니다.
@@ -468,14 +473,14 @@ SearchPage
 - empty/loading/error layout:
   - 상단 고정 영역은 유지합니다.
   - empty state는 결과 영역 중앙에 배치합니다.
-  - 바텀시트 open 시 배경 overlay로 본문을 dim 처리합니다.
+  - 바텀시트 open 시 배경 overlay로 본문을 dim 처리하고 `html`/`body` 배경 스크롤을 lock합니다.
 
 ## Verification
 
-- [ ] `corepack pnpm format:check`
-- [ ] `corepack pnpm --filter @hashi/client lint`
-- [ ] `corepack pnpm --filter @hashi/client typecheck`
-- [ ] `corepack pnpm --filter @hashi/client build`
+- [x] `corepack pnpm format:check`
+- [x] `corepack pnpm --filter @hashi/client lint`
+- [x] `corepack pnpm --filter @hashi/client typecheck`
+- [x] `corepack pnpm --filter @hashi/client build`
 - [ ] `corepack pnpm --filter @hashi/client test`
 - [ ] `/search` 직접 진입 확인
 - [ ] 홈 검색 CTA에서 `/search` 진입 확인

--- a/apps/client/src/pages/search/SearchPage.test.tsx
+++ b/apps/client/src/pages/search/SearchPage.test.tsx
@@ -36,6 +36,11 @@ describe('SearchPage', () => {
   afterEach(() => {
     cleanup()
     window.localStorage.clear()
+    document.body.style.overflow = ''
+    document.body.style.position = ''
+    document.body.style.top = ''
+    document.body.style.width = ''
+    document.documentElement.style.overflow = ''
   })
 
   it('shows recent and recommended keywords before searching', () => {
@@ -55,7 +60,9 @@ describe('SearchPage', () => {
       'bg-white',
     )
     expect(screen.getByRole('search')).toHaveClass('pb-[9px]')
-    expect(screen.getByRole('button', { name: '뒤로가기' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '뒤로가기' })).toHaveClass(
+      'size-11',
+    )
     const recentSection = screen.getByRole('region', { name: '최근 검색어' })
     const recommendedSection = screen.getByRole('region', {
       name: '추천 검색어',
@@ -91,17 +98,43 @@ describe('SearchPage', () => {
         '아키토리 무사시 제일은 여기까지 그러니 최대길이 이 정도로까지',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByRole('list').parentElement).toHaveClass('pt-[83px]')
+    expect(screen.getByRole('list').parentElement).toHaveClass('pt-[122px]')
     expect(
-      screen.getByRole('button', { name: '기본순' }).parentElement,
-    ).not.toHaveClass('app-mobile-fixed-top')
-    expect(
-      screen.getByRole('button', { name: '기본순' }).parentElement,
-    ).not.toHaveClass('mt-[9px]')
+      screen.getByRole('button', { name: '기본순' }).parentElement
+        ?.parentElement,
+    ).toHaveClass('app-mobile-fixed-top', 'z-fixed', 'bg-white')
     expect(screen.getAllByRole('listitem')).toHaveLength(10)
+    expect(
+      screen.getAllByRole('listitem')[0].querySelector('a')?.firstChild,
+    ).toHaveClass('bg-warm-gray-50')
     expect(window.localStorage.getItem('hashi:search:recent-keywords')).toBe(
       JSON.stringify(['아끼소바']),
     )
+  })
+
+  it('locks background scroll while a filter bottom sheet is open', async () => {
+    const user = userEvent.setup()
+
+    renderSearchPage()
+
+    await user.click(screen.getByRole('button', { name: '아끼소바' }))
+    await screen.findByText(
+      '아키토리 무사시 제일은 여기까지 그러니 최대길이 이 정도로까지',
+    )
+
+    await user.click(screen.getByRole('button', { name: '기본순' }))
+
+    expect(document.body.style.overflow).toBe('hidden')
+    expect(document.body.style.position).toBe('fixed')
+    expect(document.documentElement.style.overflow).toBe('hidden')
+
+    await user.click(screen.getByRole('button', { name: '적용' }))
+
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe('')
+      expect(document.body.style.position).toBe('')
+      expect(document.documentElement.style.overflow).toBe('')
+    })
   })
 
   it('keeps search usable when recent keyword storage is unavailable', async () => {

--- a/apps/client/src/pages/search/SearchPage.tsx
+++ b/apps/client/src/pages/search/SearchPage.tsx
@@ -7,9 +7,11 @@ import { SearchIdlePanel } from '@/pages/search/components/SearchIdlePanel'
 import { SearchResultSkeleton } from '@/pages/search/components/SearchResultSkeleton'
 import { useSearchPage } from '@/pages/search/hooks/useSearchPage'
 import { FilterBottomSheet } from '@/shared/components/filterBottomSheet'
+import { cn } from '@/shared/utils'
 
 export const SearchPage = () => {
   const searchPage = useSearchPage()
+  const isSearchIdle = searchPage.status.isSearchIdle
 
   return (
     <div className="flex min-h-dvh flex-col bg-white">
@@ -21,9 +23,22 @@ export const SearchPage = () => {
           onKeywordChange={searchPage.onKeywordChange}
           onSearchSubmit={searchPage.onSearchSubmit}
         />
+        {!isSearchIdle && (
+          <SearchFilterBar
+            categoryLabel={searchPage.filterLabels.foodCategory}
+            onCategoryClick={searchPage.onFoodCategoryFilterClick}
+            onSortClick={searchPage.onSortFilterClick}
+            sortLabel={searchPage.filterLabels.sort}
+          />
+        )}
       </div>
-      <div className="flex flex-1 flex-col pt-[83px]">
-        {searchPage.status.isSearchIdle ? (
+      <div
+        className={cn(
+          'flex flex-1 flex-col',
+          isSearchIdle ? 'pt-[83px]' : 'pt-[122px]',
+        )}
+      >
+        {isSearchIdle ? (
           <SearchIdlePanel
             recentSearchKeywords={searchPage.recentSearchKeywords}
             recommendedSearchKeywords={searchPage.recommendedSearchKeywords}
@@ -31,12 +46,6 @@ export const SearchPage = () => {
           />
         ) : (
           <>
-            <SearchFilterBar
-              categoryLabel={searchPage.filterLabels.foodCategory}
-              onCategoryClick={searchPage.onFoodCategoryFilterClick}
-              onSortClick={searchPage.onSortFilterClick}
-              sortLabel={searchPage.filterLabels.sort}
-            />
             {searchPage.searchRestaurantsQuery.isLoading ? (
               <SearchResultSkeleton />
             ) : searchPage.searchRestaurantsQuery.isError ? (

--- a/apps/client/src/pages/search/components/RestaurantResultItem.tsx
+++ b/apps/client/src/pages/search/components/RestaurantResultItem.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
 import type { SearchRestaurant } from '@/pages/search/types'
+import { DefaultImage } from '@/shared/components/defaultImage'
 
 interface RestaurantResultItemProps {
   restaurant: SearchRestaurant
@@ -31,9 +32,10 @@ export const RestaurantResultItem = ({
             src={restaurant.imageUrl}
           />
         ) : (
-          <div
+          <DefaultImage
             aria-hidden="true"
-            className="from-cool-gray-100 to-warm-gray-50 h-[92px] w-[92px] shrink-0 rounded-[5px] bg-linear-to-br"
+            className="h-[92px] w-[92px] shrink-0 rounded-[5px]"
+            logoSize="sm"
           />
         )}
         <div className="min-w-0 flex-1 self-center">

--- a/apps/client/src/pages/search/components/SearchHeader.tsx
+++ b/apps/client/src/pages/search/components/SearchHeader.tsx
@@ -31,7 +31,7 @@ export const SearchHeader = ({
     >
       <IconButton
         aria-label="뒤로가기"
-        className="text-cool-gray-900"
+        className="text-cool-gray-900 -m-2.5 size-11"
         onClick={onBackClick}
         size="xs"
       >

--- a/packages/hds-ui/src/components/bottomSheet/BottomSheet.spec.md
+++ b/packages/hds-ui/src/components/bottomSheet/BottomSheet.spec.md
@@ -26,7 +26,7 @@ HDS는 sheet shell, overlay, open/close interaction, title/header, footer slot, 
 - [x] Tab focus를 sheet 내부에 가둡니다.
 - [x] Escape key로 닫을 수 있습니다.
 - [x] 닫힌 뒤 이전 focus 위치로 복귀합니다.
-- [x] sheet가 열려 있을 때 body scroll을 잠급니다.
+- [x] sheet가 열려 있을 때 `html`/`body` 배경 스크롤을 잠그고 닫힐 때 기존 스크롤 위치를 복구합니다.
 - [x] safe-area bottom padding을 반영합니다.
 - [x] 열림/닫힘 시 translate transition을 적용합니다.
 - [x] 제품 도메인 데이터, route, API, logging, analytics에 의존하지 않습니다.
@@ -96,7 +96,7 @@ HDS는 sheet shell, overlay, open/close interaction, title/header, footer slot, 
 2. `open`이 `true`이면 `document.body`에 portal로 렌더링합니다.
 3. close button press, overlay press 시 `onOpenChange(false)`를 호출합니다.
 4. sheet 내부 press는 overlay press로 전파되지 않아야 합니다.
-5. sheet가 열려 있는 동안 body scroll을 잠급니다.
+5. sheet가 열려 있는 동안 `documentElement`와 `body`의 배경 스크롤을 잠그고, 닫힐 때 기존 inline style과 스크롤 위치를 복구합니다.
 6. `title`이 있으면 dialog accessible name으로 연결합니다.
 7. `title`이 없으면 `aria-label`을 dialog accessible name으로 연결합니다.
 8. sheet가 열리면 sheet panel로 focus를 이동합니다.
@@ -140,7 +140,7 @@ Storybook은 BottomSheet primitive의 slot과 옵션만 보여줍니다. 음식 
 
 ## Verification
 
-- [ ] `corepack pnpm --filter @hashi/hds-ui lint`
-- [ ] `corepack pnpm --filter @hashi/hds-ui typecheck`
-- [ ] `corepack pnpm --filter @hashi/hds-ui build`
-- [ ] `corepack pnpm --filter @hashi/hds-ui test`
+- [x] `corepack pnpm --filter @hashi/hds-ui lint`
+- [x] `corepack pnpm --filter @hashi/hds-ui typecheck`
+- [x] `corepack pnpm --filter @hashi/hds-ui build`
+- [x] `corepack pnpm --filter @hashi/hds-ui test`

--- a/packages/hds-ui/src/components/bottomSheet/BottomSheet.test.tsx
+++ b/packages/hds-ui/src/components/bottomSheet/BottomSheet.test.tsx
@@ -14,6 +14,10 @@ describe('BottomSheet', () => {
   afterEach(() => {
     cleanup()
     document.body.style.overflow = ''
+    document.body.style.position = ''
+    document.body.style.top = ''
+    document.body.style.width = ''
+    document.documentElement.style.overflow = ''
   })
 
   it('does not render when open is false', () => {
@@ -37,6 +41,39 @@ describe('BottomSheet', () => {
       screen.getByRole('dialog', { name: '정렬 순서' }),
     ).toBeInTheDocument()
     expect(screen.getByText('기본순')).toBeInTheDocument()
+  })
+
+  it('locks document background scroll while open and restores it on close', () => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(vi.fn())
+    const scrollYSpy = vi.spyOn(window, 'scrollY', 'get').mockReturnValue(128)
+
+    const { rerender } = render(
+      <BottomSheet open onOpenChange={vi.fn()} title="정렬 순서">
+        기본순
+      </BottomSheet>,
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+    expect(document.body.style.position).toBe('fixed')
+    expect(document.body.style.top).toBe('-128px')
+    expect(document.body.style.width).toBe('100%')
+    expect(document.documentElement.style.overflow).toBe('hidden')
+
+    rerender(
+      <BottomSheet open={false} onOpenChange={vi.fn()} title="정렬 순서">
+        기본순
+      </BottomSheet>,
+    )
+
+    expect(document.body.style.overflow).toBe('')
+    expect(document.body.style.position).toBe('')
+    expect(document.body.style.top).toBe('')
+    expect(document.body.style.width).toBe('')
+    expect(document.documentElement.style.overflow).toBe('')
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 128)
+
+    scrollToSpy.mockRestore()
+    scrollYSpy.mockRestore()
   })
 
   it('uses aria-label as dialog name when title is not provided', () => {

--- a/packages/hds-ui/src/components/inputField/InputField.spec.md
+++ b/packages/hds-ui/src/components/inputField/InputField.spec.md
@@ -82,17 +82,19 @@ Exported type:
 
 - root width: `100%`
 - label/input gap: `8px`
-- input box height: `51px`
+- input box height: `45px`
+- input box padding-top / padding-bottom: `13px` (`py-3.25`)
 - input box padding-left: `15px`
 - input box padding-right: `15px` without right content, `9px` with right content
 - input box radius: `10px`
 - input box background: `primary-100`
 - label: `font-sans`, `typo-sub-header-2`, `black`
 - input text: `font-sans`, `typo-body-4`, `primary-200`
-- placeholder: `warm-gray-300`
+- placeholder/hint: input typography와 동일한 `typo-body-4`, `warm-gray-300`
+- inner native input resets: `appearance-none`, `border-0`, `p-0`
 - input and right content minimum gap: `10px`
 - right icon and right element gap: `10px`
-- right action position in Figma examples: `right 9px`, vertically centered in the `51px` box
+- right action position in Figma examples: `right 9px`, vertically centered in the `45px` box
 - right icon visual box: `22px`
 
 Figma selection width is `345px`, but the component uses `w-full` for mobile app layouts. Storybook examples wrap the component in a `345px` preview frame.

--- a/packages/hds-ui/src/components/inputField/InputField.test.tsx
+++ b/packages/hds-ui/src/components/inputField/InputField.test.tsx
@@ -19,6 +19,15 @@ describe('InputField', () => {
     expect(screen.getByPlaceholderText('내용을 입력해 주세요.')).toBeTruthy()
   })
 
+  it('styles placeholder text with the input Body4 typography', () => {
+    render(<InputField aria-label="name" placeholder="내용을 입력해 주세요." />)
+
+    const input = screen.getByPlaceholderText('내용을 입력해 주세요.')
+
+    expect(input).toHaveClass('typo-body-4')
+    expect(input).toHaveClass('placeholder:text-warm-gray-300')
+  })
+
   it('renders a label and connects it to the input', () => {
     render(<InputField label="연락처" />)
 
@@ -82,6 +91,25 @@ describe('InputField', () => {
     expect(inputBox).not.toHaveClass('focus-within:outline-cool-gray-500')
     expect(inputBox).not.toHaveClass('focus-within:outline-2')
     expect(inputBox).not.toHaveClass('focus-within:outline-offset-0')
+  })
+
+  it('uses 13px vertical padding on the input box', () => {
+    render(<InputField aria-label="name" />)
+
+    const inputBox = screen.getByRole('textbox', { name: 'name' }).parentElement
+
+    expect(inputBox).toHaveClass('h-[45px]')
+    expect(inputBox).toHaveClass('py-3.25')
+  })
+
+  it('resets native input spacing so the wrapper owns the inner padding', () => {
+    render(<InputField aria-label="name" />)
+
+    const input = screen.getByRole('textbox', { name: 'name' })
+
+    expect(input).toHaveClass('appearance-none')
+    expect(input).toHaveClass('border-0')
+    expect(input).toHaveClass('p-0')
   })
 
   it('does not focus the input when the disabled input box is clicked', () => {

--- a/packages/hds-ui/src/components/inputField/InputField.tsx
+++ b/packages/hds-ui/src/components/inputField/InputField.tsx
@@ -97,7 +97,7 @@ export const InputField = ({
       <div
         data-disabled={disabled || undefined}
         className={cn(
-          'bg-primary-100 flex h-[51px] w-full items-center rounded-[10px]',
+          'bg-primary-100 flex h-[45px] w-full items-center rounded-[10px] py-3.25',
           hasRightContent ? 'pr-[9px] pl-[15px]' : 'px-[15px]',
           'data-[disabled=true]:cursor-not-allowed',
           className,
@@ -114,7 +114,7 @@ export const InputField = ({
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
           disabled={disabled}
-          className="typo-body-4 text-primary-200 placeholder:text-warm-gray-300 disabled:text-warm-gray-300 min-w-0 flex-1 bg-transparent font-sans outline-none disabled:cursor-not-allowed"
+          className="typo-body-4 text-primary-200 placeholder:text-warm-gray-300 disabled:text-warm-gray-300 min-w-0 flex-1 appearance-none border-0 bg-transparent p-0 font-sans outline-none disabled:cursor-not-allowed"
         />
 
         {hasRightContent ? (

--- a/packages/hds-ui/src/shared/useBodyScrollLock.ts
+++ b/packages/hds-ui/src/shared/useBodyScrollLock.ts
@@ -4,11 +4,36 @@ export const useBodyScrollLock = (enabled: boolean) => {
   useEffect(() => {
     if (!enabled) return
 
-    const { overflow } = document.body.style
+    const scrollY = window.scrollY
+    const {
+      left,
+      overflow: bodyOverflow,
+      position,
+      right,
+      top,
+      width,
+    } = document.body.style
+    const { overflow: documentOverflow } = document.documentElement.style
+
+    document.documentElement.style.overflow = 'hidden'
     document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${scrollY}px`
+    document.body.style.left = '0'
+    document.body.style.right = '0'
+    document.body.style.width = '100%'
 
     return () => {
-      document.body.style.overflow = overflow
+      document.documentElement.style.overflow = documentOverflow
+      document.body.style.overflow = bodyOverflow
+      document.body.style.position = position
+      document.body.style.top = top
+      document.body.style.left = left
+      document.body.style.right = right
+      document.body.style.width = width
+      if (scrollY > 0) {
+        window.scrollTo(0, scrollY)
+      }
     }
   }, [enabled])
 }


### PR DESCRIPTION
## 📌 Summary
> 1차 자체 QA에서 확인된 홈/검색/바텀시트/InputField UI 이슈를 반영했습니다.

홈 상단 검색 영역 고정, 검색 페이지 상단 고정 영역 및 이미지 fallback, 바텀시트 배경 스크롤 lock, 공통 InputField 디자인 기준을 수정했습니다.

Jira: [HASHI-94](https://siksa.atlassian.net/browse/HASHI-94?atlOrigin=eyJpIjoiZDc5ODIwM2MxNWQxNDM4ZmI1MjhhYjI2NjkwZThkMTMiLCJwIjoiaiJ9)

## 📚 Tasks

- 홈 페이지 Header 영역 고정
  - Hashi 로고, 검색 진입 영역, 검색바 하단 padding까지 fixed 영역에 포함
  - fixed 영역이 본문을 가리지 않도록 본문 top padding 보정
- 검색 페이지 Header 뒤로가기 터치 영역 확장
  - 24px 아이콘은 유지
  - 44px 터치 영역 확보
- 검색 페이지 상단 고정 영역 수정
  - 검색 결과 상태에서 정렬/음식 장르 필터 바까지 fixed 영역에 포함
  - 검색 전/검색 결과 상태별 본문 top padding 분기 처리
- 검색 결과 식당 이미지 fallback 수정
  - 이미지가 없는 경우 임시 placeholder 대신 공통 `DefaultImage` 적용
- 바텀시트 열림 상태 배경 스크롤 방지
  - `html`/`body` overflow lock
  - body fixed 처리 및 닫힘 시 기존 스크롤 위치 복구
- 공통 `InputField` 디자인 QA 반영
  - input box height `45px`
  - vertical padding `13px`
  - hint/placeholder typography `Body4`
  - native input spacing reset
- 관련 spec/test 갱신

## 🔎 Description

- 홈 화면은 상단 로고와 검색 진입 영역이 스크롤과 무관하게 유지되도록 `app-mobile-fixed-top` 영역으로 분리했습니다. 검색바 아래 `16px` 여백까지 fixed 영역에 포함하고, 본문에는 해당 높이만큼 top padding을 추가했습니다.

- 검색 화면은 검색 결과 상태에서 필터 바가 리스트와 함께 스크롤되지 않도록 검색 Header와 같은 fixed 영역 안으로 이동했습니다. 검색 전 상태와 결과 상태의 고정 영역 높이가 달라서 본문 padding을 각각 `pt-[83px]`, `pt-[122px]`로 분기했습니다.

- 검색 Header의 뒤로가기 버튼은 HDS Header의 터치 영역 기준을 참고해 `44px` 영역을 확보했습니다. 아이콘 크기는 기존 디자인대로 `24px`을 유지했습니다.

- 검색 결과 식당 이미지가 없는 경우에는 page-local 임시 gradient placeholder를 제거하고, 앱 공통 `DefaultImage`를 동일한 크기와 radius로 렌더링하도록 변경했습니다.

- HDS `BottomSheet`에서 열림 상태일 때 배경 스크롤이 남는 문제를 막기 위해 `documentElement`와 `body`를 함께 lock하고, body fixed 처리 후 닫힘 시 기존 inline style과 scroll 위치를 복구하도록 수정했습니다.

- 공통 `InputField`는 프로필 생성 화면 QA 기준에 맞춰 높이 `45px`, 내부 vertical padding `13px`, hint/placeholder `Body4` 기준을 반영했습니다. label은 기존처럼 `SubHeader2 / Black`을 유지합니다.

## 👀 To Reviewer
- HDS 변경 범위는 `BottomSheet` scroll lock과 `InputField` 스타일 기준입니다.

## ✅ Verification

- `corepack pnpm --filter @hashi/client lint`
- `corepack pnpm --filter @hashi/client typecheck`
- `corepack pnpm --filter @hashi/client build`
- `corepack pnpm --filter @hashi/hds-ui lint`
- `corepack pnpm --filter @hashi/hds-ui typecheck`
- `corepack pnpm --filter @hashi/hds-ui build`
- `corepack pnpm --filter @hashi/hds-ui test`
- `corepack pnpm format:check`
- `git diff --check`

## 📸 Screenshot
<img width="864" height="973" alt="스크린샷 2026-07-10 오후 9 01 14" src="https://github.com/user-attachments/assets/1fda1eca-fccc-4cd5-8e8f-73f731fbc9f2" />

<img width="864" height="973" alt="스크린샷 2026-07-10 오후 9 01 49" src="https://github.com/user-attachments/assets/0d2fb43a-3e30-4a31-90ce-2e9e5cacd926" />