### PR TITLE
Fix(admin): HASHI-119 최신 OpenAPI 기반 업로드 계약 정합성 수정

### DIFF
--- a/apps/admin/src/app/AdminApiIntegration.spec.md
+++ b/apps/admin/src/app/AdminApiIntegration.spec.md
@@ -30,8 +30,8 @@
 
 ## Upload Boundary
 
-1. `POST /api/v1/uploads/presigned-urls`에 `usage`, `contentType`, `fileSize`를 전송합니다.
-2. 응답의 `uploadUrl`로 동일한 `Content-Type`과 file body를 `PUT`합니다.
+1. `POST /api/v1/uploads/presigned-urls`에 `usage`, `files`(1~10개의 `contentType`, `fileSize`)를 전송합니다.
+2. 응답의 `uploads` 항목별 `uploadUrl`로 동일한 `Content-Type`과 file body를 `PUT`합니다.
 3. 성공한 `fileKey`만 admin create/update body에 포함합니다.
 4. JPEG/PNG/WebP, 최대 5MB를 API 호출 전에 검증합니다.
 5. 실패 파일은 재시도/제거할 수 있고 pending/failed count를 form validation에 전달합니다.
@@ -45,12 +45,13 @@
 - update scalar는 dirty field만 전송하고 빈 문자열로 clear하지 않습니다.
 - collection은 전체 교체 toggle이 켜진 경우에만 body에 포함합니다.
 - 기존 CDN URL을 storage key로 변환하지 않습니다.
+- create/update 응답의 soft delete 상태는 `deleted` 필드를 사용합니다.
 
 ## Magazine Write Rules
 
-- create는 title, uploaded bannerKey, http(s) Instagram URL을 요구합니다.
-- update는 dirty title/URL과 새로 업로드된 banner만 전송합니다.
-- title 150자, banner key 500자, URL 255자 제한을 backend contract에 맞춥니다.
+- create는 title, uploaded bannerKey/thumbnailKey, http(s) Instagram URL을 요구합니다.
+- update는 dirty title/URL과 새로 업로드된 banner/thumbnail만 전송합니다.
+- title 150자, image key 500자, URL 255자 제한을 backend contract에 맞춥니다.
 
 ## Data Boundaries
 

--- a/apps/admin/src/app/AdminConsole.spec.md
+++ b/apps/admin/src/app/AdminConsole.spec.md
@@ -56,8 +56,8 @@
 ### UX and Contract
 
 - 공개 매거진 table은 배너, 제목, Instagram URL, 등록일을 표시합니다.
-- drawer는 `title`, 실제 업로드로 얻은 `bannerKey`, `instagramRedirectUrl`만 전송합니다.
-- 수정 시 title/URL은 dirty field만, banner는 새 이미지 업로드가 성공했을 때만 전송합니다.
+- drawer는 `title`, 실제 업로드로 얻은 `bannerKey`, `thumbnailKey`, `instagramRedirectUrl`만 전송합니다.
+- 수정 시 title/URL은 dirty field만, banner/thumbnail은 각 새 이미지 업로드가 성공했을 때만 전송합니다.
 - 공개 목록에 없는 매거진은 numeric ID로 직접 수정·삭제할 수 있습니다.
 - region, series, genre, card news 같은 미지원 field는 제공하지 않습니다.
 

--- a/apps/admin/src/pages/magazines/MagazinesPage.test.tsx
+++ b/apps/admin/src/pages/magazines/MagazinesPage.test.tsx
@@ -82,6 +82,7 @@ describe('MagazinesPage', () => {
 
     expect(screen.getByRole('dialog')).toBeVisible()
     expect(screen.getByLabelText('배너 이미지 선택')).toBeInTheDocument()
+    expect(screen.getByLabelText('썸네일 이미지 선택')).toBeInTheDocument()
     expect(screen.queryByLabelText('배너 이미지 key')).not.toBeInTheDocument()
   })
 

