### PR TITLE
Feat(admin): HASHI-116 Admin 앱 Vercel 배포 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ playwright-report/
 test-results/
 blob-report/
 playwright/.cache/
+.env*
+!.env.example

--- a/vercel.admin.json
+++ b/vercel.admin.json
@@ -4,5 +4,11 @@
   "devCommand": "pnpm dev:admin",
   "installCommand": "pnpm install",
   "framework": "vite",
-  "outputDirectory": "apps/admin/dist"
+  "outputDirectory": "apps/admin/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
 }


### PR DESCRIPTION
## 📌 Summary

클라이언트 배포 방식과 동일하게 Vercel CLI로 Preview / Production 배포 방식으로 구현했습니다.
관리자 앱을 별도 Vercel 프로젝트로 배포할 수 있도록 설정을 보완했습니다.
SPA 하위 경로에 직접 접근해도 관리자 앱이 정상적으로 로드되도록 rewrite를 추가했습니다.


Jira: HASHI-116

## 📚 Tasks

- `vercel.admin.json`에 관리자 SPA fallback rewrite 추가
- 로컬 및 Vercel 환경 파일이 커밋되지 않도록 ignore 규칙 추가
- `.env.example`은 계속 추적할 수 있도록 예외 처리
- 관리자 Preview 및 Production 배포 확인
- Production 커스텀 도메인 `https://admin.hashi.kr` 연결
- Preview URL은 따로 CORS 허용하지않음.

## 🔎 Description

관리자 앱은 클라이언트와 분리된 `hashi-admin` Vercel 프로젝트에서 `vercel.admin.json`을 사용해 빌드합니다.
React Router 하위 경로(`/admin/login` 등)에 직접 접근하거나 새로고침할 때 404가 발생하지 않도록 모든 경로를 진입점으로 rewrite합니다.

검증한 배포 주소:
- Production: https://admin.hashi.kr
- Preview: https://hashi-admin-a5pgq126p-gyeongbinmins-projects.vercel.app

## ✅ To reviewer

- 클라와 동일하게 배포 설정 완료했습니다.
- Production URL은 서버 CORS 허용 요청해서 해둔 상태입니당 
