### PR TITLE
Chore(root): HASHI-102 TanStack Query 설정 추가

### DIFF
--- a/apps/client/src/app/providers/AsyncBoundary.test.tsx
+++ b/apps/client/src/app/providers/AsyncBoundary.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockCaptureError } = vi.hoisted(() => ({
+  mockCaptureError: vi.fn(),
+}))
+
+vi.mock('@/shared/lib/sentry', () => ({
+  captureError: mockCaptureError,
+}))
+
+import AsyncBoundary from '@/app/providers/AsyncBoundary'
+
+const ErrorThrowingChild = () => {
+  throw new Error('render failed')
+}
+
+describe('AsyncBoundary', () => {
+  it('captures errors handled by the boundary', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <AsyncBoundary>
+        <ErrorThrowingChild />
+      </AsyncBoundary>,
+    )
+
+    expect(screen.getByText('일시적인 오류가 발생했습니다.')).toBeVisible()
+    expect(mockCaptureError.mock.calls[0]?.[0]).toEqual(expect.any(Error))
+  })
+})

--- a/apps/client/src/app/providers/AsyncBoundary.tsx
+++ b/apps/client/src/app/providers/AsyncBoundary.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react'
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { ErrorBoundary } from 'react-error-boundary'
 
+import { captureError } from '@/shared/lib/sentry'
+
 interface AsyncBoundaryProps {
   children: ReactNode
 }