--- a/apps/admin/src/pages/magazines/components/MagazineFormDrawer.tsx
+++ b/apps/admin/src/pages/magazines/components/MagazineFormDrawer.tsx
@@ -32,10 +32,10 @@ export const MagazineFormDrawer = ({
 }) => {
   const [form, setForm] = useState(createMagazineForm)
   const [dirtyFields, setDirtyFields] = useState<MagazineDirtyFields>(new Set())
-  const [uploadStatus, setUploadStatus] = useState<AdminImageUploadStatus>({
-    pendingCount: 0,
-    failedCount: 0,
-  })
+  const [bannerUploadStatus, setBannerUploadStatus] =
+    useState<AdminImageUploadStatus>({ pendingCount: 0, failedCount: 0 })
+  const [thumbnailUploadStatus, setThumbnailUploadStatus] =
+    useState<AdminImageUploadStatus>({ pendingCount: 0, failedCount: 0 })
   const [errors, setErrors] = useState<Record<string, string>>({})
   const createMutation = useCreateMagazineMutation()
   const updateMutation = useUpdateMagazineMutation()
@@ -46,7 +46,8 @@ export const MagazineFormDrawer = ({
     if (!open) return
     setForm(item ? createMagazineFormFromItem(item) : createMagazineForm())
     setDirtyFields(new Set())
-    setUploadStatus({ pendingCount: 0, failedCount: 0 })
+    setBannerUploadStatus({ pendingCount: 0, failedCount: 0 })
+    setThumbnailUploadStatus({ pendingCount: 0, failedCount: 0 })
     setErrors({})
     createMutation.reset()
     updateMutation.reset()
@@ -60,8 +61,13 @@ export const MagazineFormDrawer = ({
 
   const submit = () => {
     const nextErrors = validateMagazineForm(form, mode, dirtyFields)
-    if (uploadStatus.pendingCount || uploadStatus.failedCount) {
-      nextErrors.upload = '업로드 중이거나 실패한 배너를 확인해주세요.'
+    if (
+      bannerUploadStatus.pendingCount ||
+      bannerUploadStatus.failedCount ||
+      thumbnailUploadStatus.pendingCount ||
+      thumbnailUploadStatus.failedCount
+    ) {
+      nextErrors.upload = '업로드 중이거나 실패한 이미지를 확인해주세요.'
     }
     setErrors(nextErrors)
     if (Object.keys(nextErrors).length) return
@@ -88,7 +94,7 @@ export const MagazineFormDrawer = ({
       title={
         mode === 'create' ? '매거진 등록' : `매거진 수정 #${magazineId ?? ''}`
       }
-      description="배너 이미지를 직접 업로드하고 Instagram 이동 주소를 연결합니다."
+      description="배너와 썸네일 이미지를 업로드하고 Instagram 이동 주소를 연결합니다."
       onClose={onClose}
       footer={
         <>
@@ -150,11 +156,33 @@ export const MagazineFormDrawer = ({
           onChange={(images) =>
             setForm((current) => ({ ...current, banner: images[0] ?? null }))
           }
-          onStatusChange={setUploadStatus}
+          onStatusChange={setBannerUploadStatus}
+        />
+        {form.existingThumbnailUrl && !form.thumbnail ? (
+          <div>
+            <p className="text-cool-gray-500 mb-2 text-xs">현재 썸네일</p>
+            <img
+              src={form.existingThumbnailUrl}
+              alt="현재 매거진 썸네일"
+              className="w-full rounded-lg object-cover"
+            />
+          </div>
+        ) : null}
+        <AdminImageUploader
+          label={mode === 'create' ? '썸네일 이미지 선택' : '새 썸네일로 교체'}
+          usage="magazine"
+          value={form.thumbnail ? [form.thumbnail] : []}
+          onChange={(images) =>
+            setForm((current) => ({
+              ...current,
+              thumbnail: images[0] ?? null,
+            }))
+          }
+          onStatusChange={setThumbnailUploadStatus}
         />
         {mode === 'update' ? (
           <p className="text-cool-gray-500 text-xs">
-            새 배너를 업로드하지 않으면 기존 배너가 유지됩니다.
+            새 이미지를 업로드하지 않으면 기존 배너와 썸네일이 유지됩니다.
           </p>
         ) : null}
       </div>

--- a/apps/admin/src/pages/magazines/magazineForm.test.ts
+++ b/apps/admin/src/pages/magazines/magazineForm.test.ts
@@ -13,18 +13,28 @@ const uploadedBanner = {
   contentType: 'image/webp',
 }
 
+const uploadedThumbnail = {
+  fileKey: 'magazines/tokyo-thumbnail.webp',
+  fileUrl: 'https://cdn.example/tokyo-thumbnail.webp',
+  fileName: 'tokyo-thumbnail.webp',
+  contentType: 'image/webp',
+}
+
 describe('magazineForm', () => {
-  it('serializes exactly the three create fields', () => {
+  it('serializes the banner and thumbnail keys for create', () => {
     expect(
       toCreateMagazineBody({
         title: '도쿄의 밤',
         banner: uploadedBanner,
+        thumbnail: uploadedThumbnail,
         existingBannerUrl: null,
+        existingThumbnailUrl: null,
         instagramRedirectUrl: 'https://instagram.com/p/hashi',
       }),
     ).toEqual({
       title: '도쿄의 밤',
       bannerKey: 'magazines/tokyo.webp',
+      thumbnailKey: 'magazines/tokyo-thumbnail.webp',
       instagramRedirectUrl: 'https://instagram.com/p/hashi',
     })
   })
@@ -38,14 +48,24 @@ describe('magazineForm', () => {
     })
   })
 
-  it('requires a valid http URL and uploaded banner for create', () => {
+  it('requires a valid http URL, uploaded banner, and uploaded thumbnail for create', () => {
     const form = createMagazineForm()
     form.title = '도쿄의 밤'
     form.instagramRedirectUrl = 'javascript:alert(1)'
 
     expect(validateMagazineForm(form, 'create', new Set())).toMatchObject({
       banner: expect.any(String),
+      thumbnail: expect.any(String),
       instagramRedirectUrl: expect.any(String),
+    })
+  })
+
+  it('serializes a newly uploaded thumbnail for update', () => {
+    const form = createMagazineForm()
+    form.thumbnail = uploadedThumbnail
+
+    expect(toUpdateMagazineBody(form, new Set())).toEqual({
+      thumbnailKey: 'magazines/tokyo-thumbnail.webp',
     })
   })
 })

--- a/apps/admin/src/pages/magazines/magazineForm.ts
+++ b/apps/admin/src/pages/magazines/magazineForm.ts
@@ -7,7 +7,9 @@ import type { UploadedImage } from '@/shared/api/uploadApi'
 export interface MagazineFormState {
   title: string
   banner: UploadedImage | null
+  thumbnail: UploadedImage | null
   existingBannerUrl: string | null
+  existingThumbnailUrl: string | null
   instagramRedirectUrl: string
 }
 
@@ -16,18 +18,23 @@ export type MagazineDirtyFields = Set<'title' | 'instagramRedirectUrl'>
 export const createMagazineForm = (): MagazineFormState => ({
   title: '',
   banner: null,
+  thumbnail: null,
   existingBannerUrl: null,
+  existingThumbnailUrl: null,
   instagramRedirectUrl: '',
 })
 
 export const createMagazineFormFromItem = (item: {
   title?: string
   bannerImageUrl?: string
+  thumbnailImageUrl?: string
   instagramRedirectUrl?: string
 }): MagazineFormState => ({
   title: item.title ?? '',
   banner: null,
+  thumbnail: null,
   existingBannerUrl: item.bannerImageUrl ?? null,
+  existingThumbnailUrl: item.thumbnailImageUrl ?? null,
   instagramRedirectUrl: item.instagramRedirectUrl ?? '',
 })
 
@@ -55,6 +62,9 @@ export const validateMagazineForm = (
   if (mode === 'create' && !form.banner) {
     errors.banner = '배너 이미지를 업로드해주세요.'
   }
+  if (mode === 'create' && !form.thumbnail) {
+    errors.thumbnail = '썸네일 이미지를 업로드해주세요.'
+  }
   if (
     (mode === 'create' || dirtyFields.has('instagramRedirectUrl')) &&
     (form.instagramRedirectUrl.length > 255 ||
@@ -69,9 +79,11 @@ export const toCreateMagazineBody = (
   form: MagazineFormState,
 ): CreateMagazineBody => {
   if (!form.banner) throw new Error('배너 이미지를 업로드해주세요.')
+  if (!form.thumbnail) throw new Error('썸네일 이미지를 업로드해주세요.')
   return {
     title: form.title.trim(),
     bannerKey: form.banner.fileKey,
+    thumbnailKey: form.thumbnail.fileKey,
     instagramRedirectUrl: form.instagramRedirectUrl.trim(),
   }
 }
@@ -86,6 +98,7 @@ export const toUpdateMagazineBody = (
     body.instagramRedirectUrl = form.instagramRedirectUrl.trim()
   }
   if (form.banner) body.bannerKey = form.banner.fileKey
+  if (form.thumbnail) body.thumbnailKey = form.thumbnail.fileKey
   if (Object.keys(body).length === 0) {
     throw new Error('수정할 필드를 하나 이상 입력해주세요.')
   }

--- a/apps/admin/src/shared/api/adminApi.test.ts
+++ b/apps/admin/src/shared/api/adminApi.test.ts
@@ -3,7 +3,10 @@ import { magazineApi } from '@/shared/api/magazineApi'
 import { request } from '@/shared/api/request'
 import { reservationApi } from '@/shared/api/reservationApi'
 import { restaurantApi } from '@/shared/api/restaurantApi'
-import type { CreateRestaurantBody } from '@/shared/api/restaurantApi'
+import type {
+  AdminRestaurantData,
+  CreateRestaurantBody,
+} from '@/shared/api/restaurantApi'
 
 vi.mock('@/shared/api/request', () => ({
   request: vi.fn(),
@@ -74,8 +77,16 @@ describe('admin API contract', () => {
         { dayOfWeek: 'SUNDAY', closed: true },
       ],
     } satisfies CreateRestaurantBody
+    const response = {
+      restaurantId: 2,
+      name: body.name,
+      deleted: false,
+    } satisfies AdminRestaurantData
+    requestMock.mockResolvedValue(response)
 
-    await restaurantApi.createRestaurant(body)
+    await expect(restaurantApi.createRestaurant(body)).resolves.toEqual(
+      response,
+    )
 
     expect(requestMock).toHaveBeenCalledWith('/api/v1/admin/restaurants', {
       json: body,
@@ -85,8 +96,16 @@ describe('admin API contract', () => {
 
   it('updates a restaurant by numeric ID', async () => {
     const body = { name: 'Updated Hashi Sushi' }
+    const response = {
+      restaurantId: 2,
+      name: body.name,
+      deleted: false,
+    } satisfies AdminRestaurantData
+    requestMock.mockResolvedValue(response)
 
-    await restaurantApi.updateRestaurant(2, body)
+    await expect(restaurantApi.updateRestaurant(2, body)).resolves.toEqual(
+      response,
+    )
 
     expect(requestMock).toHaveBeenCalledWith('/api/v1/admin/restaurants/2', {
       json: body,
@@ -155,6 +174,7 @@ describe('admin API contract', () => {
     const body = {
       title: 'Tokyo Night',
       bannerKey: 'magazines/tokyo.webp',
+      thumbnailKey: 'magazines/tokyo-thumbnail.webp',
       instagramRedirectUrl: 'https://instagram.com/p/hashi',
     }
 

--- a/apps/admin/src/shared/api/generated/openapi.ts
+++ b/apps/admin/src/shared/api/generated/openapi.ts
@@ -94,8 +94,8 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * 매거진 등록 — bannerKey는 presigned URL로 업로드를 마친 S3 키.
-     * @description 매거진 등록 — bannerKey는 presigned URL로 업로드를 마친 S3 키.
+     * 매거진 등록 — bannerKey·thumbnailKey는 presigned URL로 업로드를 마친 S3 키.
+     * @description 매거진 등록 — bannerKey·thumbnailKey는 presigned URL로 업로드를 마친 S3 키.
      */
     post: operations['create_1']
     delete?: never
@@ -413,7 +413,7 @@ export interface components {
       priceCurrency?: string
       minPrice?: number
       maxPrice?: number
-      active?: boolean
+      deleted?: boolean
       imageUrls?: string[]
       menus?: components['schemas']['AdminRestaurantMenuResponse'][]
       hashtags?: string[]
@@ -486,7 +486,7 @@ export interface components {
       message?: string
       data?: components['schemas']['AdminReservationResponse']
     }
-    /** @description 어드민 매거진 등록 요청. bannerKey는 presigned URL로 업로드 완료된 S3 object key다. */
+    /** @description 어드민 매거진 등록 요청. bannerKey·thumbnailKey는 presigned URL로 업로드 완료된 S3 object key다. */
     CreateMagazineRequest: {
       /**
        * @description 매거진 제목
@@ -499,17 +499,23 @@ export interface components {
        */
       bannerKey: string
       /**
+       * @description 썸네일 이미지 S3 key(업로드 완료본)
+       * @example magazines/a1b2c3-thumbnail.jpg
+       */
+      thumbnailKey: string
+      /**
        * @description 배너 탭 시 이동할 인스타그램 URL
        * @example https://www.instagram.com/p/abc123/
        */
       instagramRedirectUrl: string
     }
-    /** @description 어드민 매거진 단건 응답(등록·수정 결과). bannerImageUrl은 저장된 키를 변환한 조회 URL이다. */
+    /** @description 어드민 매거진 단건 응답(등록·수정 결과). bannerImageUrl·thumbnailImageUrl은 저장된 키를 변환한 조회 URL이다. */
     AdminMagazineResponse: {
       /** Format: int64 */
       magazineId?: number
       title?: string
       bannerImageUrl?: string
+      thumbnailImageUrl?: string
       instagramRedirectUrl?: string
       /** Format: date-time */
       createdAt?: string
@@ -618,6 +624,11 @@ export interface components {
        * @example magazines/a1b2c3-new-banner.jpg
        */
       bannerKey?: string
+      /**
+       * @description 새 썸네일 이미지 S3 key(선택, 보내면 교체)
+       * @example magazines/a1b2c3-new-thumbnail.jpg
+       */
+      thumbnailKey?: string
       /**
        * @description 인스타그램 URL(선택)
        * @example https://www.instagram.com/p/def456/

--- a/apps/admin/src/shared/api/generated/user-openapi.ts
+++ b/apps/admin/src/shared/api/generated/user-openapi.ts
@@ -34,10 +34,10 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * 업로드용 presigned URL 발급 — 발급받은 URL로 파일을 PUT한 뒤, 응답의 key를 등록 API에 전달한다.
-     * @description 업로드용 presigned URL 발급 — 발급받은 URL로 파일을 PUT한 뒤, 응답의 key를 등록 API에 전달한다.
+     * 업로드용 presigned URL 벌크 발급 — 각 URL로 파일을 PUT한 뒤, 응답의 key를 등록 API에 전달한다.
+     * @description 업로드용 presigned URL 벌크 발급 — 각 URL로 파일을 PUT한 뒤, 응답의 key를 등록 API에 전달한다.
      */
-    post: operations['issuePresignedUrl']
+    post: operations['issuePresignedUrls']
     delete?: never
     options?: never
     head?: never
@@ -118,6 +118,28 @@ export interface paths {
      * @description 어디든 예약 생성 — 미등록 식당의 식당명·주소를 직접 입력. amount 규칙은 일반 예약과 동일.
      */
     post: operations['createAnywhere']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/dev/dummies': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * 더미 시나리오 생성 — 호출 1번에 식당 1곳·회원 10명·방문 완료 예약 10건·리뷰 10건을 넣는다.
+     * @description 더미 시나리오 생성 — 호출 1번에 식당 1곳·회원 10명·방문 완료 예약 10건·리뷰 10건을 넣는다.
+     *      공개 경로라 토큰 없이 호출할 수 있고, 응답의 sampleUser.accessToken을 Authorize에 붙이면
+     *      해당 더미 회원으로 예약·리뷰 API를 곧장 시험할 수 있다.
+     */
+    post: operations['createDummies']
     delete?: never
     options?: never
     head?: never
@@ -400,6 +422,22 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v1/restaurants/{restaurantId}/reviews/images': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getRestaurantReviewImages']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v1/restaurants/{restaurantId}/menus': {
     parameters: {
       query?: never
@@ -600,6 +638,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v1/dev/data': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /**
+     * DB 데이터 초기화 — 스키마·마이그레이션 이력·어드민 계정은 보존하고 나머지 모든 테이블을 비운다
+     *      (AUTO_INCREMENT도 1로 리셋).
+     * @description DB 데이터 초기화 — 스키마·마이그레이션 이력·어드민 계정은 보존하고 나머지 모든 테이블을 비운다
+     *      (AUTO_INCREMENT도 1로 리셋). 초기화 후 더미 시나리오를 다시 넣어 깨끗한 상태에서 시험할 수 있다.
+     */
+    delete: operations['clearData']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }
 export type webhooks = Record<string, never>
 export interface components {
@@ -650,13 +710,7 @@ export interface components {
       message?: string
       data?: components['schemas']['OnboardingResponse']
     }
-    /** @description presigned URL 발급 요청. */
-    IssuePresignedUrlRequest: {
-      /**
-       * @description 업로드 용도: profile / review / restaurant / restaurant-menu / magazine
-       * @example profile
-       */
-      usage: string
+    FileRequest: {
       /**
        * @description 파일 Content-Type
        * @example image/jpeg
@@ -664,10 +718,20 @@ export interface components {
       contentType: string
       /**
        * Format: int64
-       * @description 파일 크기(byte, 최대 5MB)
-       * @example 204800
+       * @description 파일 크기(byte, 파일당 최대 5MB)
+       * @example 1048576
        */
       fileSize: number
+    }
+    /** @description presigned URL 벌크 발급 요청. 한 요청의 파일은 모두 같은 업로드 용도를 사용한다. */
+    IssuePresignedUrlsRequest: {
+      /**
+       * @description 업로드 용도: profile / review / restaurant / restaurant-menu / magazine
+       * @example review
+       */
+      usage: string
+      /** @description 업로드할 파일 목록(1~10개) */
+      files: components['schemas']['FileRequest'][]
     }
     PresignedUrlResponse: {
       uploadUrl?: string
@@ -677,12 +741,15 @@ export interface components {
       expiresInSeconds?: number
       uploadMethod?: string
     }
+    PresignedUrlsResponse: {
+      uploads?: components['schemas']['PresignedUrlResponse'][]
+    }
     /** @description 성공 응답 봉투. <code>data</code>는 <code>null</code>이어도 항상 노출한다(클래스 단위 NON_NULL 미적용). */
-    SuccessResponsePresignedUrlResponse: {
+    SuccessResponsePresignedUrlsResponse: {
       success?: boolean
       code?: string
       message?: string
-      data?: components['schemas']['PresignedUrlResponse']
+      data?: components['schemas']['PresignedUrlsResponse']
     }
     /** @description 리뷰 작성 요청. 작성자는 인증 컨텍스트에서 확인하므로 요청에 포함하지 않는다. */
     CreateReviewRequest: {
@@ -714,7 +781,7 @@ export interface components {
       /**
        * @description 리뷰 이미지 S3 key 목록(선택, 최대 10개)
        * @example [
-       *       "reviews/a1b2c3-1.jpg"
+       *       "uploads/reviews/a1b2c3-1.jpg"
        *     ]
        */
       imageFileKeys?: string[]
@@ -748,7 +815,7 @@ export interface components {
       /**
        * Format: date-time
        * @description 예약 일시(미래 시각)
-       * @example 2026-08-01T19:00:00
+       * @example 2030-08-01T19:00:00
        */
       reservedAt: string
       /**
@@ -848,7 +915,7 @@ export interface components {
       /**
        * Format: date-time
        * @description 예약 일시(미래 시각)
-       * @example 2026-08-01T19:00:00
+       * @example 2030-08-01T19:00:00
        */
       reservedAt: string
       /**
@@ -886,6 +953,31 @@ export interface components {
        * @example 4000
        */
       amount: number
+    }
+    /**
+     * @description 더미 시나리오 생성 결과 — 생성된 각 도메인의 식별자 목록과, 바로 쓸 수 있는 대표 더미 유저 토큰.
+     *      sampleUser의 accessToken을 Authorize에 붙이면 그 유저의 예약·리뷰 조회가 곧장 동작한다.
+     */
+    DummyScenarioResponse: {
+      /** Format: int64 */
+      restaurantId?: number
+      userIds?: number[]
+      reservationIds?: number[]
+      reviewIds?: number[]
+      sampleUser?: components['schemas']['SampleUser']
+    }
+    /** @description 대표 더미 유저 — 생성된 첫 번째 유저와 그 명의의 USER 액세스 토큰. */
+    SampleUser: {
+      /** Format: int64 */
+      userId?: number
+      accessToken?: string
+    }
+    /** @description 성공 응답 봉투. <code>data</code>는 <code>null</code>이어도 항상 노출한다(클래스 단위 NON_NULL 미적용). */
+    SuccessResponseDummyScenarioResponse: {
+      success?: boolean
+      code?: string
+      message?: string
+      data?: components['schemas']['DummyScenarioResponse']
     }
     /** @description 성공 응답 봉투. <code>data</code>는 <code>null</code>이어도 항상 노출한다(클래스 단위 NON_NULL 미적용). */
     SuccessResponseVoid: {
@@ -1014,7 +1106,8 @@ export interface components {
       teenCount?: number
       /** Format: int32 */
       childCount?: number
-      reviewed?: boolean
+      /** @enum {string} */
+      reviewStatus?: 'UNREVIEWED' | 'REVIEWED' | 'DELETED'
       reviewable?: boolean
       /** @enum {string} */
       reviewUnavailableReason?:
@@ -1051,7 +1144,6 @@ export interface components {
       rating?: number
       content?: string
       keywords?: string[]
-      imageUrls?: string[]
       /** Format: date-time */
       createdAt?: string
     }
@@ -1153,6 +1245,7 @@ export interface components {
       foodCategory?: string
       summary?: string
       hashtags?: string[]
+      todayBusinessHour?: components['schemas']['TodayBusinessHourResponse']
     }
     /** @description 성공 응답 봉투. <code>data</code>는 <code>null</code>이어도 항상 노출한다(클래스 단위 NON_NULL 미적용). */
     SuccessResponseRestaurantListResponse: {
@@ -1160,6 +1253,13 @@ export interface components {
       code?: string
       message?: string
       data?: components['schemas']['RestaurantListResponse']
+    }
+    TodayBusinessHourResponse: {
+      date?: string
+      dayOfWeek?: string
+      openTime?: string
+      closeTime?: string
+      closed?: boolean
     }
     RestaurantMainResponse: {
       /** Format: int64 */
@@ -1246,7 +1346,9 @@ export interface components {
       rating?: number
       content?: string
       keywords?: string[]
-      imageUrls?: string[]
+      previewImageUrls?: string[]
+      /** Format: int32 */
+      imageCount?: number
       /** Format: date-time */
       createdAt?: string
     }
@@ -1256,6 +1358,26 @@ export interface components {
       code?: string
       message?: string
       data?: components['schemas']['RestaurantReviewResponse']
+    }
+    RestaurantReviewImageListResponse: {
+      content?: components['schemas']['RestaurantReviewImageResponse'][]
+      /** Format: int64 */
+      nextCursor?: number
+      hasNext?: boolean
+    }
+    RestaurantReviewImageResponse: {
+      /** Format: int64 */
+      imageId?: number
+      /** Format: int64 */
+      reviewId?: number
+      imageUrl?: string
+    }
+    /** @description 성공 응답 봉투. <code>data</code>는 <code>null</code>이어도 항상 노출한다(클래스 단위 NON_NULL 미적용). */
+    SuccessResponseRestaurantReviewImageListResponse: {
+      success?: boolean
+      code?: string
+      message?: string
+      data?: components['schemas']['RestaurantReviewImageListResponse']
     }
     RestaurantMenuListResponse: {
       content?: components['schemas']['RestaurantMenuResponse'][]
@@ -1352,9 +1474,12 @@ export interface components {
     /**
      * @description 내 예약 목록 응답(커서 페이지네이션). nextCursor는 다음 페이지 요청에 그대로 전달하며,
      *      hasNext가 false면 마지막 페이지라 nextCursor는 null이다.
+     *      totalCount는 커서와 무관하게 필터 조건에 맞는 전체 건수다.
      */
     ReservationListResponse: {
       reservations?: components['schemas']['ReservationResponse'][]
+      /** Format: int64 */
+      totalCount?: number
       /** Format: int64 */
       nextCursor?: number
       hasNext?: boolean
@@ -1396,6 +1521,7 @@ export interface components {
       magazineId?: number
       title?: string
       bannerImageUrl?: string
+      thumbnailImageUrl?: string
       instagramRedirectUrl?: string
       /** Format: date-time */
       createdAt?: string
@@ -1440,6 +1566,19 @@ export interface components {
       code?: string
       message?: string
       data?: components['schemas']['AuthMeResponse']
+    }
+    /** @description DB 데이터 초기화 결과 — 비운 테이블 목록. */
+    ClearDataResponse: {
+      /** Format: int32 */
+      clearedTableCount?: number
+      clearedTables?: string[]
+    }
+    /** @description 성공 응답 봉투. <code>data</code>는 <code>null</code>이어도 항상 노출한다(클래스 단위 NON_NULL 미적용). */
+    SuccessResponseClearDataResponse: {
+      success?: boolean
+      code?: string
+      message?: string
+      data?: components['schemas']['ClearDataResponse']
     }
   }
   responses: never
@@ -1511,7 +1650,7 @@ export interface operations {
       }
     }
   }
-  issuePresignedUrl: {
+  issuePresignedUrls: {
     parameters: {
       query?: never
       header?: never
@@ -1520,7 +1659,7 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['IssuePresignedUrlRequest']
+        'application/json': components['schemas']['IssuePresignedUrlsRequest']
       }
     }
     responses: {
@@ -1530,7 +1669,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          '*/*': components['schemas']['SuccessResponsePresignedUrlResponse']
+          '*/*': components['schemas']['SuccessResponsePresignedUrlsResponse']
           'application/json': unknown
         }
       }
@@ -1755,6 +1894,27 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
+  createDummies: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description 생성에 성공했습니다 */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['SuccessResponseDummyScenarioResponse']
           'application/json': unknown
         }
       }
@@ -2236,15 +2396,6 @@ export interface operations {
           'application/json': unknown
         }
       }
-      /** @description 에러 응답 */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
     }
   }
   getRestaurantSummary: {
@@ -2270,15 +2421,6 @@ export interface operations {
       }
       /** @description 에러 응답 */
       400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
-      /** @description 에러 응답 */
-      401: {
         headers: {
           [name: string]: unknown
         }
@@ -2320,15 +2462,6 @@ export interface operations {
       }
       /** @description 에러 응답 */
       400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
-      /** @description 에러 응답 */
-      401: {
         headers: {
           [name: string]: unknown
         }
@@ -2382,7 +2515,42 @@ export interface operations {
         }
       }
       /** @description 에러 응답 */
-      401: {
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
+  getRestaurantReviewImages: {
+    parameters: {
+      query?: {
+        cursor?: number
+        size?: number
+      }
+      header?: never
+      path: {
+        restaurantId: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description 요청에 성공했습니다 */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['SuccessResponseRestaurantReviewImageListResponse']
+          'application/json': unknown
+        }
+      }
+      /** @description 에러 응답 */
+      400: {
         headers: {
           [name: string]: unknown
         }
@@ -2435,15 +2603,6 @@ export interface operations {
         }
       }
       /** @description 에러 응답 */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
-      /** @description 에러 응답 */
       404: {
         headers: {
           [name: string]: unknown
@@ -2485,15 +2644,6 @@ export interface operations {
           'application/json': unknown
         }
       }
-      /** @description 에러 응답 */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
     }
   }
   getSearchKeywordRecommendations: {
@@ -2519,15 +2669,6 @@ export interface operations {
       }
       /** @description 에러 응답 */
       400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
-      /** @description 에러 응답 */
-      401: {
         headers: {
           [name: string]: unknown
         }
@@ -2664,15 +2805,6 @@ export interface operations {
           'application/json': unknown
         }
       }
-      /** @description 에러 응답 */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': unknown
-        }
-      }
     }
   }
   getBanners: {
@@ -2691,15 +2823,6 @@ export interface operations {
         }
         content: {
           '*/*': components['schemas']['SuccessResponseMagazineBannerListResponse']
-          'application/json': unknown
-        }
-      }
-      /** @description 에러 응답 */
-      401: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
           'application/json': unknown
         }
       }
@@ -2771,6 +2894,27 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
+          'application/json': unknown
+        }
+      }
+    }
+  }
+  clearData: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description 요청에 성공했습니다 */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['SuccessResponseClearDataResponse']
           'application/json': unknown
         }
       }

--- a/apps/admin/src/shared/api/uploadApi.test.ts
+++ b/apps/admin/src/shared/api/uploadApi.test.ts
@@ -21,9 +21,15 @@ describe('uploadApi', () => {
       type: 'image/webp',
     })
     requestMock.mockResolvedValue({
-      uploadUrl: 'https://upload.example/image',
-      fileKey: 'restaurant/image.webp',
-      fileUrl: 'https://cdn.example/image.webp',
+      uploads: [
+        {
+          uploadUrl: 'https://upload.example/image',
+          fileKey: 'restaurant/image.webp',
+          fileUrl: 'https://cdn.example/image.webp',
+          expiresInSeconds: 300,
+          uploadMethod: 'PUT',
+        },
+      ],
     })
     fetchMock.mockResolvedValue({ ok: true })
 
@@ -38,8 +44,7 @@ describe('uploadApi', () => {
       method: 'post',
       json: {
         usage: 'restaurant',
-        contentType: 'image/webp',
-        fileSize: 1024,
+        files: [{ contentType: 'image/webp', fileSize: 1024 }],
       },
     })
     expect(fetchMock).toHaveBeenCalledWith('https://upload.example/image', {
@@ -52,9 +57,15 @@ describe('uploadApi', () => {
   it('rejects when object storage returns a non-2xx response', async () => {
     const file = new File(['image'], 'image.png', { type: 'image/png' })
     requestMock.mockResolvedValue({
-      uploadUrl: 'https://upload.example/image',
-      fileKey: 'restaurant/image.png',
-      fileUrl: 'https://cdn.example/image.png',
+      uploads: [
+        {
+          uploadUrl: 'https://upload.example/image',
+          fileKey: 'restaurant/image.png',
+          fileUrl: 'https://cdn.example/image.png',
+          expiresInSeconds: 300,
+          uploadMethod: 'PUT',
+        },
+      ],
     })
     fetchMock.mockResolvedValue({ ok: false })
 

--- a/apps/admin/src/shared/api/uploadApi.ts
+++ b/apps/admin/src/shared/api/uploadApi.ts
@@ -1,8 +1,10 @@
 import { ADMIN_ENDPOINTS } from '@/shared/api/adminEndpoints'
-import type { components } from '@/shared/api/generated/user-openapi'
+import type { components, paths } from '@/shared/api/generated/user-openapi'
 import { request } from '@/shared/api/request'
 
-type PresignedUrlData = components['schemas']['PresignedUrlResponse']
+type IssuePresignedUrlsBody =
+  paths['/api/v1/uploads/presigned-urls']['post']['requestBody']['content']['application/json']
+type PresignedUrlsData = components['schemas']['PresignedUrlsResponse']
 
 export type UploadUsage = 'restaurant' | 'restaurant-menu' | 'magazine'
 
@@ -15,19 +17,20 @@ export interface UploadedImage {
 
 export const uploadApi = {
   async uploadImage(file: File, usage: UploadUsage): Promise<UploadedImage> {
-    const presigned = await request<PresignedUrlData>(
+    const body = {
+      usage,
+      files: [{ contentType: file.type, fileSize: file.size }],
+    } satisfies IssuePresignedUrlsBody
+    const presignedUrls = await request<PresignedUrlsData>(
       ADMIN_ENDPOINTS.presignedUpload,
       {
         method: 'post',
-        json: {
-          usage,
-          contentType: file.type,
-          fileSize: file.size,
-        },
+        json: body,
       },
     )
+    const presigned = presignedUrls.uploads?.[0]
 
-    if (!presigned.uploadUrl || !presigned.fileKey || !presigned.fileUrl) {
+    if (!presigned?.uploadUrl || !presigned.fileKey || !presigned.fileUrl) {
       throw new Error('업로드 URL 응답이 올바르지 않습니다.')
     }
 


### PR DESCRIPTION
## 📌 Summary

운영 서버의 최신 OpenAPI와 어드민 이미지 업로드·식당·매거진 계약을 동기화했습니다.

Jira: HASHI-119

## 📚 Tasks

- admin/user Swagger OpenAPI 타입 최신화
- presigned URL 요청을 `files` 배열, 응답을 `uploads` 배열 형식으로 수정
- 식당 생성·수정 응답의 `active` 필드를 `deleted`로 변경
- 매거진 배너·썸네일 업로드를 분리하고 필수 `thumbnailKey` 반영
- API 계약 및 매거진 폼 회귀 테스트·스펙 갱신

## 🔎 Description

기존 어드민은 단일 파일 presigned 계약을 사용해 최신 서버가 요구하는 `files` 검증에서 400 응답이 발생했습니다. 공용 업로드 API를 최신 벌크 계약에 맞춰 식당, 메뉴, 매거진 업로드가 동일한 요청·응답 경계를 사용하도록 수정했습니다.

최신 서버 계약에서 추가된 매거진 썸네일은 별도 업로드 상태로 관리하며, 생성 시 배너와 썸네일을 모두 요구하고 수정 시 새로 업로드한 이미지만 PATCH body에 포함합니다.

식당 검색 기능은 기존 공개 식당 목록의 `keyword` 검색으로 이미 구현돼 있어 이번 diff에는 별도 변경을 포함하지 않았습니다.

## ✅ Verification

- [x] `pnpm --filter @hashi/admin lint`
- [x] `pnpm --filter @hashi/admin typecheck`
- [x] `pnpm --filter @hashi/admin test` — 23 files, 62 tests
- [x] `pnpm --filter @hashi/admin build`
- [x] `git diff --check`

## 👀 To Reviewer

- `user-openapi.ts`는 최신 Swagger 전체를 재생성해 업로드 계약 외의 최신 user schema 변경도 함께 포함합니다.
- 실제 운영 계정과 S3를 사용하는 라이브 업로드는 외부 데이터 생성을 피하기 위해 수행하지 않았습니다.
