### PR TITLE
Fix(client): HASHI-129 1차 QA 반영

### DIFF
--- a/apps/client/src/app/layout/BottomNavigationLayout.tsx
+++ b/apps/client/src/app/layout/BottomNavigationLayout.tsx
@@ -32,26 +32,38 @@ const bottomNavigationPath = {
 
 type BottomNavigationValue = (typeof bottomNavigationItems)[number]['value']
 
+type LoginRequiredLocationState = {
+  from?: {
+    pathname?: string
+  }
+}
+
 const getBottomNavigationValue = (
   pathname: string,
+  fallbackPathname?: string,
 ): BottomNavigationValue | undefined => {
-  if (pathname === ROUTES.myReservations) {
+  const targetPathname =
+    pathname === ROUTES.loginRequired && fallbackPathname
+      ? fallbackPathname
+      : pathname
+
+  if (targetPathname === ROUTES.myReservations) {
     return 'myReservations'
   }
 
-  if (pathname === ROUTES.saved) {
+  if (targetPathname === ROUTES.saved) {
     return 'save'
   }
 
-  if (pathname === ROUTES.map) {
+  if (targetPathname === ROUTES.map) {
     return 'map'
   }
 
-  if (pathname === ROUTES.mypage) {
+  if (targetPathname === ROUTES.mypage) {
     return 'mypage'
   }
 
-  if (pathname === ROUTES.home) {
+  if (targetPathname === ROUTES.home) {
     return 'home'
   }
 
@@ -61,6 +73,7 @@ const getBottomNavigationValue = (
 export const BottomNavigationLayout = () => {
   const location = useLocation()
   const navigate = useNavigate()
+  const loginRequiredState = location.state as LoginRequiredLocationState | null
 
   return (
     <>
@@ -77,7 +90,10 @@ export const BottomNavigationLayout = () => {
             )
           }
         }}
-        value={getBottomNavigationValue(location.pathname)}
+        value={getBottomNavigationValue(
+          location.pathname,
+          loginRequiredState?.from?.pathname,
+        )}
       />
     </>
   )

--- a/apps/client/src/features/restaurantList/RestaurantListPage.tsx
+++ b/apps/client/src/features/restaurantList/RestaurantListPage.tsx
@@ -87,7 +87,7 @@ export const RestaurantListPage = ({
     visibleRestaurants.length > 0 || hasMoreRestaurants || isFetchingNextPage
 
   return (
-    <div className="min-h-dvh bg-white">
+    <div className="flex min-h-dvh flex-col bg-white">
       <div
         className="app-mobile-fixed-top z-fixed bg-white"
         data-testid="restaurant-list-sticky-header"
@@ -107,7 +107,10 @@ export const RestaurantListPage = ({
         />
       </div>
 
-      <div className="pt-[75px]" data-testid="restaurant-list-scroll-content">
+      <div
+        className="flex flex-1 flex-col pt-[75px]"
+        data-testid="restaurant-list-scroll-content"
+      >
         <RestaurantFilterBar
           categoryLabel={categoryLabel}
           onClickCategory={handleOpenCategorySheet}
@@ -158,8 +161,8 @@ export const RestaurantListPage = ({
               </ul>
             ) : null}
             {shouldRenderEmptyState ? (
-              <div className="px-5">
-                <ListEmptyState description="" />
+              <div className="flex flex-1 items-center justify-center px-5">
+                <ListEmptyState description="검색된 식당이 없습니다." />
               </div>
             ) : null}
           </>

--- a/apps/client/src/features/restaurantList/RestaurantListPage.tsx
+++ b/apps/client/src/features/restaurantList/RestaurantListPage.tsx
@@ -12,6 +12,7 @@ import type {
   RestaurantListCurationType,
 } from '@/features/restaurantList'
 import { FilterBottomSheet } from '@/shared/components/filterBottomSheet'
+import { ListEmptyState } from '@/shared/components/listEmptyState'
 
 type RestaurantListPageProps = {
   title: string
@@ -157,10 +158,8 @@ export const RestaurantListPage = ({
               </ul>
             ) : null}
             {shouldRenderEmptyState ? (
-              <div className="flex min-h-[360px] items-center justify-center px-5 text-center">
-                <p className="typo-body-4 text-warm-gray-300">
-                  표시할 식당이 없습니다.
-                </p>
+              <div className="px-5">
+                <ListEmptyState description="" />
               </div>
             ) : null}
           </>

--- a/apps/client/src/features/restaurantList/components/RestaurantCard.tsx
+++ b/apps/client/src/features/restaurantList/components/RestaurantCard.tsx
@@ -25,7 +25,7 @@ export const RestaurantCard = ({
         onClick={handleClickRestaurant}
         type="button"
       >
-        <span className="typo-body-3 text-cool-gray-900 line-clamp-1">
+        <span className="typo-sub-header-2 text-cool-gray-900 line-clamp-1">
           {restaurant.name}
         </span>
         <span className="text-primary-200 mt-1 flex h-5 items-center">

--- a/apps/client/src/pages/hashiPick/HashiPickPage.test.tsx
+++ b/apps/client/src/pages/hashiPick/HashiPickPage.test.tsx
@@ -105,6 +105,9 @@ describe('HashiPickPage', () => {
       'bg-white',
     )
     expect(screen.getByTestId('restaurant-list-scroll-content')).toHaveClass(
+      'flex',
+      'flex-1',
+      'flex-col',
       'pt-[75px]',
     )
     expect(

--- a/apps/client/src/pages/home/HomePage.test.tsx
+++ b/apps/client/src/pages/home/HomePage.test.tsx
@@ -233,7 +233,7 @@ describe('HomePage', () => {
     expect(image).not.toBeInTheDocument()
     expect(
       screen.getByLabelText('돈카츠 후쿠마루 도쿄역 야에스점 대표 이미지'),
-    ).toHaveClass('bg-warm-gray-50')
+    ).toHaveClass('bg-warm-gray-100')
   })
 
   it('hides the SNS hot restaurant section when the API returns no restaurants', async () => {

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.test.tsx
@@ -105,6 +105,9 @@ describe('PopularRestaurantsPage', () => {
       'bg-white',
     )
     expect(screen.getByTestId('restaurant-list-scroll-content')).toHaveClass(
+      'flex',
+      'flex-1',
+      'flex-col',
       'pt-[75px]',
     )
     expect(

--- a/apps/client/src/pages/search/SearchPage.test.tsx
+++ b/apps/client/src/pages/search/SearchPage.test.tsx
@@ -301,7 +301,7 @@ describe('SearchPage', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(10)
     expect(
       screen.getAllByRole('listitem')[0].querySelector('a')?.firstChild,
-    ).toHaveClass('bg-warm-gray-50')
+    ).toHaveClass('bg-warm-gray-100')
     expect(window.localStorage.getItem('hashi:search:recent-keywords')).toBe(
       JSON.stringify(['아끼소바']),
     )
@@ -343,7 +343,7 @@ describe('SearchPage', () => {
 
     expect(image).not.toBeInTheDocument()
     expect(
-      screen.getAllByRole('listitem')[0].querySelector('.bg-warm-gray-50'),
+      screen.getAllByRole('listitem')[0].querySelector('.bg-warm-gray-100'),
     ).toBeInTheDocument()
   })
 

--- a/apps/client/src/shared/components/defaultImage/DefaultImage.tsx
+++ b/apps/client/src/shared/components/defaultImage/DefaultImage.tsx
@@ -26,7 +26,7 @@ export const DefaultImage = ({
   return (
     <div
       className={cn(
-        'bg-warm-gray-50 flex items-center justify-center overflow-hidden',
+        'bg-warm-gray-100 flex items-center justify-center overflow-hidden',
         className,
       )}
       {...props}


### PR DESCRIPTION
## 📌 Summary

> 1차 QA에서 확인된 식당 리스트/401 페이지/식당 상세 리뷰 이미지/복사 토스트 UI 이슈를 반영했습니다.

하시 PICK/인기 맛집 공통 식당 카드의 식당명 typography를 QA 기준에 맞게 조정하고, empty 상태는 공통 `ListEmptyState`를 사용하도록 변경했습니다.  
401 로그인 필요 페이지에서는 비로그인 사용자가 하단 네비게이션 탭을 눌러 redirect된 경우, 원래 접근하려던 탭의 active 상태가 유지되도록 처리했습니다.  
오늘의 식당/식당 상세 리뷰 이미지 뷰어는 닫을 때 기존 스크롤 위치를 복원하도록 수정했고, 식당명 복사 토스트에는 링크 아이콘을 추가했습니다.

Jira: HASHI-129

## 📚 Tasks

- 하시 PICK/인기 맛집 식당 리스트 QA 반영
  - 공통 `RestaurantCard` 식당명 typography를 `SubHeader2`로 변경
  - 식당 리스트 empty 상태에 shared `ListEmptyState` 적용
  - empty 상태는 QA 기준에 맞춰 안내 문구 없이 이미지만 노출

- 401 로그인 필요 페이지 하단 네비게이션 active 처리
  - `/login-required`로 redirect될 때 `location.state.from.pathname` 기준으로 하단 네비 active 값 계산
  - 비로그인 상태에서 `저장`, `내 예약`, `마이` 탭 접근 후 401 페이지로 이동해도 원래 누른 탭 active 유지

- 오늘의 식당/식당 상세 리뷰 이미지 뷰어 스크롤 복원
  - 리뷰 이미지 뷰어 open 시 현재 `scrollY` 저장
  - body fixed 처리 시 `top`, `width`를 함께 지정해 기존 위치 보존
  - 뷰어 close 시 body style 복원 및 기존 scroll 위치로 복귀

- 식당명 복사 토스트 UI QA 반영
  - 식당명 복사 성공 토스트 앞에 `LinkIcon` 추가
  - 오늘의 식당/식당 상세가 공유하는 `RestaurantDetailTemplate` 기준으로 반영

- 공통 이미지 fallback 색상 QA 반영
  - `DefaultImage` 배경색을 `warm-gray-100` 기준으로 변경

- 관련 테스트 갱신
  - `ReviewImageViewer` scroll lock/restore 테스트 보강

## 🔎 Description

- 하시 PICK과 인기 맛집은 각각 개별 페이지를 갖고 있지만, 실제 식당 리스트 UI는 `RestaurantListPage`와 `RestaurantCard`를 공통으로 사용합니다.  
  따라서 식당명 typography 변경과 empty state 적용은 공통 restaurant list 레이어에서 처리했습니다.

- 식당 리스트 empty 상태는 기존 텍스트 직접 렌더링 대신 shared `ListEmptyState`를 사용하도록 변경했습니다.  
  이번 QA 기준에서는 문구 없이 empty 이미지만 보여야 해서 `description=""`으로 주입했습니다.

- 401 페이지(`/login-required`)는 하단 네비게이션 레이아웃 안에서 렌더링되지만, 기존에는 현재 path가 `/login-required`라서 어떤 탭도 active 처리되지 않았습니다.  
  비로그인 사용자가 `저장`, `내 예약`, `마이` 같은 인증 필요 탭을 눌러 401 페이지로 redirect되는 경우, `AuthOnlyRoute`가 넘기는 `state.from.pathname`을 기준으로 active 탭을 계산하도록 변경했습니다.

- 오늘의 식당과 식당 상세는 공통 `RestaurantDetailTemplate` 및 `ReviewImageViewer`를 사용합니다.  
  리뷰 이미지 뷰어를 열 때 body를 fixed로 잠그면서 기존 scroll 위치를 `top: -scrollY`로 보존하고, 닫을 때 `window.scrollTo(0, scrollY)`로 복원하도록 수정했습니다.

- 식당명 복사 토스트는 기존 텍스트만 표시하던 구조에서 HDS Toast의 `icon` slot을 사용하도록 변경했습니다.  
  식당명 복사 성공 시 `LinkIcon`과 `식당명이 복사되었어요` 문구가 함께 표시됩니다.

## 👀 To Reviewer

- 하시 PICK/인기 맛집 식당 리스트는 같은 공통 컴포넌트를 사용하므로 한 번에 반영됩니다.
- 401 페이지 하단 네비 active 상태는 `/login-required` 자체 path가 아니라, redirect 전 원래 접근하려던 path 기준으로 계산합니다.
- 리뷰 이미지 뷰어 스크롤 복원은 오늘의 식당과 일반 식당 상세에 모두 적용됩니다.
- 식당명 복사 토스트 아이콘은 공유 링크 토스트와 동일하게 `LinkIcon`을 사용했습니다.

## ✅ Verification

- `corepack pnpm --dir apps/client exec vitest run src/features/restaurantDetail/components/ReviewImageViewer.test.tsx src/pages/restaurantDetail/RestaurantDetailPage.test.tsx src/pages/todayRestaurant/TodayRestaurantPage.test.tsx`
- `corepack pnpm --dir apps/client exec eslint src/features/restaurantDetail/components/ReviewImageViewer.tsx src/features/restaurantDetail/components/ReviewImageViewer.test.tsx --config ../../eslint.config.js`
- `git diff --check`
- commit hook `lint-staged` 통과

## 📸 Screenshot

- default이미지 색상 변경
<img width="454" height="86" alt="스크린샷 2026-07-15 오전 2 34 31" src="https://github.com/user-attachments/assets/c31be16a-d0c7-4798-9ce2-ad70eacca4f8" />


- 하시 PICK/인기 맛집 식당명 UI변경
<img width="503" height="410" alt="스크린샷 2026-07-15 오전 2 34 07" src="https://github.com/user-attachments/assets/0fc46abb-8045-4efb-a35f-f318752bba87" />


- 401 로그인 필요 페이지 하단 네비 active
https://github.com/user-attachments/assets/8648aaaf-399b-402a-a7fe-fc2429d8e5eb


- 식당명 복사 토스트
https://github.com/user-attachments/assets/6f919bd0-f4be-4a6f-bee1-f55208102fe2


- 리뷰 이미지 뷰어 닫기 후 스크롤 위치 유지
https://github.com/user-attachments/assets/7ca5f14c-ebeb-46ff-adcb-4184689df7e3