### PR TITLE
Feat(admin): HASHI-121 Admin Vercel workflow 분리

### DIFF
--- a/.github/workflows/vercel-admin-preview.yml
+++ b/.github/workflows/vercel-admin-preview.yml
@@ -1,33 +1,33 @@
-name: Vercel Preview Deployment
+name: Vercel Admin Preview Deployment
 
 on:
   pull_request:
     paths:
-      - '.github/workflows/vercel-preview.yml'
-      - 'apps/client/**'
+      - '.github/workflows/vercel-admin-preview.yml'
+      - 'apps/admin/**'
       - 'configs/**'
       - 'packages/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'turbo.json'
-      - 'vercel.json'
+      - 'vercel.admin.json'
   push:
     branches:
       - develop
     paths:
-      - '.github/workflows/vercel-preview.yml'
-      - 'apps/client/**'
+      - '.github/workflows/vercel-admin-preview.yml'
+      - 'apps/admin/**'
       - 'configs/**'
       - 'packages/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'turbo.json'
-      - 'vercel.json'
+      - 'vercel.admin.json'
 
 concurrency:
-  group: vercel-preview-${{ github.event.pull_request.number || github.ref }}
+  group: vercel-admin-preview-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -35,16 +35,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  deploy-preview:
+  deploy-admin-preview:
     runs-on: ubuntu-latest
 
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-      VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_ADMIN_PROJECT_ID }}
 
     steps:
       - name: Checkout
@@ -62,19 +58,19 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Pull Vercel Environment
-        run: pnpm exec vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Pull Admin Vercel Environment
+        run: pnpm exec vercel pull --yes --environment=preview --local-config=vercel.admin.json --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Build Vercel Output
-        run: pnpm exec vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Admin Vercel Output
+        run: pnpm exec vercel build --local-config=vercel.admin.json --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Deploy Preview
+      - name: Deploy Admin Preview
         id: deploy
         run: |
-          url=$(pnpm exec vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          url=$(pnpm exec vercel deploy --prebuilt --local-config=vercel.admin.json --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
-      - name: Comment Preview URL
+      - name: Comment Admin Preview URL
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -83,5 +79,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🚀 Client Preview deployed: ${{ steps.deploy.outputs.url }}`,
+              body: `🚀 Admin Preview deployed: ${{ steps.deploy.outputs.url }}`,
             })

--- a/.github/workflows/vercel-admin-production.yml
+++ b/.github/workflows/vercel-admin-production.yml
@@ -1,0 +1,62 @@
+name: Vercel Admin Production Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/vercel-admin-production.yml'
+      - 'apps/admin/**'
+      - 'configs/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'vercel.admin.json'
+
+concurrency:
+  group: vercel-admin-production-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-admin-production:
+    runs-on: ubuntu-latest
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_ADMIN_PROJECT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint Admin
+        run: pnpm --filter @hashi/admin lint
+
+      - name: Format Check
+        run: pnpm format:check
+
+      - name: Typecheck Admin
+        run: pnpm --filter @hashi/admin typecheck
+
+      - name: Pull Admin Vercel Environment
+        run: pnpm exec vercel pull --yes --environment=production --local-config=vercel.admin.json --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Admin Vercel Output
+        run: pnpm exec vercel build --prod --local-config=vercel.admin.json --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Admin Production
+        run: pnpm exec vercel deploy --prebuilt --prod --local-config=vercel.admin.json --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/vercel-production.yml'
+      - 'apps/client/**'
+      - 'configs/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'vercel.json'
 
 concurrency:
   group: vercel-production-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@
 
 기본 `vercel.json`은 client 배포용입니다. Admin은 별도 Vercel project에서 `vercel.admin.json`을 사용합니다.
 
+GitHub Actions는 client와 admin 배포 workflow를 분리합니다. Admin workflow는
+`VERCEL_ADMIN_PROJECT_ID` repository secret으로 Admin Vercel project를 선택하고,
+`vercel.admin.json`을 명시적으로 사용합니다.
+
 ```bash
 pnpm exec vercel build --local-config vercel.admin.json
 pnpm exec vercel deploy --prebuilt --local-config vercel.admin.json

--- a/docs/workflows/pr-checklist.md
+++ b/docs/workflows/pr-checklist.md
@@ -122,7 +122,10 @@ UI 변경:
 ## GitHub Actions Roles
 
 - `ci.yml`: format, lint, typecheck, test, build를 병렬 실행하는 코드 품질 gate입니다.
-- `vercel-preview.yml`: preview 배포만 담당합니다.
+- `vercel-preview.yml`: client preview 배포만 담당합니다.
+- `vercel-production.yml`: client production 배포만 담당합니다.
+- `vercel-admin-preview.yml`: admin preview 배포만 담당합니다.
+- `vercel-admin-production.yml`: admin production 배포만 담당합니다.
 - `chromatic.yml`: HDS Storybook/Chromatic 검증만 담당하며, HDS 관련 경로가 바뀐 PR에서 실행됩니다.
 - auto-label, auto-assign, Discord workflow는 PR 운영 자동화를 담당합니다.
 


### PR DESCRIPTION
## 📌 Summary

Client와 Admin의 Vercel 배포 workflow를 분리해 각 앱이 별도 Vercel 프로젝트와 설정 파일을 사용하도록 구성했습니다.

Jira: HASHI-121

## 📚 Tasks

- Admin 전용 Preview 및 Production workflow 추가
- Admin 배포에서 `VERCEL_ADMIN_PROJECT_ID` 사용
- Admin 배포 명령에 `vercel.admin.json` 명시
- Client Preview 및 Production workflow에 앱별 경로 필터 추가
- 공통 package 및 config 변경 시 Client와 Admin 배포가 모두 실행되도록 설정
- README와 GitHub Actions 역할 문서 동기화

## 🔎 Description

기존 workflow는 root `vercel.json`과 Client용 `VERCEL_PROJECT_ID`만 사용해서  Admin도  Client Preview URL를 생성하는 문제점을 확인해서 해당 문제를 해결하기위해 Admin 프로젝트 ID를 생성해 워크플로를 분리했습니다. 

Admin workflow는 `VERCEL_ADMIN_PROJECT_ID`로 `hashi-admin` 프로젝트를 선택하고, `--local-config=vercel.admin.json`을 `pull`, `build`, `deploy` 전 단계에 적용합니다. Client workflow는 기존 프로젝트 연결을 유지합니다.

앱별 경로 필터를 적용해 Admin 전용 변경에서는 Admin 배포만, Client 전용 변경에서는 Client 배포만 실행됩니다. `packages`, `configs`, lockfile 등 공통 의존성이 변경되면 두 앱의 배포가 모두 실행됩니다.

## To reviewer 

이번 PR은 예외적으로 기존 Client workflow 파일인 .github/workflows/vercel-preview.yml도 함께 수정해서 해당 파일이 Client workflow의 경로에 포함돼 있어서 Client Preview도 한번 같이 실행된 거에요~~~ 

