### PR TITLE
Feat(client): HASHI-111 하시픽 / 인기맛집 페이지 API 연동

### DIFF
--- a/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AuthSessionRestoreGate } from '@/app/providers/AuthSessionRestoreGate'
+import { ROUTES } from '@/app/router/path'
 import { getAuthMe } from '@/features/auth/api/getAuthMe'
 import { requestTokenReissue } from '@/features/auth/api/reissueToken'
 import {
@@ -45,6 +46,7 @@ describe('AuthSessionRestoreGate', () => {
     mockedGetAuthMe.mockReset()
     mockedGetApiAccessToken.mockReset()
     clearAuthSession()
+    window.history.pushState({}, '', '/')
   })
 
   it('restores access token before rendering children', async () => {
@@ -104,6 +106,29 @@ describe('AuthSessionRestoreGate', () => {
     })
     expect(mockedGetAuthMe).toHaveBeenCalledWith()
     expect(getAuthSessionStatus()).toBe('onboarding')
+  })
+
+  it('renders public restaurant list routes while auth restore runs in the background', async () => {
+    mockedRequestTokenReissue.mockResolvedValue({
+      accessToken: 'restored-access-token',
+    })
+    window.history.pushState({}, '', ROUTES.hashiPickRestaurants)
+
+    render(
+      <AuthSessionRestoreGate>
+        <div>하시픽 화면</div>
+      </AuthSessionRestoreGate>,
+    )
+
+    expect(screen.getByText('하시픽 화면')).toBeInTheDocument()
+    expect(
+      screen.queryByText('로그인 상태를 확인하고 있어요'),
+    ).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(getAccessToken()).toBe('restored-access-token')
+    })
+    expect(mockedRequestTokenReissue).toHaveBeenCalledTimes(1)
   })
 
   it('does not authenticate an admin session in the user client', async () => {

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 
+import { ROUTES } from '@/app/router/path'
 import { getAuthMe } from '@/features/auth/api/getAuthMe'
 import { requestTokenReissue } from '@/features/auth/api/reissueToken'
 import {
@@ -16,6 +17,19 @@ interface AuthSessionRestoreGateProps {
 }
 
 let authSessionRestorePromise: Promise<void> | undefined
+
+const AUTH_RESTORE_NON_BLOCKING_PATHS = new Set<string>([
+  ROUTES.hashiPickRestaurants,
+  ROUTES.popularRestaurants,
+])
+
+const getShouldRenderDuringAuthRestore = () => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  return AUTH_RESTORE_NON_BLOCKING_PATHS.has(window.location.pathname)
+}
 
 const restoreUserSession = async (accessToken: string) => {
   const authMe = await getAuthMe(accessToken)
@@ -72,8 +86,8 @@ const restoreAuthSession = async () => {
 export const AuthSessionRestoreGate = ({
   children,
 }: AuthSessionRestoreGateProps) => {
-  const [isRestoreCompleted, setIsRestoreCompleted] = useState(() =>
-    Boolean(getAccessToken()),
+  const [isRestoreCompleted, setIsRestoreCompleted] = useState(
+    () => Boolean(getAccessToken()) || getShouldRenderDuringAuthRestore(),
   )
 
   useEffect(() => {

--- a/apps/client/src/app/router/lazy.test.tsx
+++ b/apps/client/src/app/router/lazy.test.tsx
@@ -35,6 +35,18 @@ vi.mock(
 )
 
 vi.mock(
+  '@/pages/hashiPick',
+  () =>
+    new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          default: () => <main>하시픽 화면</main>,
+        })
+      }, 200)
+    }),
+)
+
+vi.mock(
   '@/pages/myReviews',
   () =>
     new Promise((resolve) => {
@@ -113,6 +125,28 @@ describe('route lazy fallback', () => {
     })
 
     expect(screen.getByText('로그인 필요 페이지')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('does not show LoadingScreen for restaurant list routes that render page skeletons', async () => {
+    vi.useFakeTimers()
+
+    const router = createMemoryRouter(appRoutes, {
+      initialEntries: ['/restaurants/hashi-pick'],
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150)
+    })
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(850)
+    })
+
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 

--- a/apps/client/src/app/router/lazy.ts
+++ b/apps/client/src/app/router/lazy.ts
@@ -141,6 +141,10 @@ export const withLazyFallback = (element: ReactNode) => {
   return createElement(RouteLoadingBoundary, null, element)
 }
 
+export const withSilentLazyFallback = (element: ReactNode) => {
+  return createElement(Suspense, { fallback: null }, element)
+}
+
 export const lazyPages = {
   comingSoon: () => lazyPage(ComingSoonPage),
   search: () => lazyPage(SearchPage),

--- a/apps/client/src/app/router/routes.test.tsx
+++ b/apps/client/src/app/router/routes.test.tsx
@@ -1,13 +1,23 @@
 import '@testing-library/jest-dom/vitest'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
 import { RouterProvider, createMemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ROUTES } from '@/app/router/path'
 import { appRoutes } from '@/app/router/routes'
+import { createQueryClient } from '@/shared/lib/queryClient'
 
 vi.mock('@/features/magazine/api/getMagazineBanners', () => ({
   getMagazineBanners: vi.fn(async () => ({ banners: [] })),
+}))
+
+vi.mock('@/features/restaurantList/api/getRestaurants', () => ({
+  getRestaurants: vi.fn(async () => ({
+    hasNext: false,
+    nextCursor: undefined,
+    restaurants: [],
+  })),
 }))
 
 const collectRoutePaths = (routes: typeof appRoutes): string[] => {
@@ -21,8 +31,13 @@ const renderRoute = (initialEntry: string) => {
   const router = createMemoryRouter(appRoutes, {
     initialEntries: [initialEntry],
   })
+  const queryClient = createQueryClient()
 
-  return render(<RouterProvider router={router} />)
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 describe('appRoutes', () => {

--- a/apps/client/src/app/router/routes.ts
+++ b/apps/client/src/app/router/routes.ts
@@ -3,7 +3,11 @@ import type { RouteObject } from 'react-router-dom'
 
 import { BottomNavigationLayout } from '@/app/layout/BottomNavigationLayout'
 import { RootLayout } from '@/app/layout/RootLayout'
-import { lazyPages, withLazyFallback } from '@/app/router/lazy'
+import {
+  lazyPages,
+  withLazyFallback,
+  withSilentLazyFallback,
+} from '@/app/router/lazy'
 import { ROUTES } from '@/app/router/path'
 import { AuthOnlyRoute, GuestOnlyRoute } from '@/app/router/RouteGuards'
 import { HomePage } from '@/pages/home'
@@ -48,11 +52,11 @@ export const appRoutes: RouteObject[] = [
       },
       {
         path: ROUTES.hashiPickRestaurants,
-        element: withLazyFallback(lazyPages.hashiPick()),
+        element: withSilentLazyFallback(lazyPages.hashiPick()),
       },
       {
         path: ROUTES.popularRestaurants,
-        element: withLazyFallback(lazyPages.popularRestaurants()),
+        element: withSilentLazyFallback(lazyPages.popularRestaurants()),
       },
       {
         path: ROUTES.magazines,

--- a/apps/client/src/features/restaurantList/RestaurantListPage.tsx
+++ b/apps/client/src/features/restaurantList/RestaurantListPage.tsx
@@ -23,22 +23,23 @@ const renderSkeletonItems = (count: number) => {
   return Array.from({ length: count }, (_, index) => (
     <li
       aria-hidden="true"
-      className="border-warm-gray-50 w-full border-b py-4.75"
+      className="border-warm-gray-50 w-full border-b py-4.75 last:border-b-0"
+      data-testid="restaurant-list-skeleton-item"
       key={index}
     >
       <div className="flex flex-col">
-        <div className="bg-cool-gray-100 h-5 w-40 animate-pulse rounded" />
-        <div className="bg-cool-gray-100 mt-2 h-5 w-28 animate-pulse rounded" />
+        <div className="bg-secondary-200 h-5 w-40 animate-pulse rounded" />
+        <div className="bg-secondary-200 mt-2 h-5 w-28 animate-pulse rounded" />
         <div className="mt-2.75 flex gap-2">
           {Array.from({ length: 3 }, (_, imageIndex) => (
             <div
-              className="bg-cool-gray-100 h-[143px] w-[143px] shrink-0 animate-pulse rounded-[5px]"
+              className="bg-secondary-200 h-[143px] w-[143px] shrink-0 animate-pulse rounded-[5px]"
               key={imageIndex}
             />
           ))}
         </div>
-        <div className="bg-cool-gray-100 mt-3 h-4 w-full animate-pulse rounded" />
-        <div className="bg-cool-gray-100 mt-2 h-4 w-3/4 animate-pulse rounded" />
+        <div className="bg-secondary-200 mt-3 h-4 w-full animate-pulse rounded" />
+        <div className="bg-secondary-200 mt-2 h-4 w-3/4 animate-pulse rounded" />
       </div>
     </li>
   ))

--- a/apps/client/src/features/restaurantList/RestaurantListPage.tsx
+++ b/apps/client/src/features/restaurantList/RestaurantListPage.tsx
@@ -1,5 +1,5 @@
 import { BackIcon } from '@hashi/hds-icons'
-import { Header, IconButton } from '@hashi/hds-ui'
+import { Button, Header, IconButton } from '@hashi/hds-ui'
 
 import {
   CATEGORY_OPTIONS,
@@ -7,18 +7,46 @@ import {
   RestaurantFilterBar,
   useRestaurantListPage,
 } from '@/features/restaurantList'
-import type { FilterOption, Restaurant } from '@/features/restaurantList'
+import type {
+  FilterOption,
+  RestaurantListCurationType,
+} from '@/features/restaurantList'
 import { FilterBottomSheet } from '@/shared/components/filterBottomSheet'
 
 type RestaurantListPageProps = {
   title: string
-  restaurants: Restaurant[]
+  restaurantType: RestaurantListCurationType
   sortOptions: FilterOption[]
+}
+
+const renderSkeletonItems = (count: number) => {
+  return Array.from({ length: count }, (_, index) => (
+    <li
+      aria-hidden="true"
+      className="border-warm-gray-50 w-full border-b py-4.75"
+      key={index}
+    >
+      <div className="flex flex-col">
+        <div className="bg-cool-gray-100 h-5 w-40 animate-pulse rounded" />
+        <div className="bg-cool-gray-100 mt-2 h-5 w-28 animate-pulse rounded" />
+        <div className="mt-2.75 flex gap-2">
+          {Array.from({ length: 3 }, (_, imageIndex) => (
+            <div
+              className="bg-cool-gray-100 h-[143px] w-[143px] shrink-0 animate-pulse rounded-[5px]"
+              key={imageIndex}
+            />
+          ))}
+        </div>
+        <div className="bg-cool-gray-100 mt-3 h-4 w-full animate-pulse rounded" />
+        <div className="bg-cool-gray-100 mt-2 h-4 w-3/4 animate-pulse rounded" />
+      </div>
+    </li>
+  ))
 }
 
 export const RestaurantListPage = ({
   title,
-  restaurants,
+  restaurantType,
   sortOptions,
 }: RestaurantListPageProps) => {
   const {
@@ -27,6 +55,9 @@ export const RestaurantListPage = ({
     draftCategory,
     draftSort,
     hasMoreRestaurants,
+    isError,
+    isFetchingNextPage,
+    isLoading,
     loadMoreRef,
     selectedSort,
     visibleRestaurants,
@@ -39,12 +70,19 @@ export const RestaurantListPage = ({
     handleOpenSortSheet,
     handleResetCategory,
     handleResetSort,
+    handleRetry,
     handleSelectCategory,
     handleSelectSort,
   } = useRestaurantListPage({
-    restaurants,
+    restaurantType,
     sortOptions,
   })
+  const shouldRenderEmptyState =
+    visibleRestaurants.length === 0 &&
+    !hasMoreRestaurants &&
+    !isFetchingNextPage
+  const shouldRenderList =
+    visibleRestaurants.length > 0 || hasMoreRestaurants || isFetchingNextPage
 
   return (
     <div className="min-h-dvh bg-white">
@@ -75,26 +113,57 @@ export const RestaurantListPage = ({
           sortLabel={selectedSort.label}
         />
 
-        <ul
-          className="mx-auto flex w-full flex-col gap-1 px-5"
-          data-testid="restaurant-list"
-        >
-          {visibleRestaurants.map((restaurant) => (
-            <RestaurantCard
-              key={restaurant.id}
-              onClick={handleClickRestaurant}
-              restaurant={restaurant}
-            />
-          ))}
-          {hasMoreRestaurants && (
-            <li
-              aria-hidden="true"
-              className="h-px"
-              data-testid="restaurant-list-load-more"
-              ref={loadMoreRef}
-            />
-          )}
-        </ul>
+        {isLoading ? (
+          <ul
+            aria-label={`${title} 식당 목록 로딩 중`}
+            className="mx-auto flex w-full flex-col gap-1 px-5"
+            data-testid="restaurant-list"
+          >
+            {renderSkeletonItems(3)}
+          </ul>
+        ) : isError ? (
+          <div className="flex min-h-[360px] flex-col items-center justify-center gap-4 px-5 text-center">
+            <p className="typo-body-4 text-primary-200">
+              식당 목록을 불러오지 못했습니다.
+            </p>
+            <Button onClick={handleRetry} size="sm" variant="neutral">
+              다시 시도
+            </Button>
+          </div>
+        ) : (
+          <>
+            {shouldRenderList ? (
+              <ul
+                className="mx-auto flex w-full flex-col gap-1 px-5"
+                data-testid="restaurant-list"
+              >
+                {visibleRestaurants.map((restaurant) => (
+                  <RestaurantCard
+                    key={restaurant.id}
+                    onClick={handleClickRestaurant}
+                    restaurant={restaurant}
+                  />
+                ))}
+                {hasMoreRestaurants && (
+                  <li
+                    aria-hidden="true"
+                    className="h-px"
+                    data-testid="restaurant-list-load-more"
+                    ref={loadMoreRef}
+                  />
+                )}
+                {isFetchingNextPage ? renderSkeletonItems(1) : null}
+              </ul>
+            ) : null}
+            {shouldRenderEmptyState ? (
+              <div className="flex min-h-[360px] items-center justify-center px-5 text-center">
+                <p className="typo-body-4 text-warm-gray-300">
+                  표시할 식당이 없습니다.
+                </p>
+              </div>
+            ) : null}
+          </>
+        )}
       </div>
 
       <FilterBottomSheet

--- a/apps/client/src/features/restaurantList/components/RestaurantCard.tsx
+++ b/apps/client/src/features/restaurantList/components/RestaurantCard.tsx
@@ -19,7 +19,7 @@ export const RestaurantCard = ({
   }
 
   return (
-    <li className="border-warm-gray-50 w-full border-b py-4.75">
+    <li className="border-warm-gray-50 w-full border-b py-4.75 last:border-b-0">
       <button
         className="flex w-full flex-col text-left"
         onClick={handleClickRestaurant}

--- a/apps/client/src/features/restaurantList/components/RestaurantCard.tsx
+++ b/apps/client/src/features/restaurantList/components/RestaurantCard.tsx
@@ -12,6 +12,8 @@ export const RestaurantCard = ({
   restaurant,
   onClick,
 }: RestaurantCardProps) => {
+  const ratingLabel = restaurant.rating.toFixed(1)
+
   const handleClickRestaurant = () => {
     onClick(restaurant.id)
   }
@@ -31,7 +33,7 @@ export const RestaurantCard = ({
             aria-hidden="true"
             className="text-primary-400 size-4.5 shrink-0"
           />
-          <span className="typo-body-3 ml-px">{restaurant.rating}</span>
+          <span className="typo-body-3 ml-px">{ratingLabel}</span>
           <span className="typo-body-7 ml-1.25">
             {restaurant.region} · {restaurant.category}
           </span>

--- a/apps/client/src/features/restaurantList/components/RestaurantImageList.tsx
+++ b/apps/client/src/features/restaurantList/components/RestaurantImageList.tsx
@@ -1,4 +1,3 @@
-import { RESTAURANT_IMAGE_SLOT_COUNT } from '@/features/restaurantList/constants'
 import { DefaultImage } from '@/shared/components/defaultImage'
 
 type RestaurantImageListProps = {
@@ -10,34 +9,29 @@ export const RestaurantImageList = ({
   images,
   restaurantName,
 }: RestaurantImageListProps) => {
-  const imageSlots = Array.from({ length: RESTAURANT_IMAGE_SLOT_COUNT })
-
   return (
     <span
       className="block w-full [scrollbar-width:none] overflow-x-auto overflow-y-hidden [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
       data-testid="restaurant-image-list"
     >
       <span className="flex w-max gap-2">
-        {imageSlots.map((_, index) => {
-          const image = images[index]
-
-          return image ? (
+        {images.length > 0 ? (
+          images.map((image, index) => (
             <img
               alt={`${restaurantName} 사진 ${index + 1}`}
               className="size-33.75 shrink-0 rounded-[5px] object-cover"
               key={`${image}-${index}`}
               src={image}
             />
-          ) : (
-            <DefaultImage
-              aria-hidden="true"
-              className="size-33.75 shrink-0 rounded-[5px]"
-              data-testid="restaurant-image-placeholder"
-              key={`placeholder-${index}`}
-              logoSize="md"
-            />
-          )
-        })}
+          ))
+        ) : (
+          <DefaultImage
+            aria-hidden="true"
+            className="size-33.75 shrink-0 rounded-[5px]"
+            data-testid="restaurant-image-placeholder"
+            logoSize="md"
+          />
+        )}
       </span>
     </span>
   )

--- a/apps/client/src/features/restaurantList/hooks/useRestaurantListPage.ts
+++ b/apps/client/src/features/restaurantList/hooks/useRestaurantListPage.ts
@@ -1,19 +1,27 @@
-import { useState } from 'react'
-import { generatePath, useNavigate } from 'react-router-dom'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
 import {
   CATEGORY_OPTIONS,
   DEFAULT_CATEGORY_OPTION,
-  RESTAURANT_LIST_PAGE_SIZE,
 } from '@/features/restaurantList/constants'
-import { useInfiniteRestaurantList } from '@/features/restaurantList/hooks/useInfiniteRestaurantList'
-import type { FilterOption, Restaurant } from '@/features/restaurantList/types'
+import { restaurantsInfiniteQueryOptions } from '@/features/restaurantList/queries/useRestaurantsInfiniteQuery'
+import type {
+  FilterOption,
+  RestaurantListCurationType,
+} from '@/features/restaurantList/types'
+import {
+  createRestaurantListRequestParams,
+  mapRestaurantSummaryToRestaurant,
+} from '@/features/restaurantList/utils'
+import { useInfiniteScrollTrigger } from '@/shared/hooks'
 
 type ActiveBottomSheet = 'sort' | 'category' | null
 
 type UseRestaurantListPageParams = {
-  restaurants: Restaurant[]
+  restaurantType: RestaurantListCurationType
   sortOptions: FilterOption[]
 }
 
@@ -21,8 +29,15 @@ const getOptionByValue = (options: FilterOption[], value: string) => {
   return options.find((option) => option.value === value)
 }
 
+const getRestaurantDetailPath = (restaurantId: string) => {
+  return ROUTES.restaurantDetail.replace(
+    ':restaurantId',
+    encodeURIComponent(restaurantId),
+  )
+}
+
 export const useRestaurantListPage = ({
-  restaurants,
+  restaurantType,
   sortOptions,
 }: UseRestaurantListPageParams) => {
   const navigate = useNavigate()
@@ -35,14 +50,34 @@ export const useRestaurantListPage = ({
     DEFAULT_CATEGORY_OPTION,
   )
   const [draftCategory, setDraftCategory] = useState(DEFAULT_CATEGORY_OPTION)
-  const {
-    hasMoreItems: hasMoreRestaurants,
-    loadMoreRef,
-    visibleItems: visibleRestaurants,
-  } = useInfiniteRestaurantList({
-    items: restaurants,
-    pageSize: RESTAURANT_LIST_PAGE_SIZE,
+
+  const requestParams = useMemo(
+    () =>
+      createRestaurantListRequestParams({
+        category: selectedCategory,
+        sort: selectedSort,
+        type: restaurantType,
+      }),
+    [restaurantType, selectedCategory, selectedSort],
+  )
+  const restaurantsQuery = useInfiniteQuery({
+    ...restaurantsInfiniteQueryOptions(requestParams),
+    throwOnError: false,
   })
+  const loadMoreRef = useInfiniteScrollTrigger<HTMLLIElement>({
+    enabled: Boolean(restaurantsQuery.hasNextPage),
+    isLoading: restaurantsQuery.isFetchingNextPage,
+    onIntersect: restaurantsQuery.fetchNextPage,
+  })
+  const visibleRestaurants =
+    restaurantsQuery.data?.pages.flatMap((page) =>
+      page.restaurants.flatMap((restaurant) => {
+        const mappedRestaurant = mapRestaurantSummaryToRestaurant(restaurant)
+
+        return mappedRestaurant ? [mappedRestaurant] : []
+      }),
+    ) ?? []
+  const hasMoreRestaurants = Boolean(restaurantsQuery.hasNextPage)
 
   const categoryLabel =
     selectedCategory.value === DEFAULT_CATEGORY_OPTION.value
@@ -104,7 +139,11 @@ export const useRestaurantListPage = ({
   }
 
   const handleClickRestaurant = (restaurantId: string) => {
-    navigate(generatePath(ROUTES.restaurantDetail, { restaurantId }))
+    navigate(getRestaurantDetailPath(restaurantId))
+  }
+
+  const handleRetry = () => {
+    void restaurantsQuery.refetch()
   }
 
   return {
@@ -113,6 +152,9 @@ export const useRestaurantListPage = ({
     draftCategory,
     draftSort,
     hasMoreRestaurants,
+    isFetchingNextPage: restaurantsQuery.isFetchingNextPage,
+    isLoading: restaurantsQuery.isLoading,
+    isError: restaurantsQuery.isError,
     loadMoreRef,
     selectedSort,
     visibleRestaurants,
@@ -125,6 +167,7 @@ export const useRestaurantListPage = ({
     handleOpenSortSheet,
     handleResetCategory,
     handleResetSort,
+    handleRetry,
     handleSelectCategory,
     handleSelectSort,
   }

--- a/apps/client/src/features/restaurantList/index.ts
+++ b/apps/client/src/features/restaurantList/index.ts
@@ -10,7 +10,11 @@ export { MOCK_RESTAURANTS } from './mocks'
 export { useInfiniteRestaurantList } from './hooks'
 export { useRestaurantListPage } from './hooks'
 export { RestaurantCard, RestaurantFilterBar } from './components'
-export type { FilterOption, Restaurant } from './types'
+export type {
+  FilterOption,
+  Restaurant,
+  RestaurantListCurationType,
+} from './types'
 export { getRestaurants } from './api/getRestaurants'
 export type {
   GetRestaurantsParams,

--- a/apps/client/src/features/restaurantList/types.ts
+++ b/apps/client/src/features/restaurantList/types.ts
@@ -3,6 +3,8 @@ export type FilterOption = {
   value: string
 }
 
+export type RestaurantListCurationType = 'hashi-pick' | 'popular'
+
 export type Restaurant = {
   id: string
   name: string

--- a/apps/client/src/features/restaurantList/utils/createRestaurantListRequestParams.test.ts
+++ b/apps/client/src/features/restaurantList/utils/createRestaurantListRequestParams.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { createRestaurantListRequestParams } from '@/features/restaurantList/utils/createRestaurantListRequestParams'
+
+describe('createRestaurantListRequestParams', () => {
+  it('maps hashi pick default filters to restaurant list API params', () => {
+    expect(
+      createRestaurantListRequestParams({
+        category: { label: '전체', value: 'all' },
+        sort: { label: '기본순', value: 'default' },
+        type: 'hashi-pick',
+      }),
+    ).toEqual({
+      genre: 'all',
+      size: 10,
+      sort: 'basic',
+      type: 'hashi-pick',
+    })
+  })
+
+  it('normalizes rice bowl category and rating sort for popular restaurants', () => {
+    expect(
+      createRestaurantListRequestParams({
+        category: { label: '덮밥류', value: 'riceBowl' },
+        sort: { label: '별점순', value: 'rating' },
+        type: 'popular',
+      }),
+    ).toEqual({
+      genre: 'rice-bowl',
+      size: 10,
+      sort: 'rating',
+      type: 'popular',
+    })
+  })
+})

--- a/apps/client/src/features/restaurantList/utils/createRestaurantListRequestParams.ts
+++ b/apps/client/src/features/restaurantList/utils/createRestaurantListRequestParams.ts
@@ -1,0 +1,48 @@
+import type { GetRestaurantsParams } from '@/features/restaurantList/api/getRestaurants'
+import { RESTAURANT_LIST_PAGE_SIZE } from '@/features/restaurantList/constants'
+import type {
+  FilterOption,
+  RestaurantListCurationType,
+} from '@/features/restaurantList/types'
+
+const apiGenreByCategory: Record<
+  string,
+  NonNullable<GetRestaurantsParams['genre']>
+> = {
+  all: 'all',
+  etc: 'etc',
+  fried: 'fried',
+  grill: 'grill',
+  nabe: 'nabe',
+  noodle: 'noodle',
+  riceBowl: 'rice-bowl',
+  sushi: 'sushi',
+}
+
+const apiSortByValue: Record<
+  string,
+  NonNullable<GetRestaurantsParams['sort']>
+> = {
+  default: 'basic',
+  popular: 'popular',
+  rating: 'rating',
+}
+
+interface CreateRestaurantListRequestParamsParams {
+  category: FilterOption
+  sort: FilterOption
+  type: RestaurantListCurationType
+}
+
+export const createRestaurantListRequestParams = ({
+  category,
+  sort,
+  type,
+}: CreateRestaurantListRequestParamsParams): GetRestaurantsParams => {
+  return {
+    genre: apiGenreByCategory[category.value] ?? 'all',
+    size: RESTAURANT_LIST_PAGE_SIZE,
+    sort: apiSortByValue[sort.value] ?? 'basic',
+    type,
+  }
+}

--- a/apps/client/src/features/restaurantList/utils/index.ts
+++ b/apps/client/src/features/restaurantList/utils/index.ts
@@ -1,0 +1,2 @@
+export { createRestaurantListRequestParams } from './createRestaurantListRequestParams'
+export { mapRestaurantSummaryToRestaurant } from './mapRestaurantSummaryToRestaurant'

--- a/apps/client/src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.test.ts
+++ b/apps/client/src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapRestaurantSummaryToRestaurant } from '@/features/restaurantList/utils/mapRestaurantSummaryToRestaurant'
+
+describe('mapRestaurantSummaryToRestaurant', () => {
+  it('maps restaurant list response fields to restaurant card data', () => {
+    expect(
+      mapRestaurantSummaryToRestaurant({
+        area: '도쿄',
+        foodCategory: '초밥',
+        hashtags: ['오마카세', '#데이트'],
+        imageUrls: [
+          'https://example.com/restaurant-1.jpg',
+          'https://example.com/restaurant-2.jpg',
+        ],
+        name: '스시 하시',
+        rating: 4.8,
+        restaurantId: 10,
+        summary: '제철 생선을 사용하는 스시 전문점',
+        thumbnailUrl: 'https://example.com/thumbnail.jpg',
+      }),
+    ).toEqual({
+      category: '초밥',
+      description: '제철 생선을 사용하는 스시 전문점',
+      hashtags: ['#오마카세', '#데이트'],
+      id: '10',
+      images: [
+        'https://example.com/restaurant-1.jpg',
+        'https://example.com/restaurant-2.jpg',
+      ],
+      name: '스시 하시',
+      rating: 4.8,
+      region: '도쿄',
+    })
+  })
+
+  it('uses thumbnail and generated type fallbacks for optional response fields', () => {
+    expect(
+      mapRestaurantSummaryToRestaurant({
+        genre: 'rice-bowl',
+        restaurantId: 11,
+        thumbnailUrl: 'https://example.com/thumbnail.jpg',
+      }),
+    ).toEqual({
+      category: '덮밥류',
+      description: '',
+      hashtags: [],
+      id: '11',
+      images: ['https://example.com/thumbnail.jpg'],
+      name: '이름 없는 식당',
+      rating: 0,
+      region: '',
+    })
+  })
+
+  it('drops restaurants without restaurantId because detail links require it', () => {
+    expect(
+      mapRestaurantSummaryToRestaurant({
+        name: '식별자 없는 식당',
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/client/src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.ts
+++ b/apps/client/src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.ts
@@ -1,0 +1,63 @@
+import type { RestaurantSummaryResponse } from '@/features/restaurantList/api/getRestaurants'
+import type { Restaurant } from '@/features/restaurantList/types'
+
+const categoryLabelByValue: Record<string, string> = {
+  all: '전체',
+  etc: '기타',
+  fried: '튀김류',
+  grill: '철판/구이류',
+  nabe: '나베/냄비류',
+  noodle: '면류',
+  'rice-bowl': '덮밥류',
+  riceBowl: '덮밥류',
+  sushi: '스시/사시미류',
+}
+
+const getCategoryLabel = ({
+  foodCategory,
+  genre,
+}: RestaurantSummaryResponse) => {
+  const category = foodCategory ?? genre
+
+  if (!category) {
+    return ''
+  }
+
+  return categoryLabelByValue[category] ?? category
+}
+
+const getRestaurantImages = ({
+  imageUrls,
+  thumbnailUrl,
+}: RestaurantSummaryResponse) => {
+  if (imageUrls && imageUrls.length > 0) {
+    return imageUrls
+  }
+
+  return thumbnailUrl ? [thumbnailUrl] : []
+}
+
+const getHashTags = ({ hashtags }: RestaurantSummaryResponse) => {
+  return (hashtags ?? []).map((hashtag) =>
+    hashtag.startsWith('#') ? hashtag : `#${hashtag}`,
+  )
+}
+
+export const mapRestaurantSummaryToRestaurant = (
+  restaurant: RestaurantSummaryResponse,
+): Restaurant | null => {
+  if (restaurant.restaurantId === undefined) {
+    return null
+  }
+
+  return {
+    category: getCategoryLabel(restaurant),
+    description: restaurant.summary ?? '',
+    hashtags: getHashTags(restaurant),
+    id: String(restaurant.restaurantId),
+    images: getRestaurantImages(restaurant),
+    name: restaurant.name ?? '이름 없는 식당',
+    rating: restaurant.rating ?? 0,
+    region: restaurant.area ?? '',
+  }
+}

--- a/apps/client/src/pages/hashiPick/HashiPick.spec.md
+++ b/apps/client/src/pages/hashiPick/HashiPick.spec.md
@@ -45,24 +45,116 @@
 - [x] 필터 BottomSheet는 X 버튼으로만 닫힙니다.
 - [x] RestaurantCard는 반복 렌더링되고 카드 클릭 시 식당 상세 route로 이동합니다.
 - [x] 식당 이미지는 가로 스크롤 리스트로 표시하고 이미지가 없으면 공통 `DefaultImage` fallback을 사용합니다.
-- [x] 식당 리스트는 mock data 25개를 10개 단위로 무한스크롤 렌더링합니다.
+- [ ] 식당 리스트는 `GET /api/v1/restaurants` 응답을 커서 기반 무한스크롤로 렌더링합니다.
+- [ ] mock data는 API loading/error/empty 테스트용 fixture로만 남기고 production render path에서 제거합니다.
 - [x] fixed header는 `z-fixed` 토큰을 사용하고, 스크롤 콘텐츠는 fixed header 높이만큼 top padding을 둡니다.
 
 ## Data Dependencies
 
+### Source
+
+- OpenAPI generated type:
+  - `apps/client/src/shared/api/generated/openapi.ts`
+- HTTP client:
+  - `apps/client/src/shared/api/request.ts`
+  - `apps/client/src/shared/api/apiClient.ts`
+- Query defaults:
+  - `apps/client/src/shared/lib/queryClient.ts`
+- Route error boundary:
+  - `apps/client/src/app/providers/AsyncBoundary.tsx`
+  - `apps/client/src/app/layout/RootLayout.tsx`
+- Shared restaurant list API:
+  - `apps/client/src/features/restaurantList/api/getRestaurants.ts`
+  - `apps/client/src/features/restaurantList/queries/restaurantListQueryKeys.ts`
+  - `apps/client/src/features/restaurantList/queries/useRestaurantsInfiniteQuery.ts`
+
+### API Integration Map
+
+| UI area             | Endpoint                  | Params                                                                             | Response data                                             | Query key                                      | Mode       | Enabled | States                                                     |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------- | ---------- | ------- | ---------------------------------------------------------- |
+| 하시 Pick 식당 목록 | `GET /api/v1/restaurants` | `type`, `genre`, `foodCategory`, `sort`, `cursor`, `size`; `keyword`는 보내지 않음 | `RestaurantListResponse.content`, `nextCursor`, `hasNext` | `restaurantListQueryKeys.infiniteList(params)` | `infinite` | always  | initial loading, next-page fetching, error, empty, success |
+
+### Endpoint Type Mapping
+
+| Endpoint                  | Generated operation            | Request type source                                   | Response type source                              |
+| ------------------------- | ------------------------------ | ----------------------------------------------------- | ------------------------------------------------- |
+| `GET /api/v1/restaurants` | `operations['getRestaurants']` | `operations['getRestaurants']['parameters']['query']` | `components['schemas']['RestaurantListResponse']` |
+
+### Request Params
+
+- `type`:
+  - 하시 Pick 목록을 서버에서 구분하는 식당 목록 유형입니다.
+  - 현재 OpenAPI는 `type?: string`만 제공하고 허용 value enum을 제공하지 않습니다.
+  - 구현 전 서버에 하시 Pick용 value가 `hashi-pick`인지 확인해야 합니다.
+- `genre`:
+  - 음식 장르 BottomSheet의 선택값을 API 값으로 변환해 보냅니다.
+  - `전체`는 `all`로 보냅니다.
+  - `스시/사시미류`는 `sushi`, `면류`는 `noodle`, `덮밥류`는 `rice-bowl`, `나베/냄비류`는 `nabe`, `튀김류`는 `fried`, `철판/구이류`는 `grill`, `기타`는 `etc`로 보냅니다.
+  - 현재 `features/restaurantList/constants/category.ts`의 value 중 `riceBowl`, `grill`은 API value와 다르므로 request param 생성 helper에서 정규화합니다.
+- `foodCategory`:
+  - 현재 화면의 장르 필터가 API `genre`에 매핑된다는 검색 page spec과 맞춥니다.
+  - 서버가 이 화면에서 `foodCategory`를 요구하면 `genre` 대신 또는 함께 보내야 하므로 서버 확인이 필요합니다.
+- `sort`:
+  - `기본순`은 API `sort`를 생략합니다. 검색 page spec 기준 `default`를 그대로 보내면 `RESTAURANT-002` 가능성이 있습니다.
+  - `인기순`은 `popular`, `별점순`은 `rating`을 보냅니다.
+- `size`:
+  - 첫 연동은 검색 page와 같은 `20`을 사용합니다.
+- `cursor`:
+  - 첫 페이지는 보내지 않고, 다음 페이지부터 이전 응답의 `nextCursor`를 그대로 보냅니다.
+- `keyword`:
+  - 하시 Pick 화면에는 검색어 UI가 없으므로 보내지 않습니다.
+
 ### Query
 
-- query: none
-- enabled condition: none
-- request params: none
-- loading state: not implemented in this publishing scope
-- error state: not implemented in this publishing scope
-- empty state: not implemented in this publishing scope
-- refetch condition: none
+- query: hashi pick restaurants infinite query
+- enabled condition: always; route 진입 시 첫 페이지를 조회합니다.
+- request params:
+  - `{ type, genre, sort, size }`
+  - `cursor`는 다음 페이지 fetch 시 `getNextPageParam`에서만 추가합니다.
+- loading state:
+  - Header와 FilterBar는 유지합니다.
+  - 첫 페이지 loading은 리스트 영역에 card skeleton 또는 `LoadingScreen` 계열 fallback을 표시합니다.
+  - 다음 페이지 fetching은 기존 리스트를 유지하고 하단 sentinel 영역에 pending indicator를 둡니다.
+- error state:
+  - 예상 가능한 400 계열 API error는 리스트 영역 local error UI로 표시하고 재시도 버튼을 제공합니다.
+  - 5xx, network, timeout, unexpected non-API error는 `queryClient` 기본 정책에 따라 최대 1회 retry 후 ErrorBoundary throw 후보입니다.
+  - 화면 전체 대신 리스트 영역에 error UI를 유지해야 하면 query option에서 `throwOnError: false`를 명시합니다.
+- empty state:
+  - API content가 비어 있고 다음 페이지가 없으면 빈 목록 안내를 표시합니다.
+- refetch condition:
+  - 정렬 `적용`
+  - 음식 장르 `적용`
+  - Error UI의 재시도
+  - 같은 params 재적용 시 TanStack Query cache/stale 정책을 따릅니다.
 
 ### Mutation
 
 - mutation: none
+
+### Response Mapping
+
+| API field                           | UI use                        | Nullable | Transform / 판단                                                                                           |
+| ----------------------------------- | ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `RestaurantListResponse.content`    | 카드 리스트                   | yes      | 없으면 빈 배열로 정규화합니다.                                                                             |
+| `RestaurantListResponse.nextCursor` | 다음 페이지 cursor            | yes      | `hasNext`가 true일 때만 다음 요청 `cursor`로 전달합니다.                                                   |
+| `RestaurantListResponse.hasNext`    | 하단 sentinel 노출            | yes      | 없으면 `false`로 정규화합니다.                                                                             |
+| `restaurantId`                      | card key, 상세 route param    | yes      | 문자열로 변환합니다. 누락 시 상세 이동이 불가능하므로 해당 item 제외 또는 서버 required 요청이 필요합니다. |
+| `name`                              | 식당명                        | yes      | 누락 시 `이름 없는 식당` fallback을 쓰되 서버 required 요청 대상입니다.                                    |
+| `rating`                            | 별점                          | yes      | 누락 시 `0`으로 표시합니다.                                                                                |
+| `area`                              | 지역 label                    | yes      | 카드의 `{region} · {category}` 중 region으로 사용합니다.                                                   |
+| `foodCategory`                      | 음식 카테고리 label           | yes      | category 우선값입니다. 없으면 `genre`를 fallback으로 사용합니다.                                           |
+| `genre`                             | 음식 카테고리 fallback/filter | yes      | 서버가 한글 label 또는 API code를 줄 수 있으므로 mapper에서 label 변환을 흡수합니다.                       |
+| `imageUrls`                         | 가로 스크롤 이미지 리스트     | yes      | 비어 있으면 `thumbnailUrl` 단일 이미지로 fallback합니다.                                                   |
+| `thumbnailUrl`                      | 이미지 fallback               | yes      | `imageUrls`가 없을 때만 리스트 이미지로 사용합니다.                                                        |
+| `summary`                           | 식당 소개                     | yes      | 카드 설명 문구로 사용합니다. 영업시간으로 매핑하지 않습니다.                                               |
+| `hashtags`                          | 관련 해시태그                 | yes      | `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.                                                         |
+
+### Missing Server Questions
+
+- 하시 Pick 목록용 `type` 허용값이 무엇인지 확인해야 합니다. 현재 generated OpenAPI에는 `type?: string`만 있고 enum 또는 예시가 없습니다.
+- 화면의 음식 장르 필터는 API `genre`와 `foodCategory` 중 어느 파라미터가 정식 계약인지 확인해야 합니다. 검색 page spec은 UI 장르를 `genre`로 보내고 있습니다.
+- `restaurantId`, `name`, `rating`, `area`, `foodCategory` 또는 `genre`, `summary`가 목록 카드에서 사실상 필수인데 generated type은 모두 optional입니다. 서버가 required로 내려주는지, 아니면 프론트 fallback/필터링을 공식 처리로 둘지 확인해야 합니다.
+- 하시 Pick 화면의 `인기순`이 API `sort=popular`인지, 하시 Pick `type` 내부에서만 동작하는 별도 정렬인지 확인해야 합니다.
 
 ## State
 
@@ -70,14 +162,18 @@
   - active bottom sheet: `sort | category | null`
   - selected/draft sort option
   - selected/draft category option
-  - visible restaurant count for infinite scroll
+  - local retry trigger only when query option override가 필요한 경우
 - form state: none
 - URL state: none
-- server state: none
+- server state:
+  - `useRestaurantsInfiniteQuery` result pages
 - derived state:
   - category filter label: `전체`일 때 `음식 장르 선택`, 그 외 selected label
+  - selected sort/category -> API request params
+  - `RestaurantSummaryResponse` -> `Restaurant`
 - owner:
   - list state and handlers are owned by `useRestaurantListPage`
+  - API response normalization is owned by `features/restaurantList` mapper/hook
 
 ## UI Structure
 
@@ -109,12 +205,15 @@ HashiPickPage
   - `RestaurantImageList`
 - feature hook:
   - `useRestaurantListPage`
-  - `useInfiniteRestaurantList`
+  - `useRestaurantsInfiniteQuery`
+  - `restaurantsInfiniteQueryOptions`
+- feature mapper:
+  - `RestaurantSummaryResponse` -> `Restaurant`
 - feature mock:
-  - `mocks/restaurantList.mock.ts`
+  - test fixture only
 - page-local component: none
 - icon:
-- `BackIcon`
+  - `BackIcon`
   - `TapDownIcon`
   - `CheckIcon`
   - `StarFillIcon`
@@ -130,10 +229,17 @@ HashiPickPage
 - back behavior:
   - Header back button navigates to `ROUTES.home`
 
+## Error Handling
+
+- API transport와 envelope parsing은 `request<TData>()`를 사용해 기존 `ky`, `ApiError`, `HttpStatusError` 설정을 그대로 활용합니다.
+- query retry/throw 기본값은 `createQueryClient`의 `checkShouldRetryQuery`, `checkShouldThrowQueryError`를 따릅니다.
+- `RESTAURANT-001` unsupported genre, `RESTAURANT-002` unsupported sort, `RESTAURANT-003` unsupported list type은 구현 중 param mapping 오류로 보고 local error UI와 테스트로 잡습니다.
+- ErrorBoundary가 화면 전체 fallback을 렌더링하면 Header/FilterBar까지 사라지므로, 제품 요구가 리스트 영역 error라면 `throwOnError: false`를 이 query에서 명시합니다.
+
 ## Verification
 
-- [x] `corepack pnpm --filter @hashi/client test -- HashiPickPage.test.tsx PopularRestaurantsPage.test.tsx FilterBottomSheet.test.tsx`
-- [x] `corepack pnpm --filter @hashi/client lint`
-- [x] `corepack pnpm --filter @hashi/client typecheck`
-- [x] `corepack pnpm --filter @hashi/client build`
-- [x] `corepack pnpm --filter @hashi/client test`
+- [ ] `corepack pnpm --filter @hashi/client test -- HashiPickPage.test.tsx PopularRestaurantsPage.test.tsx getRestaurants.test.ts useRestaurantsInfiniteQuery.test.tsx`
+- [ ] `corepack pnpm --filter @hashi/client lint`
+- [ ] `corepack pnpm --filter @hashi/client typecheck`
+- [ ] `corepack pnpm --filter @hashi/client build`
+- [ ] 수동 확인: `/restaurants/hashi-pick` 진입, 정렬 적용, 장르 적용, 다음 페이지 fetch, empty, 400 local error, 5xx/ErrorBoundary 정책

--- a/apps/client/src/pages/hashiPick/HashiPick.spec.md
+++ b/apps/client/src/pages/hashiPick/HashiPick.spec.md
@@ -41,20 +41,24 @@
 - [x] 음식 장르 기본 적용값은 `전체`이고, 필터바 기본 label은 `음식 장르 선택`입니다.
 - [x] 정렬/음식 장르 BottomSheet는 `draft`와 `selected` 상태를 분리합니다.
 - [x] 옵션 선택만으로 실제 필터 label을 바꾸지 않고 `적용` 버튼에서 반영합니다.
-- [x] `초기화`는 현재 열린 sheet의 draft 값만 기본값으로 되돌립니다.
+- [x] `초기화`는 현재 열린 sheet 값을 기본값으로 적용하고 BottomSheet를 닫습니다.
 - [x] 필터 BottomSheet는 X 버튼으로만 닫힙니다.
 - [x] RestaurantCard는 반복 렌더링되고 카드 클릭 시 식당 상세 route로 이동합니다.
-- [x] 식당 이미지는 가로 스크롤 리스트로 표시하고 이미지가 없으면 공통 `DefaultImage` fallback을 사용합니다.
-- [ ] 식당 리스트는 `GET /api/v1/restaurants` 응답을 커서 기반 무한스크롤로 렌더링합니다.
-- [ ] mock data는 API loading/error/empty 테스트용 fixture로만 남기고 production render path에서 제거합니다.
+- [x] 식당 이미지는 서버가 내려준 이미지만 가로 스크롤 리스트로 표시하고 부족한 슬롯을 `DefaultImage`로 채우지 않습니다.
+- [x] 서버 이미지(`imageUrls`, fallback `thumbnailUrl`)가 하나도 없으면 공통 `DefaultImage`를 1개만 표시합니다.
+- [x] 기존 shared 식당 목록 조회 API(`getRestaurants`, `restaurantsInfiniteQueryOptions`)를 사용해 `GET /api/v1/restaurants` 응답을 커서 기반 무한스크롤로 렌더링합니다.
+- [x] 현재 page의 `MOCK_RESTAURANTS` prop 주입은 production render path에서 제거했습니다.
 - [x] fixed header는 `z-fixed` 토큰을 사용하고, 스크롤 콘텐츠는 fixed header 높이만큼 top padding을 둡니다.
 
 ## Data Dependencies
 
 ### Source
 
+- Server API spec:
+  - user-provided `식당 목록 조회 (검색/장르 필터/정렬/큐레이션 유형 포함)` text spec
 - OpenAPI generated type:
   - `apps/client/src/shared/api/generated/openapi.ts`
+  - 구현 직전 backend schema가 바뀌었으면 `pnpm gen:api-types`로 최신화한 뒤 이 spec의 Response Mapping과 다시 비교합니다.
 - HTTP client:
   - `apps/client/src/shared/api/request.ts`
   - `apps/client/src/shared/api/apiClient.ts`
@@ -68,11 +72,20 @@
   - `apps/client/src/features/restaurantList/queries/restaurantListQueryKeys.ts`
   - `apps/client/src/features/restaurantList/queries/useRestaurantsInfiniteQuery.ts`
 
+### Current Implementation
+
+- 식당 목록 조회 endpoint 함수, query key factory, infinite query options는 `features/restaurantList`에 이미 구현되어 있습니다.
+- `HashiPickPage`는 `restaurantType="hashi-pick"`을 `RestaurantListPage`에 넘기고, `MOCK_RESTAURANTS`를 production render path에서 사용하지 않습니다.
+- `RestaurantListPage`와 `useRestaurantListPage`는 `restaurants` prop과 `useInfiniteRestaurantList` local slice가 아니라 TanStack Query server state와 `useInfiniteScrollTrigger`를 사용합니다.
+- 이 API 연동은 기존 shared 식당 목록 API를 새로 만들지 않고, 하시 Pick route UI가 기존 query options를 소비하도록 연결합니다.
+- 검색 화면과 같은 `restaurantsInfiniteQueryOptions` 패턴을 사용하되, 검색어 `keyword` 대신 하시 Pick 목록 유형 `type`을 고정해서 보냅니다.
+- 서버 기반 무한스크롤은 검색/매거진 화면 관례처럼 `useInfiniteScrollTrigger`로 sentinel intersect 시 `fetchNextPage`를 호출합니다. 기존 `useInfiniteRestaurantList` local slicing은 mock fixture 전용 경로에만 남기거나 제거합니다.
+
 ### API Integration Map
 
 | UI area             | Endpoint                  | Params                                                                             | Response data                                             | Query key                                      | Mode       | Enabled | States                                                     |
 | ------------------- | ------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------- | ---------- | ------- | ---------------------------------------------------------- |
-| 하시 Pick 식당 목록 | `GET /api/v1/restaurants` | `type`, `genre`, `foodCategory`, `sort`, `cursor`, `size`; `keyword`는 보내지 않음 | `RestaurantListResponse.content`, `nextCursor`, `hasNext` | `restaurantListQueryKeys.infiniteList(params)` | `infinite` | always  | initial loading, next-page fetching, error, empty, success |
+| 하시 Pick 식당 목록 | `GET /api/v1/restaurants` | `type`, `genre`, `sort`, `cursor`, `size`; `keyword`, `foodCategory`는 보내지 않음 | `RestaurantListResponse.content`, `nextCursor`, `hasNext` | `restaurantListQueryKeys.infiniteList(params)` | `infinite` | always  | initial loading, next-page fetching, error, empty, success |
 
 ### Endpoint Type Mapping
 
@@ -83,22 +96,23 @@
 ### Request Params
 
 - `type`:
-  - 하시 Pick 목록을 서버에서 구분하는 식당 목록 유형입니다.
-  - 현재 OpenAPI는 `type?: string`만 제공하고 허용 value enum을 제공하지 않습니다.
-  - 구현 전 서버에 하시 Pick용 value가 `hashi-pick`인지 확인해야 합니다.
+  - 검색 화면의 `keyword` 자리에 해당하는 페이지 고정 필터입니다. 하시 Pick 목록 유형을 API `type`으로 보냅니다.
+  - 음식 장르 필터는 `type`이 아니라 아래 `genre`로 보냅니다.
+  - 서버 명세 기준 하시 Pick value는 `hashi-pick`입니다.
 - `genre`:
   - 음식 장르 BottomSheet의 선택값을 API 값으로 변환해 보냅니다.
   - `전체`는 `all`로 보냅니다.
   - `스시/사시미류`는 `sushi`, `면류`는 `noodle`, `덮밥류`는 `rice-bowl`, `나베/냄비류`는 `nabe`, `튀김류`는 `fried`, `철판/구이류`는 `grill`, `기타`는 `etc`로 보냅니다.
-  - 현재 `features/restaurantList/constants/category.ts`의 value 중 `riceBowl`, `grill`은 API value와 다르므로 request param 생성 helper에서 정규화합니다.
+  - 현재 `features/restaurantList/constants/category.ts`의 value 중 `riceBowl`은 API value와 다르므로 request param 생성 helper에서 `rice-bowl`로 정규화합니다.
 - `foodCategory`:
-  - 현재 화면의 장르 필터가 API `genre`에 매핑된다는 검색 page spec과 맞춥니다.
-  - 서버가 이 화면에서 `foodCategory`를 요구하면 `genre` 대신 또는 함께 보내야 하므로 서버 확인이 필요합니다.
+  - 서버 명세에는 별도 카테고리 필터로 존재하지만, 현재 하시 Pick UI에는 음식 장르 BottomSheet만 있으므로 보내지 않습니다.
+  - 추후 UI가 음식 카테고리와 음식 장르를 분리하면 `foodCategory` request param을 별도로 추가합니다.
 - `sort`:
-  - `기본순`은 API `sort`를 생략합니다. 검색 page spec 기준 `default`를 그대로 보내면 `RESTAURANT-002` 가능성이 있습니다.
+  - `기본순`은 API `sort=basic`으로 보냅니다.
   - `인기순`은 `popular`, `별점순`은 `rating`을 보냅니다.
 - `size`:
-  - 첫 연동은 검색 page와 같은 `20`을 사용합니다.
+  - 첫 연동은 검색 page와 식당 목록 상수 관습에 맞춰 `10`을 사용합니다.
+  - 구현에서는 기존 `RESTAURANT_LIST_PAGE_SIZE = 10` 상수를 재사용하거나, page query wrapper 가까이에 같은 의미의 page size 상수를 두되 중복 의미가 생기지 않게 합니다.
 - `cursor`:
   - 첫 페이지는 보내지 않고, 다음 페이지부터 이전 응답의 `nextCursor`를 그대로 보냅니다.
 - `keyword`:
@@ -111,14 +125,23 @@
 - request params:
   - `{ type, genre, sort, size }`
   - `cursor`는 다음 페이지 fetch 시 `getNextPageParam`에서만 추가합니다.
+  - 검색 화면의 `createSearchRestaurantsRequestParams`와 같은 방식으로 하시 Pick 전용 request param helper를 둡니다.
+  - 커서로 다음 페이지를 요청할 때는 서버 명세에 따라 첫 페이지와 동일한 `sort`를 유지합니다.
+- data derivation:
+  - `query.data?.pages.flatMap((page) => page.restaurants)`로 page data를 평탄화합니다.
+  - 평탄화한 `RestaurantSummaryResponse[]`를 mapper로 `Restaurant[]` view model로 변환합니다.
+- infinite scroll trigger:
+  - `useInfiniteScrollTrigger<HTMLLIElement>`를 사용합니다.
+  - `enabled`는 `Boolean(query.hasNextPage)`, `isLoading`은 `query.isFetchingNextPage`, `onIntersect`는 `query.fetchNextPage`로 연결합니다.
+  - 다음 페이지 fetching 중에는 기존 리스트를 유지하고 중복 호출은 shared hook lock과 `isFetchingNextPage`로 막습니다.
 - loading state:
   - Header와 FilterBar는 유지합니다.
   - 첫 페이지 loading은 리스트 영역에 card skeleton 또는 `LoadingScreen` 계열 fallback을 표시합니다.
   - 다음 페이지 fetching은 기존 리스트를 유지하고 하단 sentinel 영역에 pending indicator를 둡니다.
 - error state:
   - 예상 가능한 400 계열 API error는 리스트 영역 local error UI로 표시하고 재시도 버튼을 제공합니다.
-  - 5xx, network, timeout, unexpected non-API error는 `queryClient` 기본 정책에 따라 최대 1회 retry 후 ErrorBoundary throw 후보입니다.
-  - 화면 전체 대신 리스트 영역에 error UI를 유지해야 하면 query option에서 `throwOnError: false`를 명시합니다.
+  - Header와 FilterBar를 유지해야 하므로 하시 Pick page query wrapper는 `throwOnError: false`를 명시하고 리스트 영역 local error UI를 유지합니다.
+  - 5xx, network, timeout, unexpected non-API error도 queryClient 기본 retry 정책으로 최대 1회 retry하되 ErrorBoundary로 throw하지 않습니다.
 - empty state:
   - API content가 비어 있고 다음 페이지가 없으면 빈 목록 안내를 표시합니다.
 - refetch condition:
@@ -133,28 +156,28 @@
 
 ### Response Mapping
 
-| API field                           | UI use                        | Nullable | Transform / 판단                                                                                           |
-| ----------------------------------- | ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `RestaurantListResponse.content`    | 카드 리스트                   | yes      | 없으면 빈 배열로 정규화합니다.                                                                             |
-| `RestaurantListResponse.nextCursor` | 다음 페이지 cursor            | yes      | `hasNext`가 true일 때만 다음 요청 `cursor`로 전달합니다.                                                   |
-| `RestaurantListResponse.hasNext`    | 하단 sentinel 노출            | yes      | 없으면 `false`로 정규화합니다.                                                                             |
-| `restaurantId`                      | card key, 상세 route param    | yes      | 문자열로 변환합니다. 누락 시 상세 이동이 불가능하므로 해당 item 제외 또는 서버 required 요청이 필요합니다. |
-| `name`                              | 식당명                        | yes      | 누락 시 `이름 없는 식당` fallback을 쓰되 서버 required 요청 대상입니다.                                    |
-| `rating`                            | 별점                          | yes      | 누락 시 `0`으로 표시합니다.                                                                                |
-| `area`                              | 지역 label                    | yes      | 카드의 `{region} · {category}` 중 region으로 사용합니다.                                                   |
-| `foodCategory`                      | 음식 카테고리 label           | yes      | category 우선값입니다. 없으면 `genre`를 fallback으로 사용합니다.                                           |
-| `genre`                             | 음식 카테고리 fallback/filter | yes      | 서버가 한글 label 또는 API code를 줄 수 있으므로 mapper에서 label 변환을 흡수합니다.                       |
-| `imageUrls`                         | 가로 스크롤 이미지 리스트     | yes      | 비어 있으면 `thumbnailUrl` 단일 이미지로 fallback합니다.                                                   |
-| `thumbnailUrl`                      | 이미지 fallback               | yes      | `imageUrls`가 없을 때만 리스트 이미지로 사용합니다.                                                        |
-| `summary`                           | 식당 소개                     | yes      | 카드 설명 문구로 사용합니다. 영업시간으로 매핑하지 않습니다.                                               |
-| `hashtags`                          | 관련 해시태그                 | yes      | `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.                                                         |
+| API field                           | UI use                        | Nullable           | Transform / 판단                                                                                                                                               |
+| ----------------------------------- | ----------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RestaurantListResponse.content`    | 카드 리스트                   | yes                | 없으면 빈 배열로 정규화합니다.                                                                                                                                 |
+| `RestaurantListResponse.nextCursor` | 다음 페이지 cursor            | yes                | `hasNext`가 true일 때만 다음 요청 `cursor`로 전달합니다.                                                                                                       |
+| `RestaurantListResponse.hasNext`    | 하단 sentinel 노출            | yes                | 없으면 `false`로 정규화합니다.                                                                                                                                 |
+| `restaurantId`                      | card key, 상세 route param    | generated optional | 서버 명세상 필수입니다. 문자열로 변환합니다. 실제 응답에서 누락되면 해당 item은 상세 이동이 불가능하므로 제외합니다.                                           |
+| `name`                              | 식당명                        | generated optional | 서버 명세상 필수입니다. 누락 시 `이름 없는 식당` fallback을 사용합니다.                                                                                        |
+| `rating`                            | 별점                          | generated optional | 서버 명세상 필수입니다. 누락 시 `0`으로 표시하고, UI에서는 `4.0`, `3.0`처럼 소수점 1자리로 표시합니다.                                                         |
+| `area`                              | 지역 label                    | generated optional | 서버 명세상 필수입니다. 카드의 `{region} · {category}` 중 region으로 사용합니다.                                                                               |
+| `foodCategory`                      | 음식 카테고리 label           | generated optional | 서버 명세상 필수입니다. category 우선값입니다. 없으면 `genre`를 fallback으로 사용합니다.                                                                       |
+| `genre`                             | 음식 카테고리 fallback/filter | generated optional | 서버가 한글 label 또는 API code를 줄 수 있으므로 mapper에서 label 변환을 흡수합니다.                                                                           |
+| `imageUrls`                         | 가로 스크롤 이미지 리스트     | generated optional | 서버 명세상 최대 3개입니다. 서버가 내려준 이미지만 표시하고 부족한 슬롯을 `DefaultImage`로 채우지 않습니다. 없으면 `thumbnailUrl`을 fallback으로 봅니다.       |
+| `thumbnailUrl`                      | 이미지 fallback               | generated optional | 서버 명세상 필수입니다. `imageUrls`가 없을 때만 리스트 이미지로 사용합니다. `imageUrls`와 `thumbnailUrl`이 모두 없으면 UI에서 `DefaultImage` 1개를 표시합니다. |
+| `summary`                           | 식당 소개                     | generated optional | 서버 명세상 필수입니다. 카드 설명 문구로 사용합니다. 영업시간으로 매핑하지 않습니다.                                                                           |
+| `hashtags`                          | 관련 해시태그                 | generated optional | 서버 명세상 필수입니다. `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.                                                                                     |
+| `todayBusinessHour`                 | 사용 안 함                    | yes                | 하시 Pick 카드 UI에는 영업시간 영역이 없으므로 매핑하지 않습니다.                                                                                              |
 
 ### Missing Server Questions
 
-- 하시 Pick 목록용 `type` 허용값이 무엇인지 확인해야 합니다. 현재 generated OpenAPI에는 `type?: string`만 있고 enum 또는 예시가 없습니다.
-- 화면의 음식 장르 필터는 API `genre`와 `foodCategory` 중 어느 파라미터가 정식 계약인지 확인해야 합니다. 검색 page spec은 UI 장르를 `genre`로 보내고 있습니다.
-- `restaurantId`, `name`, `rating`, `area`, `foodCategory` 또는 `genre`, `summary`가 목록 카드에서 사실상 필수인데 generated type은 모두 optional입니다. 서버가 required로 내려주는지, 아니면 프론트 fallback/필터링을 공식 처리로 둘지 확인해야 합니다.
-- 하시 Pick 화면의 `인기순`이 API `sort=popular`인지, 하시 Pick `type` 내부에서만 동작하는 별도 정렬인지 확인해야 합니다.
+- None.
+- 서버 명세로 `type=hashi-pick`, `sort=basic | popular | rating`, `genre` 필터 사용이 확인되었습니다.
+- 단, `openapi.ts` generated type은 response 필드를 optional로 생성하므로 구현은 defensive fallback을 유지합니다.
 
 ## State
 
@@ -166,7 +189,7 @@
 - form state: none
 - URL state: none
 - server state:
-  - `useRestaurantsInfiniteQuery` result pages
+  - `useInfiniteQuery(restaurantsInfiniteQueryOptions(requestParams))` result pages
 - derived state:
   - category filter label: `전체`일 때 `음식 장르 선택`, 그 외 selected label
   - selected sort/category -> API request params
@@ -184,7 +207,7 @@ HashiPickPage
     RestaurantFilterBar
     RestaurantCard list
       RestaurantImageList
-        DefaultImage fallback
+        server images or single DefaultImage fallback
     FilterBottomSheet(sort)
     FilterBottomSheet(category)
 ```
@@ -207,6 +230,10 @@ HashiPickPage
   - `useRestaurantListPage`
   - `useRestaurantsInfiniteQuery`
   - `restaurantsInfiniteQueryOptions`
+- feature query composition:
+  - `createRestaurantListRequestParams`
+  - `restaurantsInfiniteQueryOptions`
+  - `useRestaurantListPage`에서 `restaurantsInfiniteQueryOptions`를 감싸고 `throwOnError: false`를 명시합니다.
 - feature mapper:
   - `RestaurantSummaryResponse` -> `Restaurant`
 - feature mock:
@@ -233,13 +260,14 @@ HashiPickPage
 
 - API transport와 envelope parsing은 `request<TData>()`를 사용해 기존 `ky`, `ApiError`, `HttpStatusError` 설정을 그대로 활용합니다.
 - query retry/throw 기본값은 `createQueryClient`의 `checkShouldRetryQuery`, `checkShouldThrowQueryError`를 따릅니다.
-- `RESTAURANT-001` unsupported genre, `RESTAURANT-002` unsupported sort, `RESTAURANT-003` unsupported list type은 구현 중 param mapping 오류로 보고 local error UI와 테스트로 잡습니다.
-- ErrorBoundary가 화면 전체 fallback을 렌더링하면 Header/FilterBar까지 사라지므로, 제품 요구가 리스트 영역 error라면 `throwOnError: false`를 이 query에서 명시합니다.
+- `COMMON-400` cursor/size validation, `RESTAURANT-001` unsupported genre, `RESTAURANT-002` unsupported sort, `RESTAURANT-003` unsupported type은 구현 중 param mapping 오류로 보고 local error UI와 테스트로 잡습니다.
+- 이 화면은 `foodCategory`를 보내지 않지만, 추후 추가 시 `RESTAURANT-007` unsupported foodCategory도 local error UI 대상입니다.
+- ErrorBoundary가 화면 전체 fallback을 렌더링하면 Header/FilterBar까지 사라지므로 `throwOnError: false`를 이 query wrapper에서 명시합니다.
 
 ## Verification
 
-- [ ] `corepack pnpm --filter @hashi/client test -- HashiPickPage.test.tsx PopularRestaurantsPage.test.tsx getRestaurants.test.ts useRestaurantsInfiniteQuery.test.tsx`
-- [ ] `corepack pnpm --filter @hashi/client lint`
-- [ ] `corepack pnpm --filter @hashi/client typecheck`
-- [ ] `corepack pnpm --filter @hashi/client build`
+- [x] `corepack pnpm --filter @hashi/client test -- src/app/router/routes.test.tsx src/features/restaurantList/utils/createRestaurantListRequestParams.test.ts src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.test.ts src/features/restaurantList/api/getRestaurants.test.ts src/pages/search/queries/useSearchRestaurantsInfiniteQuery.test.tsx`
+- [x] `corepack pnpm --filter @hashi/client lint`
+- [x] `corepack pnpm --filter @hashi/client typecheck`
+- [x] `corepack pnpm --filter @hashi/client build`
 - [ ] 수동 확인: `/restaurants/hashi-pick` 진입, 정렬 적용, 장르 적용, 다음 페이지 fetch, empty, 400 local error, 5xx/ErrorBoundary 정책

--- a/apps/client/src/pages/hashiPick/HashiPick.spec.md
+++ b/apps/client/src/pages/hashiPick/HashiPick.spec.md
@@ -136,7 +136,7 @@
   - 다음 페이지 fetching 중에는 기존 리스트를 유지하고 중복 호출은 shared hook lock과 `isFetchingNextPage`로 막습니다.
 - loading state:
   - Header와 FilterBar는 유지합니다.
-  - 첫 페이지 loading은 리스트 영역에 card skeleton 또는 `LoadingScreen` 계열 fallback을 표시합니다.
+  - 첫 페이지 loading은 화면 전체 `LoadingScreen`이 아니라 리스트 영역 card skeleton만 표시합니다.
   - 다음 페이지 fetching은 기존 리스트를 유지하고 하단 sentinel 영역에 pending indicator를 둡니다.
 - error state:
   - 예상 가능한 400 계열 API error는 리스트 영역 local error UI로 표시하고 재시도 버튼을 제공합니다.

--- a/apps/client/src/pages/hashiPick/HashiPickPage.test.tsx
+++ b/apps/client/src/pages/hashiPick/HashiPickPage.test.tsx
@@ -1,17 +1,26 @@
 import '@testing-library/jest-dom/vitest'
+import { QueryClientProvider } from '@tanstack/react-query'
 import {
   act,
   cleanup,
   fireEvent,
   render,
   screen,
-  within,
+  waitFor,
 } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ROUTES } from '@/app/router/path'
+import { getRestaurants } from '@/features/restaurantList'
 import { HashiPickPage } from '@/pages/hashiPick/HashiPickPage'
+import { createQueryClient } from '@/shared/lib/queryClient'
+
+vi.mock('@/features/restaurantList/api/getRestaurants', () => ({
+  getRestaurants: vi.fn(),
+}))
+
+const mockedGetRestaurants = vi.mocked(getRestaurants)
 
 const LocationPath = () => {
   const location = useLocation()
@@ -19,15 +28,57 @@ const LocationPath = () => {
   return <div data-testid="location-path">{location.pathname}</div>
 }
 
+const createRestaurantsResult = ({
+  count,
+  hasNext = false,
+  imageUrls = [],
+  nextCursor,
+  rating = 4,
+  startId = 1,
+}: {
+  count: number
+  hasNext?: boolean
+  imageUrls?: string[]
+  nextCursor?: string
+  rating?: number
+  startId?: number
+}): Awaited<ReturnType<typeof getRestaurants>> => {
+  return {
+    hasNext,
+    nextCursor,
+    restaurants: Array.from({ length: count }, (_, index) => {
+      const restaurantId = startId + index
+
+      return {
+        area: '도쿄',
+        foodCategory: '초밥',
+        hashtags: ['해시태그'],
+        imageUrls,
+        name: `히마와리 스시 ${restaurantId}`,
+        rating,
+        restaurantId,
+        summary: '식당 소개를 여기 간단하게 한 줄 적어주세요.',
+      }
+    }),
+  }
+}
+
 const renderHashiPickPage = () => {
+  const queryClient = createQueryClient()
+
   return render(
-    <MemoryRouter initialEntries={[ROUTES.hashiPickRestaurants]}>
-      <Routes>
-        <Route element={<HashiPickPage />} path={ROUTES.hashiPickRestaurants} />
-        <Route element={<LocationPath />} path={ROUTES.restaurantDetail} />
-        <Route element={<LocationPath />} path={ROUTES.home} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[ROUTES.hashiPickRestaurants]}>
+        <Routes>
+          <Route
+            element={<HashiPickPage />}
+            path={ROUTES.hashiPickRestaurants}
+          />
+          <Route element={<LocationPath />} path={ROUTES.restaurantDetail} />
+          <Route element={<LocationPath />} path={ROUTES.home} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -67,13 +118,20 @@ const mockIntersectionObserver = () => {
 }
 
 describe('HashiPickPage', () => {
+  beforeEach(() => {
+    mockedGetRestaurants.mockResolvedValue(
+      createRestaurantsResult({ count: 3 }),
+    )
+  })
+
   afterEach(() => {
     cleanup()
     document.body.style.overflow = ''
+    mockedGetRestaurants.mockReset()
     vi.unstubAllGlobals()
   })
 
-  it('renders title, filters, and restaurant cards', () => {
+  it('renders title, filters, and restaurants from API response', async () => {
     renderHashiPickPage()
 
     expect(screen.getByTestId('restaurant-list-sticky-header')).toHaveClass(
@@ -84,7 +142,6 @@ describe('HashiPickPage', () => {
     expect(screen.getByTestId('restaurant-list-scroll-content')).toHaveClass(
       'pt-[75px]',
     )
-    expect(screen.getByTestId('restaurant-list')).not.toHaveClass('pt-[123px]')
     expect(
       screen.getByRole('heading', { name: '하시 Pick' }),
     ).toBeInTheDocument()
@@ -94,13 +151,22 @@ describe('HashiPickPage', () => {
     expect(
       screen.getByRole('button', { name: '음식 장르 필터: 음식 장르 선택' }),
     ).toBeInTheDocument()
+
     expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
-    ).toHaveLength(10)
+      await screen.findAllByRole('button', { name: /히마와리 스시/ }),
+    ).toHaveLength(3)
+    expect(screen.getAllByText('4.0')).toHaveLength(3)
+    expect(mockedGetRestaurants).toHaveBeenCalledWith({
+      genre: 'all',
+      size: 10,
+      sort: 'basic',
+      type: 'hashi-pick',
+    })
   })
 
-  it('keeps selected sort unchanged until apply is pressed', () => {
+  it('keeps selected sort unchanged until apply is pressed', async () => {
     renderHashiPickPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
 
     fireEvent.click(screen.getByRole('button', { name: '정렬 필터: 기본순' }))
     fireEvent.click(screen.getByRole('button', { name: '인기순' }))
@@ -109,9 +175,7 @@ describe('HashiPickPage', () => {
     expect(
       screen.getByRole('button', { name: '정렬 필터: 기본순' }),
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: '정렬 필터: 인기순' }),
-    ).not.toBeInTheDocument()
+    expect(mockedGetRestaurants).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByRole('button', { name: '정렬 필터: 기본순' }))
     fireEvent.click(screen.getByRole('button', { name: '별점순' }))
@@ -120,31 +184,45 @@ describe('HashiPickPage', () => {
     expect(
       screen.getByRole('button', { name: '정렬 필터: 별점순' }),
     ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(mockedGetRestaurants).toHaveBeenLastCalledWith({
+        genre: 'all',
+        size: 10,
+        sort: 'rating',
+        type: 'hashi-pick',
+      })
+    })
   })
 
-  it('resets category to default and closes the bottom sheet when reset is pressed', () => {
+  it('normalizes category filter when apply is pressed', async () => {
     renderHashiPickPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
 
     fireEvent.click(
       screen.getByRole('button', { name: '음식 장르 필터: 음식 장르 선택' }),
     )
-    fireEvent.click(screen.getByRole('button', { name: '면류' }))
-    fireEvent.click(screen.getByRole('button', { name: '초기화' }))
+    fireEvent.click(screen.getByRole('button', { name: '덮밥류' }))
+    fireEvent.click(screen.getByRole('button', { name: '적용' }))
 
     expect(
-      screen.getByRole('button', {
-        name: '음식 장르 필터: 음식 장르 선택',
-      }),
+      screen.getByRole('button', { name: '음식 장르 필터: 덮밥류' }),
     ).toBeInTheDocument()
-    expect(screen.getByRole('dialog', { name: '음식 장르 선택' })).toHaveClass(
-      'animate-bottom-sheet-panel-out',
-    )
+    await waitFor(() => {
+      expect(mockedGetRestaurants).toHaveBeenLastCalledWith({
+        genre: 'rice-bowl',
+        size: 10,
+        sort: 'basic',
+        type: 'hashi-pick',
+      })
+    })
   })
 
-  it('navigates to restaurant detail when a card is pressed', () => {
+  it('navigates to restaurant detail when a card is pressed', async () => {
     renderHashiPickPage()
 
-    fireEvent.click(screen.getAllByRole('button', { name: /히마와리 스시/ })[0])
+    fireEvent.click(
+      await screen.findByRole('button', { name: /히마와리 스시 1/ }),
+    )
 
     expect(screen.getByTestId('location-path')).toHaveTextContent(
       '/restaurants/1',
@@ -159,37 +237,77 @@ describe('HashiPickPage', () => {
     expect(screen.getByTestId('location-path')).toHaveTextContent(ROUTES.home)
   })
 
-  it('renders five fallback image slots that follow the parent content width', () => {
+  it('renders only image urls returned by the server', async () => {
+    mockedGetRestaurants.mockResolvedValueOnce(
+      createRestaurantsResult({
+        count: 1,
+        imageUrls: [
+          'https://example.com/restaurant-1.jpg',
+          'https://example.com/restaurant-2.jpg',
+          'https://example.com/restaurant-3.jpg',
+        ],
+      }),
+    )
+
     renderHashiPickPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
     const imageList = screen.getAllByTestId('restaurant-image-list')[0]
 
-    expect(screen.queryAllByRole('img')).toHaveLength(0)
     expect(imageList).toHaveClass('w-full', 'overflow-x-auto')
     expect(imageList).not.toHaveClass('max-w-[353px]')
-    expect(
-      within(imageList).getAllByTestId('restaurant-image-placeholder'),
-    ).toHaveLength(5)
+    expect(screen.getAllByRole('img')).toHaveLength(3)
+    expect(screen.queryByTestId('restaurant-image-placeholder')).toBeNull()
   })
 
-  it('loads restaurants in 10 item chunks when the bottom sentinel enters the viewport', () => {
+  it('renders one default image when no image is returned by the server', async () => {
+    mockedGetRestaurants.mockResolvedValueOnce(
+      createRestaurantsResult({
+        count: 1,
+        imageUrls: [],
+      }),
+    )
+
+    renderHashiPickPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
+
+    expect(screen.queryAllByRole('img')).toHaveLength(0)
+    expect(screen.getAllByTestId('restaurant-image-placeholder')).toHaveLength(
+      1,
+    )
+  })
+
+  it('fetches next page when the bottom sentinel enters the viewport', async () => {
+    mockedGetRestaurants
+      .mockResolvedValueOnce(
+        createRestaurantsResult({
+          count: 10,
+          hasNext: true,
+          nextCursor: 'c-10',
+        }),
+      )
+      .mockResolvedValueOnce(createRestaurantsResult({ count: 2, startId: 11 }))
     const { triggerIntersect } = mockIntersectionObserver()
 
     renderHashiPickPage()
 
     expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
+      await screen.findAllByRole('button', { name: /히마와리 스시/ }),
     ).toHaveLength(10)
+    await screen.findByTestId('restaurant-list-load-more')
 
     triggerIntersect()
 
+    await waitFor(() => {
+      expect(mockedGetRestaurants).toHaveBeenLastCalledWith({
+        cursor: 'c-10',
+        genre: 'all',
+        size: 10,
+        sort: 'basic',
+        type: 'hashi-pick',
+      })
+    })
     expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
-    ).toHaveLength(20)
-
-    triggerIntersect()
-
-    expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
-    ).toHaveLength(25)
+      await screen.findAllByRole('button', { name: /히마와리 스시/ }),
+    ).toHaveLength(12)
   })
 })

--- a/apps/client/src/pages/hashiPick/HashiPickPage.test.tsx
+++ b/apps/client/src/pages/hashiPick/HashiPickPage.test.tsx
@@ -155,6 +155,9 @@ describe('HashiPickPage', () => {
     expect(
       await screen.findAllByRole('button', { name: /히마와리 스시/ }),
     ).toHaveLength(3)
+    expect(
+      screen.getByRole('button', { name: /히마와리 스시 3/ }).closest('li'),
+    ).toHaveClass('last:border-b-0')
     expect(screen.getAllByText('4.0')).toHaveLength(3)
     expect(mockedGetRestaurants).toHaveBeenCalledWith({
       genre: 'all',
@@ -235,6 +238,23 @@ describe('HashiPickPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '뒤로가기' }))
 
     expect(screen.getByTestId('location-path')).toHaveTextContent(ROUTES.home)
+  })
+
+  it('renders secondary color skeletons while the first page is loading', () => {
+    mockedGetRestaurants.mockReturnValueOnce(new Promise(() => {}))
+
+    renderHashiPickPage()
+
+    const skeletonItems = screen.getAllByTestId('restaurant-list-skeleton-item')
+
+    expect(skeletonItems).toHaveLength(3)
+    expect(skeletonItems[2]).toHaveClass('last:border-b-0')
+    expect(
+      skeletonItems[0]?.querySelector('.bg-secondary-200'),
+    ).toBeInTheDocument()
+    expect(
+      skeletonItems[0]?.querySelector('.bg-cool-gray-100'),
+    ).not.toBeInTheDocument()
   })
 
   it('renders only image urls returned by the server', async () => {

--- a/apps/client/src/pages/hashiPick/HashiPickPage.tsx
+++ b/apps/client/src/pages/hashiPick/HashiPickPage.tsx
@@ -1,13 +1,12 @@
 import {
   HASHI_PICK_SORT_OPTIONS,
-  MOCK_RESTAURANTS,
   RestaurantListPage,
 } from '@/features/restaurantList'
 
 export const HashiPickPage = () => {
   return (
     <RestaurantListPage
-      restaurants={MOCK_RESTAURANTS}
+      restaurantType="hashi-pick"
       sortOptions={HASHI_PICK_SORT_OPTIONS}
       title="하시 Pick"
     />

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
@@ -136,7 +136,7 @@
   - 다음 페이지 fetching 중에는 기존 리스트를 유지하고 중복 호출은 shared hook lock과 `isFetchingNextPage`로 막습니다.
 - loading state:
   - Header와 FilterBar는 유지합니다.
-  - 첫 페이지 loading은 리스트 영역에 card skeleton 또는 `LoadingScreen` 계열 fallback을 표시합니다.
+  - 첫 페이지 loading은 화면 전체 `LoadingScreen`이 아니라 리스트 영역 card skeleton만 표시합니다.
   - 다음 페이지 fetching은 기존 리스트를 유지하고 하단 sentinel 영역에 pending indicator를 둡니다.
 - error state:
   - 예상 가능한 400 계열 API error는 리스트 영역 local error UI로 표시하고 재시도 버튼을 제공합니다.

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
@@ -45,24 +45,119 @@
 - [x] 필터 BottomSheet는 X 버튼으로만 닫힙니다.
 - [x] RestaurantCard는 반복 렌더링되고 카드 클릭 시 식당 상세 route로 이동합니다.
 - [x] 식당 이미지는 가로 스크롤 리스트로 표시하고 이미지가 없으면 공통 `DefaultImage` fallback을 사용합니다.
-- [x] 식당 리스트는 mock data 25개를 10개 단위로 무한스크롤 렌더링합니다.
+- [ ] 식당 리스트는 `GET /api/v1/restaurants` 응답을 커서 기반 무한스크롤로 렌더링합니다.
+- [ ] mock data는 API loading/error/empty 테스트용 fixture로만 남기고 production render path에서 제거합니다.
 - [x] fixed header는 `z-fixed` 토큰을 사용하고, 스크롤 콘텐츠는 fixed header 높이만큼 top padding을 둡니다.
 
 ## Data Dependencies
 
+### Source
+
+- OpenAPI generated type:
+  - `apps/client/src/shared/api/generated/openapi.ts`
+- HTTP client:
+  - `apps/client/src/shared/api/request.ts`
+  - `apps/client/src/shared/api/apiClient.ts`
+- Query defaults:
+  - `apps/client/src/shared/lib/queryClient.ts`
+- Route error boundary:
+  - `apps/client/src/app/providers/AsyncBoundary.tsx`
+  - `apps/client/src/app/layout/RootLayout.tsx`
+- Shared restaurant list API:
+  - `apps/client/src/features/restaurantList/api/getRestaurants.ts`
+  - `apps/client/src/features/restaurantList/queries/restaurantListQueryKeys.ts`
+  - `apps/client/src/features/restaurantList/queries/useRestaurantsInfiniteQuery.ts`
+
+### API Integration Map
+
+| UI area             | Endpoint                  | Params                                                                             | Response data                                             | Query key                                      | Mode       | Enabled | States                                                     |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------- | ---------- | ------- | ---------------------------------------------------------- |
+| 인기 맛집 식당 목록 | `GET /api/v1/restaurants` | `type`, `genre`, `foodCategory`, `sort`, `cursor`, `size`; `keyword`는 보내지 않음 | `RestaurantListResponse.content`, `nextCursor`, `hasNext` | `restaurantListQueryKeys.infiniteList(params)` | `infinite` | always  | initial loading, next-page fetching, error, empty, success |
+
+### Endpoint Type Mapping
+
+| Endpoint                  | Generated operation            | Request type source                                   | Response type source                              |
+| ------------------------- | ------------------------------ | ----------------------------------------------------- | ------------------------------------------------- |
+| `GET /api/v1/restaurants` | `operations['getRestaurants']` | `operations['getRestaurants']['parameters']['query']` | `components['schemas']['RestaurantListResponse']` |
+
+### Request Params
+
+- `type`:
+  - 인기 맛집 목록을 서버에서 구분하는 식당 목록 유형입니다.
+  - 현재 OpenAPI는 `type?: string`만 제공하고 허용 value enum을 제공하지 않습니다.
+  - 구현 전 서버에 인기 맛집용 value가 `popular`인지 확인해야 합니다.
+  - 만약 서버가 인기 맛집을 `type`이 아니라 `sort=popular`만으로 표현한다면, 이 화면의 `기본순`은 `sort=popular`로 보내고 `type`은 생략해야 합니다.
+- `genre`:
+  - 음식 장르 BottomSheet의 선택값을 API 값으로 변환해 보냅니다.
+  - `전체`는 `all`로 보냅니다.
+  - `스시/사시미류`는 `sushi`, `면류`는 `noodle`, `덮밥류`는 `rice-bowl`, `나베/냄비류`는 `nabe`, `튀김류`는 `fried`, `철판/구이류`는 `grill`, `기타`는 `etc`로 보냅니다.
+  - 현재 `features/restaurantList/constants/category.ts`의 value 중 `riceBowl`, `grill`은 API value와 다르므로 request param 생성 helper에서 정규화합니다.
+- `foodCategory`:
+  - 현재 화면의 장르 필터가 API `genre`에 매핑된다는 검색 page spec과 맞춥니다.
+  - 서버가 이 화면에서 `foodCategory`를 요구하면 `genre` 대신 또는 함께 보내야 하므로 서버 확인이 필요합니다.
+- `sort`:
+  - `기본순`은 인기 맛집 목록의 기본 서버 정렬을 유지합니다.
+  - 서버가 인기 맛집을 `type=popular`로 구분한다면 `기본순`에서는 `sort`를 생략합니다.
+  - 서버가 인기 맛집을 `sort=popular`로 구분한다면 `기본순`에서 `sort=popular`를 보내야 합니다.
+  - `별점순`은 `rating`을 보냅니다.
+- `size`:
+  - 첫 연동은 검색 page와 같은 `20`을 사용합니다.
+- `cursor`:
+  - 첫 페이지는 보내지 않고, 다음 페이지부터 이전 응답의 `nextCursor`를 그대로 보냅니다.
+- `keyword`:
+  - 인기 맛집 화면에는 검색어 UI가 없으므로 보내지 않습니다.
+
 ### Query
 
-- query: none
-- enabled condition: none
-- request params: none
-- loading state: not implemented in this publishing scope
-- error state: not implemented in this publishing scope
-- empty state: not implemented in this publishing scope
-- refetch condition: none
+- query: popular restaurants infinite query
+- enabled condition: always; route 진입 시 첫 페이지를 조회합니다.
+- request params:
+  - `{ type, genre, sort, size }`
+  - `cursor`는 다음 페이지 fetch 시 `getNextPageParam`에서만 추가합니다.
+- loading state:
+  - Header와 FilterBar는 유지합니다.
+  - 첫 페이지 loading은 리스트 영역에 card skeleton 또는 `LoadingScreen` 계열 fallback을 표시합니다.
+  - 다음 페이지 fetching은 기존 리스트를 유지하고 하단 sentinel 영역에 pending indicator를 둡니다.
+- error state:
+  - 예상 가능한 400 계열 API error는 리스트 영역 local error UI로 표시하고 재시도 버튼을 제공합니다.
+  - 5xx, network, timeout, unexpected non-API error는 `queryClient` 기본 정책에 따라 최대 1회 retry 후 ErrorBoundary throw 후보입니다.
+  - 화면 전체 대신 리스트 영역에 error UI를 유지해야 하면 query option에서 `throwOnError: false`를 명시합니다.
+- empty state:
+  - API content가 비어 있고 다음 페이지가 없으면 빈 목록 안내를 표시합니다.
+- refetch condition:
+  - 정렬 `적용`
+  - 음식 장르 `적용`
+  - Error UI의 재시도
+  - 같은 params 재적용 시 TanStack Query cache/stale 정책을 따릅니다.
 
 ### Mutation
 
 - mutation: none
+
+### Response Mapping
+
+| API field                           | UI use                        | Nullable | Transform / 판단                                                                                           |
+| ----------------------------------- | ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `RestaurantListResponse.content`    | 카드 리스트                   | yes      | 없으면 빈 배열로 정규화합니다.                                                                             |
+| `RestaurantListResponse.nextCursor` | 다음 페이지 cursor            | yes      | `hasNext`가 true일 때만 다음 요청 `cursor`로 전달합니다.                                                   |
+| `RestaurantListResponse.hasNext`    | 하단 sentinel 노출            | yes      | 없으면 `false`로 정규화합니다.                                                                             |
+| `restaurantId`                      | card key, 상세 route param    | yes      | 문자열로 변환합니다. 누락 시 상세 이동이 불가능하므로 해당 item 제외 또는 서버 required 요청이 필요합니다. |
+| `name`                              | 식당명                        | yes      | 누락 시 `이름 없는 식당` fallback을 쓰되 서버 required 요청 대상입니다.                                    |
+| `rating`                            | 별점                          | yes      | 누락 시 `0`으로 표시합니다.                                                                                |
+| `area`                              | 지역 label                    | yes      | 카드의 `{region} · {category}` 중 region으로 사용합니다.                                                   |
+| `foodCategory`                      | 음식 카테고리 label           | yes      | category 우선값입니다. 없으면 `genre`를 fallback으로 사용합니다.                                           |
+| `genre`                             | 음식 카테고리 fallback/filter | yes      | 서버가 한글 label 또는 API code를 줄 수 있으므로 mapper에서 label 변환을 흡수합니다.                       |
+| `imageUrls`                         | 가로 스크롤 이미지 리스트     | yes      | 비어 있으면 `thumbnailUrl` 단일 이미지로 fallback합니다.                                                   |
+| `thumbnailUrl`                      | 이미지 fallback               | yes      | `imageUrls`가 없을 때만 리스트 이미지로 사용합니다.                                                        |
+| `summary`                           | 식당 소개                     | yes      | 카드 설명 문구로 사용합니다. 영업시간으로 매핑하지 않습니다.                                               |
+| `hashtags`                          | 관련 해시태그                 | yes      | `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.                                                         |
+
+### Missing Server Questions
+
+- 인기 맛집 목록용 `type` 허용값이 무엇인지 확인해야 합니다. 현재 generated OpenAPI에는 `type?: string`만 있고 enum 또는 예시가 없습니다.
+- 인기 맛집의 `기본순`이 `type=popular`의 서버 기본 정렬인지, 아니면 `sort=popular`를 보내야 하는지 확인해야 합니다.
+- 화면의 음식 장르 필터는 API `genre`와 `foodCategory` 중 어느 파라미터가 정식 계약인지 확인해야 합니다. 검색 page spec은 UI 장르를 `genre`로 보내고 있습니다.
+- `restaurantId`, `name`, `rating`, `area`, `foodCategory` 또는 `genre`, `summary`가 목록 카드에서 사실상 필수인데 generated type은 모두 optional입니다. 서버가 required로 내려주는지, 아니면 프론트 fallback/필터링을 공식 처리로 둘지 확인해야 합니다.
 
 ## State
 
@@ -70,14 +165,18 @@
   - active bottom sheet: `sort | category | null`
   - selected/draft sort option
   - selected/draft category option
-  - visible restaurant count for infinite scroll
+  - local retry trigger only when query option override가 필요한 경우
 - form state: none
 - URL state: none
-- server state: none
+- server state:
+  - `useRestaurantsInfiniteQuery` result pages
 - derived state:
   - category filter label: `전체`일 때 `음식 장르 선택`, 그 외 selected label
+  - selected sort/category -> API request params
+  - `RestaurantSummaryResponse` -> `Restaurant`
 - owner:
   - list state and handlers are owned by `useRestaurantListPage`
+  - API response normalization is owned by `features/restaurantList` mapper/hook
 
 ## UI Structure
 
@@ -109,9 +208,12 @@ PopularRestaurantsPage
   - `RestaurantImageList`
 - feature hook:
   - `useRestaurantListPage`
-  - `useInfiniteRestaurantList`
+  - `useRestaurantsInfiniteQuery`
+  - `restaurantsInfiniteQueryOptions`
+- feature mapper:
+  - `RestaurantSummaryResponse` -> `Restaurant`
 - feature mock:
-  - `mocks/restaurantList.mock.ts`
+  - test fixture only
 - page-local component: none
 - icon:
   - `BackIcon`
@@ -130,10 +232,17 @@ PopularRestaurantsPage
 - back behavior:
   - Header back button navigates to `ROUTES.home`
 
+## Error Handling
+
+- API transport와 envelope parsing은 `request<TData>()`를 사용해 기존 `ky`, `ApiError`, `HttpStatusError` 설정을 그대로 활용합니다.
+- query retry/throw 기본값은 `createQueryClient`의 `checkShouldRetryQuery`, `checkShouldThrowQueryError`를 따릅니다.
+- `RESTAURANT-001` unsupported genre, `RESTAURANT-002` unsupported sort, `RESTAURANT-003` unsupported list type은 구현 중 param mapping 오류로 보고 local error UI와 테스트로 잡습니다.
+- ErrorBoundary가 화면 전체 fallback을 렌더링하면 Header/FilterBar까지 사라지므로, 제품 요구가 리스트 영역 error라면 `throwOnError: false`를 이 query에서 명시합니다.
+
 ## Verification
 
-- [x] `corepack pnpm --filter @hashi/client test -- HashiPickPage.test.tsx PopularRestaurantsPage.test.tsx FilterBottomSheet.test.tsx`
-- [x] `corepack pnpm --filter @hashi/client lint`
-- [x] `corepack pnpm --filter @hashi/client typecheck`
-- [x] `corepack pnpm --filter @hashi/client build`
-- [x] `corepack pnpm --filter @hashi/client test`
+- [ ] `corepack pnpm --filter @hashi/client test -- HashiPickPage.test.tsx PopularRestaurantsPage.test.tsx getRestaurants.test.ts useRestaurantsInfiniteQuery.test.tsx`
+- [ ] `corepack pnpm --filter @hashi/client lint`
+- [ ] `corepack pnpm --filter @hashi/client typecheck`
+- [ ] `corepack pnpm --filter @hashi/client build`
+- [ ] 수동 확인: `/restaurants/popular` 진입, 정렬 적용, 장르 적용, 다음 페이지 fetch, empty, 400 local error, 5xx/ErrorBoundary 정책

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
@@ -41,20 +41,24 @@
 - [x] 음식 장르 기본 적용값은 `전체`이고, 필터바 기본 label은 `음식 장르 선택`입니다.
 - [x] 정렬/음식 장르 BottomSheet는 `draft`와 `selected` 상태를 분리합니다.
 - [x] 옵션 선택만으로 실제 필터 label을 바꾸지 않고 `적용` 버튼에서 반영합니다.
-- [x] `초기화`는 현재 열린 sheet의 draft 값만 기본값으로 되돌립니다.
+- [x] `초기화`는 현재 열린 sheet 값을 기본값으로 적용하고 BottomSheet를 닫습니다.
 - [x] 필터 BottomSheet는 X 버튼으로만 닫힙니다.
 - [x] RestaurantCard는 반복 렌더링되고 카드 클릭 시 식당 상세 route로 이동합니다.
-- [x] 식당 이미지는 가로 스크롤 리스트로 표시하고 이미지가 없으면 공통 `DefaultImage` fallback을 사용합니다.
-- [ ] 식당 리스트는 `GET /api/v1/restaurants` 응답을 커서 기반 무한스크롤로 렌더링합니다.
-- [ ] mock data는 API loading/error/empty 테스트용 fixture로만 남기고 production render path에서 제거합니다.
+- [x] 식당 이미지는 서버가 내려준 이미지만 가로 스크롤 리스트로 표시하고 부족한 슬롯을 `DefaultImage`로 채우지 않습니다.
+- [x] 서버 이미지(`imageUrls`, fallback `thumbnailUrl`)가 하나도 없으면 공통 `DefaultImage`를 1개만 표시합니다.
+- [x] 기존 shared 식당 목록 조회 API(`getRestaurants`, `restaurantsInfiniteQueryOptions`)를 사용해 `GET /api/v1/restaurants` 응답을 커서 기반 무한스크롤로 렌더링합니다.
+- [x] 현재 page의 `MOCK_RESTAURANTS` prop 주입은 production render path에서 제거했습니다.
 - [x] fixed header는 `z-fixed` 토큰을 사용하고, 스크롤 콘텐츠는 fixed header 높이만큼 top padding을 둡니다.
 
 ## Data Dependencies
 
 ### Source
 
+- Server API spec:
+  - user-provided `식당 목록 조회 (검색/장르 필터/정렬/큐레이션 유형 포함)` text spec
 - OpenAPI generated type:
   - `apps/client/src/shared/api/generated/openapi.ts`
+  - 구현 직전 backend schema가 바뀌었으면 `pnpm gen:api-types`로 최신화한 뒤 이 spec의 Response Mapping과 다시 비교합니다.
 - HTTP client:
   - `apps/client/src/shared/api/request.ts`
   - `apps/client/src/shared/api/apiClient.ts`
@@ -68,11 +72,20 @@
   - `apps/client/src/features/restaurantList/queries/restaurantListQueryKeys.ts`
   - `apps/client/src/features/restaurantList/queries/useRestaurantsInfiniteQuery.ts`
 
+### Current Implementation
+
+- 식당 목록 조회 endpoint 함수, query key factory, infinite query options는 `features/restaurantList`에 이미 구현되어 있습니다.
+- `PopularRestaurantsPage`는 `restaurantType="popular"`를 `RestaurantListPage`에 넘기고, `MOCK_RESTAURANTS`를 production render path에서 사용하지 않습니다.
+- `RestaurantListPage`와 `useRestaurantListPage`는 `restaurants` prop과 `useInfiniteRestaurantList` local slice가 아니라 TanStack Query server state와 `useInfiniteScrollTrigger`를 사용합니다.
+- 이 API 연동은 기존 shared 식당 목록 API를 새로 만들지 않고, 인기 맛집 route UI가 기존 query options를 소비하도록 연결합니다.
+- 검색 화면과 같은 `restaurantsInfiniteQueryOptions` 패턴을 사용하되, 검색어 `keyword` 대신 인기 맛집 목록 유형 `type`을 고정해서 보냅니다.
+- 서버 기반 무한스크롤은 검색/매거진 화면 관례처럼 `useInfiniteScrollTrigger`로 sentinel intersect 시 `fetchNextPage`를 호출합니다. 기존 `useInfiniteRestaurantList` local slicing은 mock fixture 전용 경로에만 남기거나 제거합니다.
+
 ### API Integration Map
 
 | UI area             | Endpoint                  | Params                                                                             | Response data                                             | Query key                                      | Mode       | Enabled | States                                                     |
 | ------------------- | ------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------- | ---------- | ------- | ---------------------------------------------------------- |
-| 인기 맛집 식당 목록 | `GET /api/v1/restaurants` | `type`, `genre`, `foodCategory`, `sort`, `cursor`, `size`; `keyword`는 보내지 않음 | `RestaurantListResponse.content`, `nextCursor`, `hasNext` | `restaurantListQueryKeys.infiniteList(params)` | `infinite` | always  | initial loading, next-page fetching, error, empty, success |
+| 인기 맛집 식당 목록 | `GET /api/v1/restaurants` | `type`, `genre`, `sort`, `cursor`, `size`; `keyword`, `foodCategory`는 보내지 않음 | `RestaurantListResponse.content`, `nextCursor`, `hasNext` | `restaurantListQueryKeys.infiniteList(params)` | `infinite` | always  | initial loading, next-page fetching, error, empty, success |
 
 ### Endpoint Type Mapping
 
@@ -83,25 +96,23 @@
 ### Request Params
 
 - `type`:
-  - 인기 맛집 목록을 서버에서 구분하는 식당 목록 유형입니다.
-  - 현재 OpenAPI는 `type?: string`만 제공하고 허용 value enum을 제공하지 않습니다.
-  - 구현 전 서버에 인기 맛집용 value가 `popular`인지 확인해야 합니다.
-  - 만약 서버가 인기 맛집을 `type`이 아니라 `sort=popular`만으로 표현한다면, 이 화면의 `기본순`은 `sort=popular`로 보내고 `type`은 생략해야 합니다.
+  - 검색 화면의 `keyword` 자리에 해당하는 페이지 고정 필터입니다. 인기 맛집 목록 유형을 API `type`으로 보냅니다.
+  - 음식 장르 필터는 `type`이 아니라 아래 `genre`로 보냅니다.
+  - 서버 명세 기준 인기 맛집 value는 `popular`입니다.
 - `genre`:
   - 음식 장르 BottomSheet의 선택값을 API 값으로 변환해 보냅니다.
   - `전체`는 `all`로 보냅니다.
   - `스시/사시미류`는 `sushi`, `면류`는 `noodle`, `덮밥류`는 `rice-bowl`, `나베/냄비류`는 `nabe`, `튀김류`는 `fried`, `철판/구이류`는 `grill`, `기타`는 `etc`로 보냅니다.
-  - 현재 `features/restaurantList/constants/category.ts`의 value 중 `riceBowl`, `grill`은 API value와 다르므로 request param 생성 helper에서 정규화합니다.
+  - 현재 `features/restaurantList/constants/category.ts`의 value 중 `riceBowl`은 API value와 다르므로 request param 생성 helper에서 `rice-bowl`로 정규화합니다.
 - `foodCategory`:
-  - 현재 화면의 장르 필터가 API `genre`에 매핑된다는 검색 page spec과 맞춥니다.
-  - 서버가 이 화면에서 `foodCategory`를 요구하면 `genre` 대신 또는 함께 보내야 하므로 서버 확인이 필요합니다.
+  - 서버 명세에는 별도 카테고리 필터로 존재하지만, 현재 인기 맛집 UI에는 음식 장르 BottomSheet만 있으므로 보내지 않습니다.
+  - 추후 UI가 음식 카테고리와 음식 장르를 분리하면 `foodCategory` request param을 별도로 추가합니다.
 - `sort`:
-  - `기본순`은 인기 맛집 목록의 기본 서버 정렬을 유지합니다.
-  - 서버가 인기 맛집을 `type=popular`로 구분한다면 `기본순`에서는 `sort`를 생략합니다.
-  - 서버가 인기 맛집을 `sort=popular`로 구분한다면 `기본순`에서 `sort=popular`를 보내야 합니다.
+  - `기본순`은 API `sort=basic`으로 보냅니다.
   - `별점순`은 `rating`을 보냅니다.
 - `size`:
-  - 첫 연동은 검색 page와 같은 `20`을 사용합니다.
+  - 첫 연동은 검색 page와 식당 목록 상수 관습에 맞춰 `10`을 사용합니다.
+  - 구현에서는 기존 `RESTAURANT_LIST_PAGE_SIZE = 10` 상수를 재사용하거나, page query wrapper 가까이에 같은 의미의 page size 상수를 두되 중복 의미가 생기지 않게 합니다.
 - `cursor`:
   - 첫 페이지는 보내지 않고, 다음 페이지부터 이전 응답의 `nextCursor`를 그대로 보냅니다.
 - `keyword`:
@@ -114,14 +125,23 @@
 - request params:
   - `{ type, genre, sort, size }`
   - `cursor`는 다음 페이지 fetch 시 `getNextPageParam`에서만 추가합니다.
+  - 검색 화면의 `createSearchRestaurantsRequestParams`와 같은 방식으로 인기 맛집 전용 request param helper를 둡니다.
+  - 커서로 다음 페이지를 요청할 때는 서버 명세에 따라 첫 페이지와 동일한 `sort`를 유지합니다.
+- data derivation:
+  - `query.data?.pages.flatMap((page) => page.restaurants)`로 page data를 평탄화합니다.
+  - 평탄화한 `RestaurantSummaryResponse[]`를 mapper로 `Restaurant[]` view model로 변환합니다.
+- infinite scroll trigger:
+  - `useInfiniteScrollTrigger<HTMLLIElement>`를 사용합니다.
+  - `enabled`는 `Boolean(query.hasNextPage)`, `isLoading`은 `query.isFetchingNextPage`, `onIntersect`는 `query.fetchNextPage`로 연결합니다.
+  - 다음 페이지 fetching 중에는 기존 리스트를 유지하고 중복 호출은 shared hook lock과 `isFetchingNextPage`로 막습니다.
 - loading state:
   - Header와 FilterBar는 유지합니다.
   - 첫 페이지 loading은 리스트 영역에 card skeleton 또는 `LoadingScreen` 계열 fallback을 표시합니다.
   - 다음 페이지 fetching은 기존 리스트를 유지하고 하단 sentinel 영역에 pending indicator를 둡니다.
 - error state:
   - 예상 가능한 400 계열 API error는 리스트 영역 local error UI로 표시하고 재시도 버튼을 제공합니다.
-  - 5xx, network, timeout, unexpected non-API error는 `queryClient` 기본 정책에 따라 최대 1회 retry 후 ErrorBoundary throw 후보입니다.
-  - 화면 전체 대신 리스트 영역에 error UI를 유지해야 하면 query option에서 `throwOnError: false`를 명시합니다.
+  - Header와 FilterBar를 유지해야 하므로 인기 맛집 page query wrapper는 `throwOnError: false`를 명시하고 리스트 영역 local error UI를 유지합니다.
+  - 5xx, network, timeout, unexpected non-API error도 queryClient 기본 retry 정책으로 최대 1회 retry하되 ErrorBoundary로 throw하지 않습니다.
 - empty state:
   - API content가 비어 있고 다음 페이지가 없으면 빈 목록 안내를 표시합니다.
 - refetch condition:
@@ -136,28 +156,28 @@
 
 ### Response Mapping
 
-| API field                           | UI use                        | Nullable | Transform / 판단                                                                                           |
-| ----------------------------------- | ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `RestaurantListResponse.content`    | 카드 리스트                   | yes      | 없으면 빈 배열로 정규화합니다.                                                                             |
-| `RestaurantListResponse.nextCursor` | 다음 페이지 cursor            | yes      | `hasNext`가 true일 때만 다음 요청 `cursor`로 전달합니다.                                                   |
-| `RestaurantListResponse.hasNext`    | 하단 sentinel 노출            | yes      | 없으면 `false`로 정규화합니다.                                                                             |
-| `restaurantId`                      | card key, 상세 route param    | yes      | 문자열로 변환합니다. 누락 시 상세 이동이 불가능하므로 해당 item 제외 또는 서버 required 요청이 필요합니다. |
-| `name`                              | 식당명                        | yes      | 누락 시 `이름 없는 식당` fallback을 쓰되 서버 required 요청 대상입니다.                                    |
-| `rating`                            | 별점                          | yes      | 누락 시 `0`으로 표시합니다.                                                                                |
-| `area`                              | 지역 label                    | yes      | 카드의 `{region} · {category}` 중 region으로 사용합니다.                                                   |
-| `foodCategory`                      | 음식 카테고리 label           | yes      | category 우선값입니다. 없으면 `genre`를 fallback으로 사용합니다.                                           |
-| `genre`                             | 음식 카테고리 fallback/filter | yes      | 서버가 한글 label 또는 API code를 줄 수 있으므로 mapper에서 label 변환을 흡수합니다.                       |
-| `imageUrls`                         | 가로 스크롤 이미지 리스트     | yes      | 비어 있으면 `thumbnailUrl` 단일 이미지로 fallback합니다.                                                   |
-| `thumbnailUrl`                      | 이미지 fallback               | yes      | `imageUrls`가 없을 때만 리스트 이미지로 사용합니다.                                                        |
-| `summary`                           | 식당 소개                     | yes      | 카드 설명 문구로 사용합니다. 영업시간으로 매핑하지 않습니다.                                               |
-| `hashtags`                          | 관련 해시태그                 | yes      | `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.                                                         |
+| API field                           | UI use                        | Nullable           | Transform / 판단                                                                                                                                               |
+| ----------------------------------- | ----------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RestaurantListResponse.content`    | 카드 리스트                   | yes                | 없으면 빈 배열로 정규화합니다.                                                                                                                                 |
+| `RestaurantListResponse.nextCursor` | 다음 페이지 cursor            | yes                | `hasNext`가 true일 때만 다음 요청 `cursor`로 전달합니다.                                                                                                       |
+| `RestaurantListResponse.hasNext`    | 하단 sentinel 노출            | yes                | 없으면 `false`로 정규화합니다.                                                                                                                                 |
+| `restaurantId`                      | card key, 상세 route param    | generated optional | 서버 명세상 필수입니다. 문자열로 변환합니다. 실제 응답에서 누락되면 해당 item은 상세 이동이 불가능하므로 제외합니다.                                           |
+| `name`                              | 식당명                        | generated optional | 서버 명세상 필수입니다. 누락 시 `이름 없는 식당` fallback을 사용합니다.                                                                                        |
+| `rating`                            | 별점                          | generated optional | 서버 명세상 필수입니다. 누락 시 `0`으로 표시하고, UI에서는 `4.0`, `3.0`처럼 소수점 1자리로 표시합니다.                                                         |
+| `area`                              | 지역 label                    | generated optional | 서버 명세상 필수입니다. 카드의 `{region} · {category}` 중 region으로 사용합니다.                                                                               |
+| `foodCategory`                      | 음식 카테고리 label           | generated optional | 서버 명세상 필수입니다. category 우선값입니다. 없으면 `genre`를 fallback으로 사용합니다.                                                                       |
+| `genre`                             | 음식 카테고리 fallback/filter | generated optional | 서버가 한글 label 또는 API code를 줄 수 있으므로 mapper에서 label 변환을 흡수합니다.                                                                           |
+| `imageUrls`                         | 가로 스크롤 이미지 리스트     | generated optional | 서버 명세상 최대 3개입니다. 서버가 내려준 이미지만 표시하고 부족한 슬롯을 `DefaultImage`로 채우지 않습니다. 없으면 `thumbnailUrl`을 fallback으로 봅니다.       |
+| `thumbnailUrl`                      | 이미지 fallback               | generated optional | 서버 명세상 필수입니다. `imageUrls`가 없을 때만 리스트 이미지로 사용합니다. `imageUrls`와 `thumbnailUrl`이 모두 없으면 UI에서 `DefaultImage` 1개를 표시합니다. |
+| `summary`                           | 식당 소개                     | generated optional | 서버 명세상 필수입니다. 카드 설명 문구로 사용합니다. 영업시간으로 매핑하지 않습니다.                                                                           |
+| `hashtags`                          | 관련 해시태그                 | generated optional | 서버 명세상 필수입니다. `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.                                                                                     |
+| `todayBusinessHour`                 | 사용 안 함                    | yes                | 인기 맛집 카드 UI에는 영업시간 영역이 없으므로 매핑하지 않습니다.                                                                                              |
 
 ### Missing Server Questions
 
-- 인기 맛집 목록용 `type` 허용값이 무엇인지 확인해야 합니다. 현재 generated OpenAPI에는 `type?: string`만 있고 enum 또는 예시가 없습니다.
-- 인기 맛집의 `기본순`이 `type=popular`의 서버 기본 정렬인지, 아니면 `sort=popular`를 보내야 하는지 확인해야 합니다.
-- 화면의 음식 장르 필터는 API `genre`와 `foodCategory` 중 어느 파라미터가 정식 계약인지 확인해야 합니다. 검색 page spec은 UI 장르를 `genre`로 보내고 있습니다.
-- `restaurantId`, `name`, `rating`, `area`, `foodCategory` 또는 `genre`, `summary`가 목록 카드에서 사실상 필수인데 generated type은 모두 optional입니다. 서버가 required로 내려주는지, 아니면 프론트 fallback/필터링을 공식 처리로 둘지 확인해야 합니다.
+- None.
+- 서버 명세로 `type=popular`, `sort=basic | rating`, `genre` 필터 사용이 확인되었습니다.
+- 단, `openapi.ts` generated type은 response 필드를 optional로 생성하므로 구현은 defensive fallback을 유지합니다.
 
 ## State
 
@@ -169,7 +189,7 @@
 - form state: none
 - URL state: none
 - server state:
-  - `useRestaurantsInfiniteQuery` result pages
+  - `useInfiniteQuery(restaurantsInfiniteQueryOptions(requestParams))` result pages
 - derived state:
   - category filter label: `전체`일 때 `음식 장르 선택`, 그 외 selected label
   - selected sort/category -> API request params
@@ -187,7 +207,7 @@ PopularRestaurantsPage
     RestaurantFilterBar
     RestaurantCard list
       RestaurantImageList
-        DefaultImage fallback
+        server images or single DefaultImage fallback
     FilterBottomSheet(sort)
     FilterBottomSheet(category)
 ```
@@ -210,6 +230,10 @@ PopularRestaurantsPage
   - `useRestaurantListPage`
   - `useRestaurantsInfiniteQuery`
   - `restaurantsInfiniteQueryOptions`
+- feature query composition:
+  - `createRestaurantListRequestParams`
+  - `restaurantsInfiniteQueryOptions`
+  - `useRestaurantListPage`에서 `restaurantsInfiniteQueryOptions`를 감싸고 `throwOnError: false`를 명시합니다.
 - feature mapper:
   - `RestaurantSummaryResponse` -> `Restaurant`
 - feature mock:
@@ -236,13 +260,14 @@ PopularRestaurantsPage
 
 - API transport와 envelope parsing은 `request<TData>()`를 사용해 기존 `ky`, `ApiError`, `HttpStatusError` 설정을 그대로 활용합니다.
 - query retry/throw 기본값은 `createQueryClient`의 `checkShouldRetryQuery`, `checkShouldThrowQueryError`를 따릅니다.
-- `RESTAURANT-001` unsupported genre, `RESTAURANT-002` unsupported sort, `RESTAURANT-003` unsupported list type은 구현 중 param mapping 오류로 보고 local error UI와 테스트로 잡습니다.
-- ErrorBoundary가 화면 전체 fallback을 렌더링하면 Header/FilterBar까지 사라지므로, 제품 요구가 리스트 영역 error라면 `throwOnError: false`를 이 query에서 명시합니다.
+- `COMMON-400` cursor/size validation, `RESTAURANT-001` unsupported genre, `RESTAURANT-002` unsupported sort, `RESTAURANT-003` unsupported type은 구현 중 param mapping 오류로 보고 local error UI와 테스트로 잡습니다.
+- 이 화면은 `foodCategory`를 보내지 않지만, 추후 추가 시 `RESTAURANT-007` unsupported foodCategory도 local error UI 대상입니다.
+- ErrorBoundary가 화면 전체 fallback을 렌더링하면 Header/FilterBar까지 사라지므로 `throwOnError: false`를 이 query wrapper에서 명시합니다.
 
 ## Verification
 
-- [ ] `corepack pnpm --filter @hashi/client test -- HashiPickPage.test.tsx PopularRestaurantsPage.test.tsx getRestaurants.test.ts useRestaurantsInfiniteQuery.test.tsx`
-- [ ] `corepack pnpm --filter @hashi/client lint`
-- [ ] `corepack pnpm --filter @hashi/client typecheck`
-- [ ] `corepack pnpm --filter @hashi/client build`
+- [x] `corepack pnpm --filter @hashi/client test -- src/app/router/routes.test.tsx src/features/restaurantList/utils/createRestaurantListRequestParams.test.ts src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.test.ts src/features/restaurantList/api/getRestaurants.test.ts src/pages/search/queries/useSearchRestaurantsInfiniteQuery.test.tsx`
+- [x] `corepack pnpm --filter @hashi/client lint`
+- [x] `corepack pnpm --filter @hashi/client typecheck`
+- [x] `corepack pnpm --filter @hashi/client build`
 - [ ] 수동 확인: `/restaurants/popular` 진입, 정렬 적용, 장르 적용, 다음 페이지 fetch, empty, 400 local error, 5xx/ErrorBoundary 정책

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx
@@ -1,10 +1,26 @@
 import '@testing-library/jest-dom/vitest'
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ROUTES } from '@/app/router/path'
+import { getRestaurants } from '@/features/restaurantList'
 import { PopularRestaurantsPage } from '@/pages/popularRestaurants/PopularRestaurantsPage'
+import { createQueryClient } from '@/shared/lib/queryClient'
+
+vi.mock('@/features/restaurantList/api/getRestaurants', () => ({
+  getRestaurants: vi.fn(),
+}))
+
+const mockedGetRestaurants = vi.mocked(getRestaurants)
 
 const LocationPath = () => {
   const location = useLocation()
@@ -12,18 +28,57 @@ const LocationPath = () => {
   return <div data-testid="location-path">{location.pathname}</div>
 }
 
+const createRestaurantsResult = ({
+  count,
+  hasNext = false,
+  imageUrls = [],
+  nextCursor,
+  rating = 4,
+  startId = 1,
+}: {
+  count: number
+  hasNext?: boolean
+  imageUrls?: string[]
+  nextCursor?: string
+  rating?: number
+  startId?: number
+}): Awaited<ReturnType<typeof getRestaurants>> => {
+  return {
+    hasNext,
+    nextCursor,
+    restaurants: Array.from({ length: count }, (_, index) => {
+      const restaurantId = startId + index
+
+      return {
+        area: '도쿄',
+        foodCategory: '초밥',
+        hashtags: ['해시태그'],
+        imageUrls,
+        name: `히마와리 스시 ${restaurantId}`,
+        rating,
+        restaurantId,
+        summary: '식당 소개를 여기 간단하게 한 줄 적어주세요.',
+      }
+    }),
+  }
+}
+
 const renderPopularRestaurantsPage = () => {
+  const queryClient = createQueryClient()
+
   return render(
-    <MemoryRouter initialEntries={[ROUTES.popularRestaurants]}>
-      <Routes>
-        <Route
-          element={<PopularRestaurantsPage />}
-          path={ROUTES.popularRestaurants}
-        />
-        <Route element={<LocationPath />} path={ROUTES.restaurantDetail} />
-        <Route element={<LocationPath />} path={ROUTES.home} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[ROUTES.popularRestaurants]}>
+        <Routes>
+          <Route
+            element={<PopularRestaurantsPage />}
+            path={ROUTES.popularRestaurants}
+          />
+          <Route element={<LocationPath />} path={ROUTES.restaurantDetail} />
+          <Route element={<LocationPath />} path={ROUTES.home} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -63,13 +118,20 @@ const mockIntersectionObserver = () => {
 }
 
 describe('PopularRestaurantsPage', () => {
+  beforeEach(() => {
+    mockedGetRestaurants.mockResolvedValue(
+      createRestaurantsResult({ count: 3 }),
+    )
+  })
+
   afterEach(() => {
     cleanup()
     document.body.style.overflow = ''
+    mockedGetRestaurants.mockReset()
     vi.unstubAllGlobals()
   })
 
-  it('renders popular restaurant list with default and rating sort options', () => {
+  it('renders popular restaurant list with default and rating sort options', async () => {
     renderPopularRestaurantsPage()
 
     expect(screen.getByTestId('restaurant-list-sticky-header')).toHaveClass(
@@ -80,13 +142,22 @@ describe('PopularRestaurantsPage', () => {
     expect(screen.getByTestId('restaurant-list-scroll-content')).toHaveClass(
       'pt-[75px]',
     )
-    expect(screen.getByTestId('restaurant-list')).not.toHaveClass('pt-[123px]')
     expect(
       screen.getByRole('heading', { name: '인기 맛집' }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: '정렬 필터: 기본순' }),
     ).toBeInTheDocument()
+    expect(
+      await screen.findAllByRole('button', { name: /히마와리 스시/ }),
+    ).toHaveLength(3)
+    expect(screen.getAllByText('4.0')).toHaveLength(3)
+    expect(mockedGetRestaurants).toHaveBeenCalledWith({
+      genre: 'all',
+      size: 10,
+      sort: 'basic',
+      type: 'popular',
+    })
 
     fireEvent.click(screen.getByRole('button', { name: '정렬 필터: 기본순' }))
 
@@ -94,6 +165,27 @@ describe('PopularRestaurantsPage', () => {
     expect(
       screen.queryByRole('button', { name: '인기순' }),
     ).not.toBeInTheDocument()
+  })
+
+  it('applies rating sort to popular restaurants request params', async () => {
+    renderPopularRestaurantsPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
+
+    fireEvent.click(screen.getByRole('button', { name: '정렬 필터: 기본순' }))
+    fireEvent.click(screen.getByRole('button', { name: '별점순' }))
+    fireEvent.click(screen.getByRole('button', { name: '적용' }))
+
+    expect(
+      screen.getByRole('button', { name: '정렬 필터: 별점순' }),
+    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(mockedGetRestaurants).toHaveBeenLastCalledWith({
+        genre: 'all',
+        size: 10,
+        sort: 'rating',
+        type: 'popular',
+      })
+    })
   })
 
   it('navigates to home when the header back button is pressed', () => {
@@ -104,16 +196,14 @@ describe('PopularRestaurantsPage', () => {
     expect(screen.getByTestId('location-path')).toHaveTextContent(ROUTES.home)
   })
 
-  it('resets sort to default and closes the bottom sheet when reset is pressed', () => {
+  it('resets sort to default and closes the bottom sheet when reset is pressed', async () => {
     renderPopularRestaurantsPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
 
     fireEvent.click(screen.getByRole('button', { name: '정렬 필터: 기본순' }))
     fireEvent.click(screen.getByRole('button', { name: '별점순' }))
     fireEvent.click(screen.getByRole('button', { name: '적용' }))
-
-    expect(
-      screen.getByRole('button', { name: '정렬 필터: 별점순' }),
-    ).toBeInTheDocument()
+    await screen.findByRole('button', { name: '정렬 필터: 별점순' })
 
     fireEvent.click(screen.getByRole('button', { name: '정렬 필터: 별점순' }))
     fireEvent.click(screen.getByRole('button', { name: '초기화' }))
@@ -126,25 +216,73 @@ describe('PopularRestaurantsPage', () => {
     )
   })
 
-  it('loads restaurants in 10 item chunks when the bottom sentinel enters the viewport', () => {
+  it('fetches next page when the bottom sentinel enters the viewport', async () => {
+    mockedGetRestaurants
+      .mockResolvedValueOnce(
+        createRestaurantsResult({
+          count: 10,
+          hasNext: true,
+          nextCursor: 'c-10',
+        }),
+      )
+      .mockResolvedValueOnce(createRestaurantsResult({ count: 2, startId: 11 }))
     const { triggerIntersect } = mockIntersectionObserver()
 
     renderPopularRestaurantsPage()
 
     expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
+      await screen.findAllByRole('button', { name: /히마와리 스시/ }),
     ).toHaveLength(10)
+    await screen.findByTestId('restaurant-list-load-more')
 
     triggerIntersect()
 
+    await waitFor(() => {
+      expect(mockedGetRestaurants).toHaveBeenLastCalledWith({
+        cursor: 'c-10',
+        genre: 'all',
+        size: 10,
+        sort: 'basic',
+        type: 'popular',
+      })
+    })
     expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
-    ).toHaveLength(20)
+      await screen.findAllByRole('button', { name: /히마와리 스시/ }),
+    ).toHaveLength(12)
+  })
 
-    triggerIntersect()
+  it('renders only image urls returned by the server', async () => {
+    mockedGetRestaurants.mockResolvedValueOnce(
+      createRestaurantsResult({
+        count: 1,
+        imageUrls: [
+          'https://example.com/restaurant-1.jpg',
+          'https://example.com/restaurant-2.jpg',
+        ],
+      }),
+    )
 
-    expect(
-      screen.getAllByRole('button', { name: /히마와리 스시/ }),
-    ).toHaveLength(25)
+    renderPopularRestaurantsPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
+
+    expect(screen.getAllByRole('img')).toHaveLength(2)
+    expect(screen.queryByTestId('restaurant-image-placeholder')).toBeNull()
+  })
+
+  it('renders one default image when no image is returned by the server', async () => {
+    mockedGetRestaurants.mockResolvedValueOnce(
+      createRestaurantsResult({
+        count: 1,
+        imageUrls: [],
+      }),
+    )
+
+    renderPopularRestaurantsPage()
+    await screen.findByRole('button', { name: /히마와리 스시 1/ })
+
+    expect(screen.queryAllByRole('img')).toHaveLength(0)
+    expect(screen.getAllByTestId('restaurant-image-placeholder')).toHaveLength(
+      1,
+    )
   })
 })

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx
@@ -151,6 +151,9 @@ describe('PopularRestaurantsPage', () => {
     expect(
       await screen.findAllByRole('button', { name: /히마와리 스시/ }),
     ).toHaveLength(3)
+    expect(
+      screen.getByRole('button', { name: /히마와리 스시 3/ }).closest('li'),
+    ).toHaveClass('last:border-b-0')
     expect(screen.getAllByText('4.0')).toHaveLength(3)
     expect(mockedGetRestaurants).toHaveBeenCalledWith({
       genre: 'all',

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.tsx
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.tsx
@@ -1,5 +1,4 @@
 import {
-  MOCK_RESTAURANTS,
   POPULAR_RESTAURANTS_SORT_OPTIONS,
   RestaurantListPage,
 } from '@/features/restaurantList'
@@ -7,7 +6,7 @@ import {
 export const PopularRestaurantsPage = () => {
   return (
     <RestaurantListPage
-      restaurants={MOCK_RESTAURANTS}
+      restaurantType="popular"
       sortOptions={POPULAR_RESTAURANTS_SORT_OPTIONS}
       title="인기 맛집"
     />


### PR DESCRIPTION
## 📌 Summary
> 하시 Pick/인기 맛집 화면의 식당 리스트를 실제 식당 목록 조회 API 응답 기반으로 렌더링하도록 연동했습니다. 검색 화면과 동일한 식당 목록 API/query 구조를 재사용하고, 각 화면의 고정 큐레이션 유형에 맞춰 `type`, `genre`, `sort` 파라미터를 매핑했습니다. API 응답 기반 view model 정규화, 커서 기반 무한스크롤, 식당 상세 이동, 이미지/별점 표시 정책도 함께 반영했습니다.

Jira: [HASHI-117](https://siksa.atlassian.net/browse/HASHI-117)

## 📚 Tasks

- 하시 Pick 식당 리스트 API 연동
- 인기 맛집 식당 리스트 API 연동
- 기존 식당 목록 조회 API/query option 재사용
- 화면별 큐레이션 `type` 고정값 적용
- 장르/정렬 필터 API request param 매핑
- 커서 기반 무한스크롤 처리
- API 응답 기반 식당 카드 view model 정규화
- 식당 카드 클릭 시 상세 화면 이동 처리
- 서버 이미지 표시 정책 반영
- 별점 소수점 1자리 표시 처리
- 하시 Pick/인기 맛집 API 연동 테스트 보강
- 하시 Pick/인기 맛집 spec 문서 최신화

## 🔎 Description

1. 하시 Pick/인기 맛집 화면에서 기존 mock 기반 리스트 대신 서버 API 응답을 사용하도록 변경했습니다.

- `GET /api/v1/restaurants`
  - 하시 Pick 화면은 `type=hashi-pick`을 고정해서 요청합니다.
  - 인기 맛집 화면은 `type=popular`를 고정해서 요청합니다.
  - 검색 화면과 동일하게 `restaurantsInfiniteQueryOptions`를 재사용합니다.
  - 각 화면에는 검색어 UI가 없으므로 `keyword`는 보내지 않습니다.

2. 장르/정렬 필터는 UI 선택값을 API 값으로 변환해 요청합니다.

- `genre`
  - `전체`는 `all`
  - `스시/사시미류`는 `sushi`
  - `면류`는 `noodle`
  - `덮밥류`는 `rice-bowl`
  - `나베/냄비류`는 `nabe`
  - `튀김류`는 `fried`
  - `철판/구이류`는 `grill`
  - `기타`는 `etc`
- `sort`
  - `기본순`은 `basic`
  - 하시 Pick의 `인기순`은 `popular`
  - `별점순`은 `rating`

3. 식당 리스트는 TanStack Query의 `useInfiniteQuery`로 연결했습니다.

- 첫 요청에는 `cursor`를 보내지 않습니다.
- 이후 페이지부터 `pageParam`으로 받은 `nextCursor`를 요청에 포함합니다.
- `size=10` 기준으로 조회합니다.
- 하단 sentinel이 viewport에 들어오면 `fetchNextPage`를 호출합니다.
- 검색 화면과 동일하게 `useInfiniteScrollTrigger`를 사용합니다.

4. API 응답은 UI 컴포넌트로 직접 전달하지 않고 feature mapper에서 view model로 정규화했습니다.

- `restaurantId`가 없으면 상세 이동이 불가능하므로 해당 item은 제외합니다.
- `restaurantId`는 문자열로 변환해 상세 route param으로 사용합니다.
- `name`이 없으면 `이름 없는 식당` fallback을 사용합니다.
- `rating`이 없으면 `0`으로 정규화합니다.
- `foodCategory`를 우선 category label로 사용하고, 없으면 `genre`를 fallback으로 사용합니다.
- `hashtags`는 `#` prefix가 없으면 UI mapper에서 붙여 표시합니다.
- `summary`는 식당 소개 문구로 사용합니다.
- `todayBusinessHour`는 현재 하시 Pick/인기 맛집 카드 UI에 노출 영역이 없어 사용하지 않습니다.

5. 식당 상세 이동은 검색/홈 화면 관례와 맞춰 route path를 생성합니다.

- 카드 클릭 시 `ROUTES.restaurantDetail`에 `restaurantId`를 주입해 이동합니다.
- `restaurantId`는 URL path segment로 들어가므로 `encodeURIComponent`를 적용합니다.

6. 이미지와 별점 표시 정책을 최신 기획 기준으로 반영했습니다.

- 서버에서 내려준 `imageUrls`가 있으면 해당 이미지만 표시합니다.
- 부족한 이미지 슬롯을 `DefaultImage`로 채우지 않습니다.
- `imageUrls`가 없으면 서버 `thumbnailUrl`을 단일 이미지 fallback으로 사용합니다.
- `imageUrls`와 `thumbnailUrl`이 모두 없으면 공통 `DefaultImage`를 1개만 표시합니다.
- 별점은 서버에서 `4`, `3`처럼 정수로 내려와도 `4.0`, `3.0`처럼 소수점 1자리로 표시합니다.

**테스트 보강**
- 하시 Pick 화면에서 API 응답 기반 식당 리스트가 렌더링되는지 확인
- 인기 맛집 화면에서 API 응답 기반 식당 리스트가 렌더링되는지 확인
- 화면별 고정 `type`, `genre`, `sort`, `size=10` request param 검증
- 정렬/장르 필터 적용 시 API param이 변경되는지 확인
- 커서 기반 다음 페이지 요청과 리스트 append 검증
- 식당 카드 클릭 시 상세 route로 이동하는지 확인
- 서버 이미지가 있을 때 해당 이미지만 렌더링되는지 확인
- 서버 이미지가 없을 때 `DefaultImage` 1개만 렌더링되는지 확인
- 별점이 소수점 1자리로 표시되는지 확인
- `restaurantId` 누락 응답은 상세 이동 불가 item으로 제외되는지 mapper 테스트로 검증

## 👀 To Reviewer

- 하시 Pick/인기 맛집은 기존 `GET /api/v1/restaurants` API를 재사용합니다.
- 각 화면의 큐레이션 구분은 `type`으로 고정해서 보냅니다.
  - 하시 Pick: `type=hashi-pick`
  - 인기 맛집: `type=popular`
- 두 화면 모두 검색어 UI가 없으므로 `keyword`는 보내지 않습니다.
- 현재 UI의 음식 장르 필터는 API `genre`로 매핑하고, `foodCategory`는 보내지 않습니다.
- 무한스크롤은 검색 화면과 동일한 `useInfiniteQuery` + `useInfiniteScrollTrigger` 패턴을 따릅니다.
- 첫 페이지와 다음 페이지 모두 `size=10`을 사용합니다.
- `openapi.ts` generated type상 응답 필드가 optional이므로 mapper에서 defensive fallback을 유지했습니다.
- 식당 이미지가 일부만 내려온 경우 부족한 슬롯을 채우지 않고 서버 이미지 개수만큼만 표시합니다.
- 서버 이미지가 아예 없을 때만 공통 `DefaultImage`를 1개 표시합니다.
- 별점은 항상 소수점 1자리로 표시합니다.
- 하시 Pick은 `기본순/인기순/별점순`, 인기 맛집은 `기본순/별점순`만 노출합니다.

## ✅ Verification

- `corepack pnpm --filter @hashi/client test -- src/pages/hashiPick/HashiPickPage.test.tsx src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx src/features/restaurantList/utils/mapRestaurantSummaryToRestaurant.test.ts src/features/restaurantList/utils/createRestaurantListRequestParams.test.ts`
- `corepack pnpm --filter @hashi/client typecheck`
- `corepack pnpm --filter @hashi/client lint`
- `corepack pnpm --filter @hashi/client build`
- `corepack pnpm format:check`
- `git diff --check`

## 📸 Screenshot
https://github.com/user-attachments/assets/ceb2b8cf-387b-410e-ae8e-effeb7caafd8