@@ -11,6 +13,7 @@ const AsyncBoundary = ({ children }: AsyncBoundaryProps) => {
     <QueryErrorResetBoundary>
       {({ reset }) => (
         <ErrorBoundary
+          onError={captureError}
           onReset={reset}
           fallbackRender={({ resetErrorBoundary }) => (
             <section>

--- a/apps/client/src/shared/api/apiError.ts
+++ b/apps/client/src/shared/api/apiError.ts
@@ -20,14 +20,32 @@ export class ApiError extends Error {
   }
 }
 
+export class HttpStatusError extends Error {
+  readonly status: number
+
+  constructor(status: number, options?: ErrorOptions) {
+    super(`HTTP ${status}`, options)
+    this.name = 'HttpStatusError'
+    this.status = status
+  }
+}
+
 export const isApiError = (error: unknown): error is ApiError =>
   error instanceof ApiError
 
-export const checkIsRetryableApiError = (error: unknown) =>
-  isApiError(error) && error.status >= 500
+export const isHttpStatusError = (error: unknown): error is HttpStatusError =>
+  error instanceof HttpStatusError
+
+export const checkHasHttpStatus = (
+  error: unknown,
+): error is ApiError | HttpStatusError =>
+  isApiError(error) || isHttpStatusError(error)
+
+export const checkIsRetryableStatusError = (error: unknown) =>
+  checkHasHttpStatus(error) && error.status >= 500
 
 export const checkIsAuthRequiredError = (error: unknown) =>
-  isApiError(error) && error.status === 401
+  checkHasHttpStatus(error) && error.status === 401
 
 export const checkIsNotFoundError = (error: unknown) =>
-  isApiError(error) && error.status === 404
+  checkHasHttpStatus(error) && error.status === 404

--- a/apps/client/src/shared/api/apiError.ts
+++ b/apps/client/src/shared/api/apiError.ts
@@ -2,11 +2,13 @@ import type { ErrorResponse } from '@/shared/api/types'
 
 export class ApiError extends Error {
   readonly response: ErrorResponse
+  readonly status: number
 
-  constructor(response: ErrorResponse) {
+  constructor(response: ErrorResponse, status: number) {
     super(response.message)
     this.name = 'ApiError'
     this.response = response
+    this.status = status
   }
 
   get code() {
@@ -20,3 +22,12 @@ export class ApiError extends Error {
 
 export const isApiError = (error: unknown): error is ApiError =>
   error instanceof ApiError
+
+export const checkIsRetryableApiError = (error: unknown) =>
+  isApiError(error) && error.status >= 500
+
+export const checkIsAuthRequiredError = (error: unknown) =>
+  isApiError(error) && error.status === 401
+
+export const checkIsNotFoundError = (error: unknown) =>
+  isApiError(error) && error.status === 404

--- a/apps/client/src/shared/api/index.ts
+++ b/apps/client/src/shared/api/index.ts
@@ -1,4 +1,13 @@
-export { ApiError, isApiError } from './apiError'
+export {
+  ApiError,
+  HttpStatusError,
+  checkHasHttpStatus,
+  checkIsAuthRequiredError,
+  checkIsNotFoundError,
+  checkIsRetryableStatusError,
+  isApiError,
+  isHttpStatusError,
+} from './apiError'
 export { apiClient } from './apiClient'
 export { request } from './request'
 export {

--- a/apps/client/src/shared/api/request.test.ts
+++ b/apps/client/src/shared/api/request.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ApiError } from '@/shared/api/apiError'
+import { ApiError, HttpStatusError } from '@/shared/api/apiError'
 import { apiClient } from '@/shared/api/apiClient'
 import { request } from '@/shared/api/request'
 import type { ErrorResponse } from '@/shared/api/types'
@@ -135,7 +135,7 @@ describe('request', () => {
     )
   })
 
-  it('throws HTTP status error when error response is not JSON', async () => {
+  it('throws HttpStatusError when error response is not JSON', async () => {
     mockedApiClient.mockResolvedValue(
       createHttpResponse({
         ok: false,
@@ -144,7 +144,11 @@ describe('request', () => {
       }) as never,
     )
 
-    await expect(request('users')).rejects.toThrow('HTTP 502')
+    await expect(request('users')).rejects.toMatchObject({
+      message: 'HTTP 502',
+      status: 502,
+    })
+    await expect(request('users')).rejects.toBeInstanceOf(HttpStatusError)
   })
 
   it('normalizes leading slashes in request path', async () => {

--- a/apps/client/src/shared/api/request.test.ts
+++ b/apps/client/src/shared/api/request.test.ts
@@ -14,14 +14,16 @@ const createHttpResponse = ({
   ok,
   status,
   body,
+  jsonError,
 }: {
   ok: boolean
   status: number
-  body: unknown
+  body?: unknown
+  jsonError?: Error
 }) => ({
   ok,
   status,
-  json: () => Promise.resolve(body),
+  json: () => (jsonError ? Promise.reject(jsonError) : Promise.resolve(body)),
 })
 
 const validationErrorResponse: ErrorResponse = {
@@ -106,6 +108,7 @@ describe('request', () => {
       code: 'VALIDATION_ERROR',
       fieldErrors: validationErrorResponse.errors,
       response: validationErrorResponse,
+      status: 400,
     })
   })
 
@@ -127,7 +130,21 @@ describe('request', () => {
       }) as never,
     )
 
-    await expect(request('users')).rejects.toEqual(new ApiError(serverError))
+    await expect(request('users')).rejects.toEqual(
+      new ApiError(serverError, 500),
+    )
+  })
+
+  it('throws HTTP status error when error response is not JSON', async () => {
+    mockedApiClient.mockResolvedValue(
+      createHttpResponse({
+        ok: false,
+        status: 502,
+        jsonError: new SyntaxError('Unexpected token < in JSON'),
+      }) as never,
+    )
+
+    await expect(request('users')).rejects.toThrow('HTTP 502')
   })
 
   it('normalizes leading slashes in request path', async () => {

--- a/apps/client/src/shared/api/request.ts
+++ b/apps/client/src/shared/api/request.ts
@@ -1,5 +1,5 @@
 import type { Options } from 'ky'
-import { ApiError } from '@/shared/api/apiError'
+import { ApiError, HttpStatusError } from '@/shared/api/apiError'
 import { apiClient } from '@/shared/api/apiClient'
 import { isErrorResponse, type ApiResponse } from '@/shared/api/types'
 
@@ -17,7 +17,7 @@ export const request = async <TData>(
     response = await httpResponse.json<ApiResponse<TData>>()
   } catch (error) {
     if (!httpResponse.ok) {
-      throw new Error(`HTTP ${httpResponse.status}`, { cause: error })
+      throw new HttpStatusError(httpResponse.status, { cause: error })
     }
 
     throw error
@@ -28,7 +28,7 @@ export const request = async <TData>(
   }
 
   if (!httpResponse.ok) {
-    throw new Error(`HTTP ${httpResponse.status}`)
+    throw new HttpStatusError(httpResponse.status)
   }
 
   return response.data

--- a/apps/client/src/shared/api/request.ts
+++ b/apps/client/src/shared/api/request.ts
@@ -11,10 +11,20 @@ export const request = async <TData>(
 ): Promise<TData | null> => {
   const normalizedPath = normalizePath(path)
   const httpResponse = await apiClient(normalizedPath, options)
-  const response = await httpResponse.json<ApiResponse<TData>>()
+  let response: ApiResponse<TData>
+
+  try {
+    response = await httpResponse.json<ApiResponse<TData>>()
+  } catch (error) {
+    if (!httpResponse.ok) {
+      throw new Error(`HTTP ${httpResponse.status}`, { cause: error })
+    }
+
+    throw error
+  }
 
   if (isErrorResponse(response)) {
-    throw new ApiError(response)
+    throw new ApiError(response, httpResponse.status)
   }
 
   if (!httpResponse.ok) {

--- a/apps/client/src/shared/lib/queryClient.test.ts
+++ b/apps/client/src/shared/lib/queryClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ApiError } from '@/shared/api/apiError'
+import { ApiError, HttpStatusError } from '@/shared/api/apiError'
 import type { ErrorResponse } from '@/shared/api/types'
 import { queryClient } from '@/shared/lib/queryClient'
 
@@ -44,6 +44,15 @@ describe('queryClient', () => {
     expect(retry(0, createApiError(401))).toBe(false)
     expect(retry(0, createApiError(404))).toBe(false)
     expect(retry(0, createApiError(409))).toBe(false)
+  })
+
+  it('retries HttpStatusError with server error status only', () => {
+    const retry = getQueryRetry()
+
+    expect(retry(0, new HttpStatusError(502))).toBe(true)
+    expect(retry(0, new HttpStatusError(503))).toBe(true)
+    expect(retry(0, new HttpStatusError(404))).toBe(false)
+    expect(retry(0, new HttpStatusError(409))).toBe(false)
   })
 
   it('does not retry after the max retry count', () => {

--- a/apps/client/src/shared/lib/queryClient.test.ts
+++ b/apps/client/src/shared/lib/queryClient.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { ApiError } from '@/shared/api/apiError'
+import type { ErrorResponse } from '@/shared/api/types'
+import { queryClient } from '@/shared/lib/queryClient'
+
+type QueryRetry = (failureCount: number, error: Error) => boolean
+
+const createApiError = (status: number) => {
+  const response: ErrorResponse = {
+    success: false,
+    code: `COMMON-${status}`,
+    message: '요청을 처리하지 못했습니다.',
+    data: null,
+    timestamp: '2026-07-10T13:00:00.000Z',
+    path: '/api/v1/test',
+  }
+
+  return new ApiError(response, status)
+}
+
+const getQueryRetry = () => {
+  const retry = queryClient.getDefaultOptions().queries?.retry
+
+  if (typeof retry !== 'function') {
+    throw new Error('query retry option must be a function')
+  }
+
+  return retry as QueryRetry
+}
+
+describe('queryClient', () => {
+  it('retries ApiError with server error status before the max retry count', () => {
+    const retry = getQueryRetry()
+
+    expect(retry(0, createApiError(500))).toBe(true)
+    expect(retry(0, createApiError(502))).toBe(true)
+  })
+
+  it('does not retry ApiError with client or business error status', () => {
+    const retry = getQueryRetry()
+
+    expect(retry(0, createApiError(400))).toBe(false)
+    expect(retry(0, createApiError(401))).toBe(false)
+    expect(retry(0, createApiError(404))).toBe(false)
+    expect(retry(0, createApiError(409))).toBe(false)
+  })
+
+  it('does not retry after the max retry count', () => {
+    const retry = getQueryRetry()
+
+    expect(retry(1, createApiError(500))).toBe(false)
+  })
+})

--- a/apps/client/src/shared/lib/queryClient.ts
+++ b/apps/client/src/shared/lib/queryClient.ts
@@ -1,5 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
-import { isHTTPError, isNetworkError, isTimeoutError } from 'ky'
+import { isNetworkError, isTimeoutError } from 'ky'
+
+import { checkIsRetryableApiError } from '@/shared/api/apiError'
 
 const MAX_QUERY_RETRY_COUNT = 1
 
@@ -8,8 +10,8 @@ const checkShouldRetryQuery = (failureCount: number, error: Error) => {
     return false
   }
 
-  if (isHTTPError(error)) {
-    return error.response.status >= 500
+  if (checkIsRetryableApiError(error)) {
+    return true
   }
 
   return isNetworkError(error) || isTimeoutError(error)

--- a/apps/client/src/shared/lib/queryClient.ts
+++ b/apps/client/src/shared/lib/queryClient.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
 import { isNetworkError, isTimeoutError } from 'ky'
 
-import { checkIsRetryableApiError } from '@/shared/api/apiError'
+import { checkIsRetryableStatusError } from '@/shared/api/apiError'
 
 const MAX_QUERY_RETRY_COUNT = 1
 
@@ -10,7 +10,7 @@ const checkShouldRetryQuery = (failureCount: number, error: Error) => {
     return false
   }
 
-  if (checkIsRetryableApiError(error)) {
+  if (checkIsRetryableStatusError(error)) {
     return true
   }
 

--- a/apps/client/src/shared/lib/sentry.test.ts
+++ b/apps/client/src/shared/lib/sentry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { ApiError } from '@/shared/api/apiError'
+import type { ErrorResponse } from '@/shared/api/types'
+import { checkShouldCaptureError } from '@/shared/lib/sentry'
+
+const createApiError = (status: number) => {
+  const response: ErrorResponse = {
+    success: false,
+    code: `COMMON-${status}`,
+    message: '요청을 처리하지 못했습니다.',
+    data: null,
+    timestamp: '2026-07-10T13:00:00.000Z',
+    path: '/api/v1/test',
+  }
+
+  return new ApiError(response, status)
+}
+
+describe('checkShouldCaptureError', () => {
+  it('captures unknown runtime errors', () => {
+    expect(checkShouldCaptureError(new Error('render failed'))).toBe(true)
+  })
+
+  it('captures ApiError with server error status', () => {
+    expect(checkShouldCaptureError(createApiError(500))).toBe(true)
+    expect(checkShouldCaptureError(createApiError(502))).toBe(true)
+  })
+
+  it('captures method mismatch ApiError as an integration error', () => {
+    expect(checkShouldCaptureError(createApiError(405))).toBe(true)
+  })
+
+  it('does not capture expected client or business ApiError', () => {
+    expect(checkShouldCaptureError(createApiError(400))).toBe(false)
+    expect(checkShouldCaptureError(createApiError(401))).toBe(false)
+    expect(checkShouldCaptureError(createApiError(404))).toBe(false)
+    expect(checkShouldCaptureError(createApiError(409))).toBe(false)
+    expect(checkShouldCaptureError(createApiError(415))).toBe(false)
+  })
+})

--- a/apps/client/src/shared/lib/sentry.test.ts
+++ b/apps/client/src/shared/lib/sentry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ApiError } from '@/shared/api/apiError'
+import { ApiError, HttpStatusError } from '@/shared/api/apiError'
 import type { ErrorResponse } from '@/shared/api/types'
 import { checkShouldCaptureError } from '@/shared/lib/sentry'
 
@@ -37,5 +37,13 @@ describe('checkShouldCaptureError', () => {
     expect(checkShouldCaptureError(createApiError(404))).toBe(false)
     expect(checkShouldCaptureError(createApiError(409))).toBe(false)
     expect(checkShouldCaptureError(createApiError(415))).toBe(false)
+  })
+
+  it('captures HttpStatusError with reportable status only', () => {
+    expect(checkShouldCaptureError(new HttpStatusError(502))).toBe(true)
+    expect(checkShouldCaptureError(new HttpStatusError(405))).toBe(true)
+    expect(checkShouldCaptureError(new HttpStatusError(400))).toBe(false)
+    expect(checkShouldCaptureError(new HttpStatusError(404))).toBe(false)
+    expect(checkShouldCaptureError(new HttpStatusError(409))).toBe(false)
   })
 })

--- a/apps/client/src/shared/lib/sentry.ts
+++ b/apps/client/src/shared/lib/sentry.ts
@@ -1,5 +1,23 @@
 import * as Sentry from '@sentry/react'
 
+import { isApiError } from '@/shared/api/apiError'
+
+export const checkShouldCaptureError = (error: unknown) => {
+  if (!isApiError(error)) {
+    return true
+  }
+
+  return error.status === 405 || error.status >= 500
+}
+
+export const captureError = (error: unknown) => {
+  if (!checkShouldCaptureError(error)) {
+    return
+  }
+
+  Sentry.captureException(error)
+}
+
 export function initSentry() {
   const dsn = import.meta.env.VITE_SENTRY_DSN
   if (!dsn) return

--- a/apps/client/src/shared/lib/sentry.ts
+++ b/apps/client/src/shared/lib/sentry.ts
@@ -1,13 +1,13 @@
 import * as Sentry from '@sentry/react'
 
-import { isApiError } from '@/shared/api/apiError'
+import { checkHasHttpStatus } from '@/shared/api/apiError'
 
 export const checkShouldCaptureError = (error: unknown) => {
-  if (!isApiError(error)) {
-    return true
+  if (checkHasHttpStatus(error)) {
+    return error.status === 405 || error.status >= 500
   }
 
-  return error.status === 405 || error.status >= 500
+  return true
 }
 
 export const captureError = (error: unknown) => {

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -11,6 +11,7 @@ HASHI Client의 데이터 레이어는 앱 내부에서 먼저 조립하고, 실
 - API base URL: `VITE_API_BASE_URL`
 - OpenAPI type generation: `openapi-typescript`
 - 공통 request helper: `apps/client/src/shared/api`
+- API error model: `ApiError`가 서버 error envelope와 HTTP status를 함께 보존
 - generated API type output: `apps/client/src/shared/api/generated/openapi.ts`
 - Query provider/client: `apps/client/src/app/providers/QueryProvider.tsx`, `apps/client/src/shared/lib/queryClient.ts`
 
@@ -42,6 +43,24 @@ apps/client/src/shared/api/
 - endpoint 함수는 `request` 같은 low-level helper를 사용합니다.
 - endpoint 함수는 React, TanStack Query, route, UI state를 알면 안 됩니다.
 - 인증, refresh, retry 정책은 실제 요구사항 없이 미리 복잡하게 만들지 않습니다.
+
+## Error Handling Rules
+
+`apps/client/src/shared/api`는 서버 response envelope를 파싱하고 `success: false` 응답을 `ApiError`로 변환합니다.
+
+- `ApiError`는 서버 `code`, `message`, `errors`와 HTTP status를 함께 보존합니다.
+- HTTP status는 retry, 로그인 유도, not found, Sentry 기록 여부를 판단할 때 사용합니다.
+- field-level error는 `ApiError.fieldErrors`와 문서화된 error code를 기준으로 page/form 가까이에서 매핑합니다.
+- 서버 `message`는 임시 사용자 문구 후보일 수 있지만, 제품 문구는 page spec에서 확정합니다.
+- non-JSON error response는 HTTP status error로 정규화해 JSON 파싱 오류가 사용자 UI 정책을 깨지 않도록 합니다.
+
+TanStack Query retry는 `shared/lib/queryClient.ts`의 기본 정책에서 한 번만 판단합니다.
+
+- network error, timeout, `ApiError.status >= 500`만 최대 1회 재시도합니다.
+- `400`, `401`, `403`, `404`, `405`, `409`, `415` 같은 사용자 입력, 인증, 권한, not found, 비즈니스 충돌, 업로드 validation 오류는 자동 재시도하지 않습니다.
+- mutation은 중복 실행 위험이 있으므로 기본 retry를 비활성화합니다.
+- 전역 `throwOnError: true`는 사용하지 않습니다. page-entry required data는 route/page boundary 또는 `useSuspenseQuery`로, 검색/필터/form처럼 부분 실패가 자연스러운 화면은 local error UI로 처리합니다.
+- ErrorBoundary에서 잡힌 에러는 Sentry 필터를 거쳐 unknown error, render error, 5xx API error, 405 integration error만 기록합니다.
 
 ## API Integration Workflow
 

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -11,7 +11,7 @@ HASHI Client의 데이터 레이어는 앱 내부에서 먼저 조립하고, 실
 - API base URL: `VITE_API_BASE_URL`
 - OpenAPI type generation: `openapi-typescript`
 - 공통 request helper: `apps/client/src/shared/api`
-- API error model: `ApiError`가 서버 error envelope와 HTTP status를 함께 보존
+- API error model: `ApiError`와 `HttpStatusError`가 HTTP status를 보존
 - generated API type output: `apps/client/src/shared/api/generated/openapi.ts`
 - Query provider/client: `apps/client/src/app/providers/QueryProvider.tsx`, `apps/client/src/shared/lib/queryClient.ts`
 
@@ -49,18 +49,19 @@ apps/client/src/shared/api/
 `apps/client/src/shared/api`는 서버 response envelope를 파싱하고 `success: false` 응답을 `ApiError`로 변환합니다.
 
 - `ApiError`는 서버 `code`, `message`, `errors`와 HTTP status를 함께 보존합니다.
+- `HttpStatusError`는 proxy HTML 응답, 빈 503 응답처럼 서버 envelope가 없는 HTTP 실패의 status를 보존합니다.
 - HTTP status는 retry, 로그인 유도, not found, Sentry 기록 여부를 판단할 때 사용합니다.
 - field-level error는 `ApiError.fieldErrors`와 문서화된 error code를 기준으로 page/form 가까이에서 매핑합니다.
 - 서버 `message`는 임시 사용자 문구 후보일 수 있지만, 제품 문구는 page spec에서 확정합니다.
-- non-JSON error response는 HTTP status error로 정규화해 JSON 파싱 오류가 사용자 UI 정책을 깨지 않도록 합니다.
+- non-JSON error response는 `HttpStatusError`로 정규화해 JSON 파싱 오류가 사용자 UI 정책을 깨지 않도록 합니다.
 
 TanStack Query retry는 `shared/lib/queryClient.ts`의 기본 정책에서 한 번만 판단합니다.
 
-- network error, timeout, `ApiError.status >= 500`만 최대 1회 재시도합니다.
+- network error, timeout, `ApiError`/`HttpStatusError`의 `status >= 500`만 최대 1회 재시도합니다.
 - `400`, `401`, `403`, `404`, `405`, `409`, `415` 같은 사용자 입력, 인증, 권한, not found, 비즈니스 충돌, 업로드 validation 오류는 자동 재시도하지 않습니다.
 - mutation은 중복 실행 위험이 있으므로 기본 retry를 비활성화합니다.
 - 전역 `throwOnError: true`는 사용하지 않습니다. page-entry required data는 route/page boundary 또는 `useSuspenseQuery`로, 검색/필터/form처럼 부분 실패가 자연스러운 화면은 local error UI로 처리합니다.
-- ErrorBoundary에서 잡힌 에러는 Sentry 필터를 거쳐 unknown error, render error, 5xx API error, 405 integration error만 기록합니다.
+- ErrorBoundary에서 잡힌 에러는 Sentry 필터를 거쳐 unknown error, render error, 5xx status error, 405 integration error만 기록합니다.
 
 ## API Integration Workflow
 

--- a/docs/workflows/api-integration.md
+++ b/docs/workflows/api-integration.md
@@ -47,7 +47,7 @@ OPENAPI_SCHEMA_URL=http://localhost:8080/v3/api-docs pnpm gen:api-types
    - endpoint 함수와 request/response type을 작성합니다.
    - query key factory를 작성합니다.
    - `queryOptions`, `mutationOptions`, query/mutation hook을 작성합니다.
-   - 기존 퍼블리싱 UI 상태에 server state를 연결합니다.
+   - 기존 퍼블리싱 UI 상태에 server state와 API error state를 연결합니다.
    - page spec의 `Data Dependencies`와 `Verification`을 갱신합니다.
 
 3. `verify-api-integration`
@@ -108,5 +108,8 @@ apps/client/src/features/{feature}/
 - response를 바꾸는 params가 query key에 포함됩니다.
 - mutation 성공 후 stale한 list/detail/infinite query가 invalidated 됩니다.
 - loading, error, empty, disabled, success 상태가 UI에 연결됩니다.
+- API error는 `ApiError.status`, 서버 `code`, `fieldErrors` 중 필요한 기준으로 분류됩니다.
+- validation, auth, not found, conflict, upload error는 자동 retry나 전역 boundary로 올리지 않고 page/form/local UI에서 처리합니다.
+- 5xx, timeout, network error만 query retry 후보로 둡니다.
 - endpoint 함수가 React Query, route, UI state를 알지 않습니다.
 - 필요한 page spec과 data-layer 문서가 최신 상태입니다.

--- a/docs/workflows/api-integration.md
+++ b/docs/workflows/api-integration.md
@@ -108,7 +108,7 @@ apps/client/src/features/{feature}/
 - response를 바꾸는 params가 query key에 포함됩니다.
 - mutation 성공 후 stale한 list/detail/infinite query가 invalidated 됩니다.
 - loading, error, empty, disabled, success 상태가 UI에 연결됩니다.
-- API error는 `ApiError.status`, 서버 `code`, `fieldErrors` 중 필요한 기준으로 분류됩니다.
+- API error는 `ApiError`/`HttpStatusError`의 `status`, 서버 `code`, `fieldErrors` 중 필요한 기준으로 분류됩니다.
 - validation, auth, not found, conflict, upload error는 자동 retry나 전역 boundary로 올리지 않고 page/form/local UI에서 처리합니다.
 - 5xx, timeout, network error만 query retry 후보로 둡니다.
 - endpoint 함수가 React Query, route, UI state를 알지 않습니다.


### PR DESCRIPTION
## 📌 Summary
> 서버 에러 응답 코드와 TanStack Query 설정을 기준으로 클라이언트 API 에러 처리 흐름을 정리하고, retry / ErrorBoundary / Sentry 기록 기준을 보강했습니다.

Jira: [HASHI-102](https://siksa.atlassian.net/browse/HASHI-102)

## 📚 Tasks
- 서버 error envelope를 `ApiError`로 정규화하고 HTTP status를 함께 보존하도록 수정
- `request`에서 non-JSON 에러 응답을 `HTTP {status}` 에러로 정규화
- TanStack Query retry 기준을 `ApiError.status >= 500`, network error, timeout error 기준으로 변경
- `400`, `401`, `403`, `404`, `409`, `415` 등 사용자 입력/인증/권한/비즈니스 충돌 에러는 자동 retry 대상에서 제외
- ErrorBoundary에서 잡힌 에러를 Sentry 필터를 거쳐 기록하도록 연결
- Sentry에는 unknown/render error, 5xx API error, 405 integration error만 기록하도록 필터 추가
- API error 처리 기준을 `docs/architecture/data-layer.md`, `docs/workflows/api-integration.md`에 반영
- `request`, `queryClient`, `sentry`, `AsyncBoundary` 동작 검증 테스트 추가

## 🧭 Error Handling Policy

### 1. API Error Model
서버가 내려주는 error envelope는 `ApiError`로 변환합니다.

```ts
throw new ApiError(response, httpResponse.status)
```

`ApiError`는 다음 정보를 보존합니다.

- 서버 `code`
- 서버 `message`
- 서버 `errors`
- HTTP `status`

이 값은 retry, 로그인 유도, not found 처리, field error mapping, Sentry 기록 여부를 판단할 때 사용합니다.

### 2. Request Handling
`request`는 서버 응답을 다음 기준으로 처리합니다.

- `success: true`: `response.data` 반환
- `success: false`: `ApiError(response, status)` throw
- non-JSON error response: `HTTP {status}` error throw
- leading slash가 포함된 path는 기존처럼 normalize

non-JSON error response는 HTML error page나 proxy error처럼 서버 envelope가 아닌 응답이 내려오는 경우를 대비한 처리입니다.

### 3. Query Retry
TanStack Query의 query retry는 다음 경우에만 최대 1회 실행됩니다.

- network error
- timeout error
- `ApiError.status >= 500`

다음 에러는 자동 retry하지 않습니다.

- `400 Bad Request`
- `401 Unauthorized`
- `403 Forbidden`
- `404 Not Found`
- `409 Conflict`
- `415 Unsupported Media Type`
- mutation error

예약 생성, 리뷰 작성, 포인트 사용 같은 mutation은 중복 실행 위험이 있으므로 기본 retry를 비활성화합니다.

### 4. ErrorBoundary / Sentry
`AsyncBoundary`는 `QueryErrorResetBoundary`와 `react-error-boundary`를 연결하고, boundary에서 잡힌 에러를 Sentry 필터로 전달합니다.

Sentry 기록 대상:

- render error
- unknown JavaScript error
- 5xx API error
- 405 integration error

Sentry 기본 제외 대상:

- validation error
- auth required error
- not found error
- business conflict error
- upload validation error

## 🗂️ File Structure

이번 작업은 앱 내부 데이터 레이어와 provider 계층에만 적용했습니다.

```text
apps/client/src/shared/api/
  apiError.ts
  request.ts
  request.test.ts

apps/client/src/shared/lib/
  queryClient.ts
  queryClient.test.ts
  sentry.ts
  sentry.test.ts

apps/client/src/app/providers/
  AsyncBoundary.tsx
  AsyncBoundary.test.tsx
```

HDS 패키지에는 API, query, route, Sentry, product error logic을 추가하지 않았습니다.

## ✅ Test Plan

- [x] `corepack pnpm format:check`
- [x] `corepack pnpm --filter @hashi/client lint`
- [x] `corepack pnpm --filter @hashi/client typecheck`
- [x] `corepack pnpm --filter @hashi/client exec vitest run src/shared/api/request.test.ts src/shared/lib/queryClient.test.ts src/shared/lib/sentry.test.ts src/app/providers/AsyncBoundary.test.tsx`
- [x] `corepack pnpm --filter @hashi/client build`

## 👀 To Reviewer
- 전역 `throwOnError: true`는 의도적으로 추가하지 않았습니다.
  - 검색, 필터, form처럼 화면 일부만 실패할 수 있는 query까지 전역 boundary로 올라가는 것을 막기 위함입니다.
- `ApiError.status`는 retry, auth, not found, Sentry 분류의 기준값으로 사용됩니다.
- 서버 `message`는 보존하지만, 제품 문구로 그대로 노출하는 정책은 아직 두지 않았습니다.
  - page/form 가까이에서 spec 기준으로 매핑하는 방향입니다.
- `401`, refresh token, logout, redirect 정책은 실제 인증 흐름이 확정된 뒤 별도 작업에서 다루는 것이 좋습니다.
- `409 Conflict`는 장애가 아니라 예약/리뷰/회원가입 등 비즈니스 상태 충돌일 수 있어 자동 retry하지 않습니다.