### PR TITLE
Feat(reservation): 예약 취소 후 식당 추천 제공

### DIFF
--- a/apps/client/src/app/router/lazy.ts
+++ b/apps/client/src/app/router/lazy.ts
@@ -127,6 +127,9 @@ const MyReservationsPage = lazyRoute(() => import('@/pages/myReservations'))
 const ReservationDetailPage = lazyRoute(
   () => import('@/pages/reservationDetail'),
 )
+const ReservationRescuePage = lazyRoute(
+  () => import('@/pages/reservationRescue'),
+)
 const LoginRequiredPage = lazyRoute(() => import('@/pages/loginRequired'))
 const KakaoOAuthCallbackPage = lazyRoute(
   () => import('@/pages/kakaoOAuthCallback'),
@@ -167,6 +170,7 @@ export const lazyPages = {
   reservationRequest: () => lazyPage(ReservationRequestPage),
   myReservations: () => lazyPage(MyReservationsPage),
   reservationDetail: () => lazyPage(ReservationDetailPage),
+  reservationRescue: () => lazyPage(ReservationRescuePage),
   loginRequired: () => lazyPage(LoginRequiredPage),
   kakaoOAuthCallback: () => lazyPage(KakaoOAuthCallbackPage),
   notFound: () => lazyPage(NotFoundPage),

--- a/apps/client/src/app/router/path.ts
+++ b/apps/client/src/app/router/path.ts
@@ -23,6 +23,7 @@ export const ROUTES = {
   reservationRequest: '/reservations/request',
   myReservations: '/my-reservations',
   reservationDetail: '/reservations/:reservationId',
+  reservationRescue: '/reservations/:reservationId/rescue',
   loginRequired: '/login-required',
   kakaoOAuthCallback: '/oauth/callback/kakao',
 } as const

--- a/apps/client/src/app/router/routes.test.tsx
+++ b/apps/client/src/app/router/routes.test.tsx
@@ -71,4 +71,8 @@ describe('appRoutes', () => {
   it('registers Kakao OAuth callback as an app route', () => {
     expect(collectRoutePaths(appRoutes)).toContain(ROUTES.kakaoOAuthCallback)
   })
+
+  it('registers reservation rescue as an app route', () => {
+    expect(collectRoutePaths(appRoutes)).toContain(ROUTES.reservationRescue)
+  })
 })

--- a/apps/client/src/app/router/routes.ts
+++ b/apps/client/src/app/router/routes.ts
@@ -143,6 +143,10 @@ export const appRoutes: RouteObject[] = [
             path: ROUTES.reservationDetail,
             element: lazyPages.reservationDetail(),
           },
+          {
+            path: ROUTES.reservationRescue,
+            element: withLazyFallback(lazyPages.reservationRescue()),
+          },
         ],
       },
       {

--- a/apps/client/src/features/reservation/components/reservationCancelDialog/ReservationCancelDialog.tsx
+++ b/apps/client/src/features/reservation/components/reservationCancelDialog/ReservationCancelDialog.tsx
@@ -33,7 +33,9 @@ export const ReservationCancelDialog = ({
               <span className="block">
                 예약을 취소하면 방문 예정 내역에서 삭제되며
               </span>
-              <span className="block">동일한 예약은 다시 접수해야 합니다.</span>
+              <span className="block">
+                취소 후에도 다른 식당을 바로 찾아볼 수 있어요.
+              </span>
             </Dialog.Description>
           </div>
         </Dialog.Header>

--- a/apps/client/src/pages/reservationDetail/ReservationDetailPage.test.tsx
+++ b/apps/client/src/pages/reservationDetail/ReservationDetailPage.test.tsx
@@ -225,12 +225,20 @@ describe('ReservationDetailPage', () => {
       within(dialog).getByText('정말 예약을 취소하시겠습니까?'),
     ).toBeInTheDocument()
     expect(
-      within(dialog).getByText('동일한 예약은 다시 접수해야 합니다.'),
+      within(dialog).getByText(
+        '취소 후에도 다른 식당을 바로 찾아볼 수 있어요.',
+      ),
     ).toBeInTheDocument()
   })
 
-  it('cancels the reservation and moves to the canceled reservation list after confirming cancellation', async () => {
+  it('cancels the reservation and moves to restaurant recommendations after confirming cancellation', async () => {
     const { queryClient } = renderReservationDetailPage()
+    mockedGetMyReservations.mockImplementation(
+      () =>
+        new Promise(() => {
+          // 목록 동기화가 느려도 추천 화면 이동은 기다리지 않아야 합니다.
+        }),
+    )
 
     fireEvent.click(
       await screen.findByRole('button', { name: '예약 취소하기' }),
@@ -241,11 +249,9 @@ describe('ReservationDetailPage', () => {
 
     await waitFor(() => {
       expect(mockedCancelReservation).toHaveBeenCalledWith(12)
-      expect(mockShowToast).toHaveBeenCalledWith({
-        children: '예약 취소 요청이 완료되었습니다',
-      })
+      expect(mockShowToast).not.toHaveBeenCalled()
       expect(mockNavigate).toHaveBeenCalledWith(
-        `${ROUTES.myReservations}?status=CANCELED`,
+        ROUTES.reservationRescue.replace(':reservationId', '12'),
       )
       expect(queryClient.getQueryData(reservationDetailQueryKey(12))).toEqual({
         ...reservationDetailFixture,
@@ -351,7 +357,7 @@ describe('ReservationDetailPage', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        `${ROUTES.myReservations}?status=CANCELED`,
+        ROUTES.reservationRescue.replace(':reservationId', '12'),
       )
     })
   })

--- a/apps/client/src/pages/reservationDetail/hooks/useReservationDetailPage.ts
+++ b/apps/client/src/pages/reservationDetail/hooks/useReservationDetailPage.ts
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react'
-import { showToast } from '@hashi/hds-ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
@@ -98,14 +97,18 @@ export const useReservationDetailPage = () => {
         queryKey,
         refetchType: 'inactive',
       })
-      await syncCanceledReservationCache(
+
+      setIsCancelDialogOpen(false)
+      navigate(
+        ROUTES.reservationRescue.replace(
+          ':reservationId',
+          String(reservationId),
+        ),
+      )
+      void syncCanceledReservationCache(
         queryClient,
         canceledReservation.reservation,
       )
-
-      showToast({ children: canceledReservation.message })
-      setIsCancelDialogOpen(false)
-      navigate(`${ROUTES.myReservations}?status=CANCELED`)
     } catch {
       // 실패 toast는 공통 mutation error handler에서 처리합니다.
     } finally {

--- a/apps/client/src/pages/reservationRescue/ReservationRescuePage.spec.md
+++ b/apps/client/src/pages/reservationRescue/ReservationRescuePage.spec.md
@@ -1,0 +1,327 @@
+# Page Spec: `ReservationRescuePage`
+
+## Purpose
+
+- 사용자가 예약을 취소한 직후 식사 계획까지 포기하지 않도록, 기존 HASHI 추천 식당을 이어서 탐색할 수 있는 화면을 제공합니다.
+- 신규 추천 API를 만들지 않고 기존 예약 상세 데이터와 식당 목록 API를 조합합니다.
+- 추천 근거는 API가 보장하는 `HASHI PICK`과 평점순 정렬까지만 표현합니다. 유사도, 실시간 예약 가능 여부, 거리처럼 API가 제공하지 않는 정보는 표시하지 않습니다.
+
+## Route
+
+- path: `/reservations/:reservationId/rescue`
+- path constant:
+  - `ROUTES.reservationRescue`
+- route owner:
+  - `apps/client/src/app/router/routes.ts`
+- layout:
+  - `RootLayout`
+  - 하단 네비게이션 없음
+- access type:
+  - `authOnly`
+- guard:
+  - `AuthOnlyRoute`
+- lazy loading:
+  - `lazyPages.reservationRescue`
+- bottom navigation:
+  - no
+- redirect:
+  - unauthenticated: `/login-required`
+  - 취소된 예약이 아니거나 식당 ID가 없는 예약: `/my-reservations?status=CANCELED`
+- auth status:
+  - uses `useAuthStatus`: no
+  - route guard가 인증 상태를 소유합니다.
+
+## Location
+
+- page path:
+  - `apps/client/src/pages/reservationRescue/ReservationRescuePage.tsx`
+- spec path:
+  - `apps/client/src/pages/reservationRescue/ReservationRescuePage.spec.md`
+- page-local components:
+  - `apps/client/src/pages/reservationRescue/components/ReservationRescueIntro.tsx`
+  - `apps/client/src/pages/reservationRescue/components/ReservationRescueRestaurantList.tsx`
+- page-local hook:
+  - `apps/client/src/pages/reservationRescue/hooks/useReservationRescuePage.ts`
+- page-local query:
+  - `apps/client/src/pages/reservationRescue/queries/reservationRescueQueryOptions.ts`
+- route registration:
+  - `apps/client/src/app/router/path.ts`
+  - `apps/client/src/app/router/lazy.ts`
+  - `apps/client/src/app/router/routes.ts`
+
+## Scope
+
+### Included
+
+- 예약 취소 성공 후 추천 화면으로 이동합니다.
+- 기존 예약 상세 query cache를 재사용하고 직접 진입 또는 새로고침 시 같은 상세 API로 취소된 예약 정보를 조회합니다.
+- 기존 식당 목록 API에서 HASHI PICK 평점순 식당을 조회합니다.
+- 취소한 식당을 프론트엔드에서 제외하고 최대 3개를 표시합니다.
+- 추천 카드에서 기존 식당 상세와 예약 흐름으로 이동합니다.
+- loading, error, empty 상태를 제공합니다.
+
+### Excluded
+
+- 신규 추천 API 또는 추천 알고리즘
+- 장르·지역·가격대 기반 유사 식당 계산
+- 실시간 예약 가능 여부
+- 유사도 퍼센트, 거리, 예상 이동 시간
+- HDS 신규 컴포넌트 또는 디자인 토큰 추가
+- 취소 정책과 취소 API 계약 변경
+
+## Requirements
+
+- [ ] 예약 상세의 기존 취소 확인 `Dialog`를 유지합니다.
+- [ ] 취소 확인 문구에 취소 후 다른 식당을 탐색할 수 있다는 안내를 추가합니다.
+- [ ] 취소 mutation 성공 시 기존 성공 toast와 취소 목록 이동 대신 추천 화면으로 이동합니다.
+- [ ] 취소 mutation 실패 시 현재 예약 상세와 취소 확인 UI를 유지하고 기존 공통 mutation error 정책을 따릅니다.
+- [ ] 추천 화면 상단에 `예약은 취소됐지만, 맛있는 일정은 계속돼요`를 표시합니다.
+- [ ] 보조 문구로 `하시가 엄선한 평점 높은 식당을 다시 골라봤어요`를 표시합니다.
+- [ ] 추천 식당은 취소한 식당을 제외하고 최대 3개를 표시합니다.
+- [ ] 추천 식당 카드는 기존 `RestaurantCard`를 재사용합니다.
+- [ ] 식당 카드를 누르면 기존 식당 상세 화면으로 이동합니다.
+- [ ] `취소된 예약 보기` 액션은 `/my-reservations?status=CANCELED`로 이동합니다.
+- [ ] API가 제공하지 않는 유사도, 실시간 예약 가능 여부, 거리 문구를 표시하지 않습니다.
+- [ ] 360px 이상의 모바일 viewport에서 가로 overflow 없이 렌더링합니다.
+- [ ] 제목, 목록, 로딩, 오류 상태에 접근 가능한 이름을 제공합니다.
+
+## Data Dependencies
+
+### Canceled Reservation Query
+
+- owner:
+  - 기존 `useReservationDetailQuery`
+  - 기존 `reservationDetailQueryKey`
+- endpoint:
+  - `GET /api/v1/reservations/:reservationId`
+- enabled condition:
+  - route의 `reservationId`가 유효한 양의 정수일 때
+- cache behavior:
+  - 취소 mutation 성공 시 기존 상세 cache에 저장한 `CANCELED` 예약 응답을 즉시 사용합니다.
+  - 추천 route 직접 진입 또는 새로고침에서는 기존 상세 query가 서버 데이터를 조회합니다.
+- required fields:
+  - `reservationStatus === 'CANCELED'`
+  - `restaurantId`
+- loading state:
+  - 페이지 전체 콘텐츠 영역에서 기존 `secondary-200` token 기반 skeleton을 표시합니다.
+- error state:
+  - 404는 기존 `NotFoundPage`를 사용합니다.
+  - 그 외 critical error는 route `AsyncBoundary`로 전달합니다.
+- invalid state:
+  - 취소 상태가 아니거나 `restaurantId`가 없으면 취소 목록으로 replace 이동합니다.
+
+### Rescue Restaurant Query
+
+- owner:
+  - endpoint 함수는 기존 `getRestaurants`를 재사용합니다.
+  - query options와 query key는 `reservationRescue` page가 소유합니다.
+- endpoint:
+  - `GET /api/v1/restaurants`
+- request params:
+  - `genre: 'all'`
+  - `sort: 'rating'`
+  - `type: 'hashi-pick'`
+  - `size: 5`
+- enabled condition:
+  - 취소된 예약의 `restaurantId`가 확인된 뒤
+- response mapping:
+  - 기존 `mapRestaurantSummaryToRestaurant`를 재사용합니다.
+  - 매핑 실패한 항목과 취소한 `restaurantId`를 제외합니다.
+  - 남은 결과에서 앞의 3개만 표시합니다.
+- loading state:
+  - 기존 `RestaurantListPage`의 식당 카드 skeleton 구조와 token을 동일하게 사용합니다.
+- error state:
+  - 추천 영역 안에 `식당 목록을 불러오지 못했어요`와 HDS `Button`의 `다시 시도`를 표시합니다.
+  - 취소 성공 상태는 되돌리지 않으며 ErrorBoundary로 전파하지 않습니다.
+- empty state:
+  - 기존 `ListEmptyState`를 재사용합니다.
+  - `지금 추천할 식당을 찾지 못했어요`와 HDS `Button`의 `하시 PICK 둘러보기`를 표시합니다.
+- refetch condition:
+  - 사용자가 `다시 시도`를 누르면 해당 query를 refetch합니다.
+
+### Cancel Reservation Mutation
+
+- owner:
+  - 기존 `useCancelReservationMutation`
+- request data:
+  - route의 `reservationId`
+- submit enabled condition:
+  - 기존 취소 dialog가 열려 있고 mutation이 pending이 아닐 때
+- success handling:
+  - 기존 reservation detail cache update와 canceled reservation list cache synchronization을 유지합니다.
+  - dialog를 닫고 `ROUTES.reservationRescue`로 이동합니다.
+  - 추천 화면 자체가 성공 피드백을 제공하므로 기존 취소 성공 toast는 표시하지 않습니다.
+- failure handling:
+  - 기존 공통 mutation error toast를 유지합니다.
+  - 추천 화면으로 이동하지 않습니다.
+
+## User Flow
+
+1. 사용자가 예약 상세에서 `예약 취소`를 누릅니다.
+2. 기존 취소 확인 dialog가 열립니다.
+3. 사용자가 `취소하기`를 누르면 취소 mutation을 호출합니다.
+4. mutation 성공 시 예약 cache를 동기화하고 `/reservations/:reservationId/rescue`로 이동합니다.
+5. 추천 화면은 취소된 예약의 `restaurantId`를 확인합니다.
+6. HASHI PICK 평점순 식당 5개를 조회하고 취소한 식당을 제외한 최대 3개를 표시합니다.
+7. 사용자가 식당 카드를 누르면 기존 식당 상세로 이동합니다.
+8. 사용자가 `취소된 예약 보기`를 누르면 취소 목록으로 이동합니다.
+
+## State
+
+- local state:
+  - 없음
+- form state:
+  - 없음
+- URL state:
+  - `reservationId` path param
+- server state:
+  - 취소된 예약 상세 query
+  - rescue restaurant query
+- derived state:
+  - 유효한 취소 예약 여부
+  - 원래 식당을 제외한 추천 식당 최대 3개
+  - loading, error, empty, success UI state
+
+## Validation
+
+- `reservationId`:
+  - 기존 `parseReservationId`를 재사용해 양의 정수인지 검증합니다.
+- canceled reservation:
+  - `reservationStatus`가 `CANCELED`이고 `restaurantId`가 있어야 합니다.
+- restaurant result:
+  - 기존 mapper가 필수 식당 필드를 검증합니다.
+
+## UI Structure
+
+```text
+ReservationRescuePage
+  Header
+    IconButton(뒤로가기)
+    Title(식당 다시 찾기)
+  ReservationRescueIntro
+    Eyebrow(HASHI PICK)
+    Heading
+    Description
+  ReservationRescueRestaurantList
+    RestaurantCard x 0..3
+    LoadingSkeleton / LocalError / ListEmptyState
+  Button(취소된 예약 보기)
+```
+
+## Component Mapping
+
+- HDS component:
+  - `Header`
+  - `IconButton`
+  - `Button`
+- HDS icon:
+  - `BackIcon`
+- app shared component:
+  - `ListEmptyState`
+  - `DefaultImage`는 `RestaurantCard`의 기존 `RestaurantImageList`를 통해 사용합니다.
+- existing feature component:
+  - `RestaurantCard`
+  - `RestaurantImageList`
+- existing utility:
+  - `mapRestaurantSummaryToRestaurant`
+  - `parseReservationId`
+- page-local component:
+  - `ReservationRescueIntro`
+  - `ReservationRescueRestaurantList`
+- design-system boundary:
+  - 도메인 문구, query, route, 식당 필터링은 page layer가 소유합니다.
+  - 이 기능을 위해 `packages/hds-ui`, `packages/hds-icons`, `packages/hds-tokens`를 변경하지 않습니다.
+
+## Design Direction
+
+- 기존 홈과 식당 목록 화면처럼 흰색 배경과 모바일 단일 컬럼을 유지합니다.
+- 헤더와 식당 카드는 기존 화면과 동일한 높이, 타이포 위계, 이미지 비율을 사용합니다.
+- 상단 메시지는 `typo-header-*`, `typo-body-*`, `text-primary-*`, `text-cool-gray-*` token만 사용합니다.
+- 강조색은 기존 브랜드 token 범위에서만 사용하고 새 hex color를 추가하지 않습니다.
+- spacing은 Tailwind scale을 우선 사용하고, 기존 컴포넌트와 시각적으로 일치해야 하는 경우에만 현재 코드의 값을 따릅니다.
+- 추천 목록은 과도한 장식, 신규 그래픽, 가짜 배지보다 실제 식당 이미지와 기존 카드 정보 위계를 중심으로 구성합니다.
+- 페이지 전용 UI는 `apps/client/src/pages/reservationRescue` 안에 두며 단일 사용 컴포넌트를 HDS로 승격하지 않습니다.
+
+## Error Handling
+
+- 취소 mutation 실패:
+  - 기존 예약 상세에 남고 공통 mutation error toast를 표시합니다.
+- 예약 상세 404:
+  - `NotFoundPage`를 표시합니다.
+- 예약 상세 critical error:
+  - `AsyncBoundary`로 전달합니다.
+- 취소 상태 또는 식당 ID 불일치:
+  - `/my-reservations?status=CANCELED`로 replace 이동합니다.
+- 추천 query 실패:
+  - 페이지 로컬 오류와 `다시 시도`를 표시합니다.
+- 추천 query empty:
+  - `ListEmptyState`와 `하시 PICK 둘러보기`를 표시합니다.
+
+## Navigation
+
+- entry:
+  - 예약 상세의 취소 mutation 성공
+- links:
+  - 추천 식당 카드 → `/restaurants/:restaurantId`
+  - `취소된 예약 보기` → `/my-reservations?status=CANCELED`
+  - empty fallback → `/restaurants/hashi-pick`
+- route params:
+  - `reservationId`
+- search params:
+  - 없음
+- back behavior:
+  - 브라우저 history의 취소 전 상세로 돌아가면 이미 blocked 상태가 되므로 `navigate(-1)`을 사용하지 않습니다.
+  - 헤더의 뒤로가기는 `/my-reservations?status=CANCELED`로 replace 이동합니다.
+- auth redirect:
+  - 비회원은 `AuthOnlyRoute` 정책을 따릅니다.
+
+## Styling
+
+- Tailwind layout:
+  - 모바일 단일 컬럼, `app-mobile-fixed-top` 헤더, 본문 수직 스크롤
+- responsive:
+  - `RootLayout`의 mobile frame과 max width를 따릅니다.
+  - 최소 360px viewport에서 가로 overflow가 없어야 합니다.
+- fixed area:
+  - 상단 HDS `Header`
+  - 하단 CTA는 콘텐츠를 가리지 않도록 fixed로 만들지 않고 목록 다음에 배치합니다.
+- scroll area:
+  - intro, 추천 목록, CTA를 포함한 page body
+- empty/loading/error layout:
+  - 성공 목록과 같은 좌우 padding을 유지해 layout shift를 줄입니다.
+
+## Testing
+
+- route:
+  - authOnly route와 lazy page 등록을 확인합니다.
+  - 유효하지 않은 `reservationId`를 처리합니다.
+- cancel integration:
+  - 취소 성공 시 cache synchronization 후 rescue route로 이동합니다.
+  - 취소 실패 시 이동하지 않습니다.
+- recommendation:
+  - 기존 식당 목록 API에 고정 params를 전달합니다.
+  - 취소한 식당을 제외합니다.
+  - mapper 실패 항목을 제외합니다.
+  - 결과를 최대 3개로 제한합니다.
+- UI states:
+  - loading skeleton
+  - local query error와 retry
+  - empty state와 HASHI PICK fallback
+  - success list
+- navigation:
+  - 추천 카드에서 식당 상세 이동
+  - 뒤로가기와 `취소된 예약 보기`에서 취소 목록 이동
+
+## Verification
+
+- [ ] `corepack pnpm --filter @hashi/client test`
+- [ ] `corepack pnpm --filter @hashi/client lint`
+- [ ] `corepack pnpm --filter @hashi/client typecheck`
+- [ ] `corepack pnpm --filter @hashi/client build`
+- [ ] `corepack pnpm format:check`
+- [ ] 360px, 393px 모바일 viewport 수동 확인
+- [ ] 취소 확인 → 취소 성공 → 추천 화면 → 식당 상세 흐름 확인
+- [ ] route path / params 확인
+- [ ] auth guard 확인
+- [ ] loading / empty / error / success 상태 확인
+- [ ] 신규 HDS component, token, 임의 hex color가 추가되지 않았는지 확인

--- a/apps/client/src/pages/reservationRescue/ReservationRescuePage.test.tsx
+++ b/apps/client/src/pages/reservationRescue/ReservationRescuePage.test.tsx
@@ -1,0 +1,265 @@
+import '@testing-library/jest-dom/vitest'
+
+import { QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ROUTES } from '@/app/router/path'
+import { getRestaurants } from '@/features/restaurantList/api/getRestaurants'
+import { getReservationDetail } from '@/pages/reservationDetail/api/getReservationDetail'
+import { ReservationRescuePage } from '@/pages/reservationRescue/ReservationRescuePage'
+import { createQueryClient } from '@/shared/lib/queryClient'
+
+const { mockNavigate, mockReservationParams } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockReservationParams: { reservationId: '12' },
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockReservationParams,
+  }
+})
+
+vi.mock('@/pages/reservationDetail/api/getReservationDetail', () => ({
+  getReservationDetail: vi.fn(),
+}))
+
+vi.mock('@/features/restaurantList/api/getRestaurants', () => ({
+  getRestaurants: vi.fn(),
+}))
+
+const mockedGetReservationDetail = vi.mocked(getReservationDetail)
+const mockedGetRestaurants = vi.mocked(getRestaurants)
+
+const canceledReservationFixture = {
+  reservationId: 12,
+  reservationStatus: 'CANCELED' as const,
+  restaurantId: 2,
+  restaurantName: '취소한 식당',
+}
+
+const restaurantFixtures = [
+  {
+    restaurantId: 1,
+    name: '긴자 사사키',
+    rating: 4.9,
+    area: '긴자',
+    foodCategory: 'sushi',
+    summary: '정갈한 스시 오마카세',
+  },
+  {
+    restaurantId: 2,
+    name: '취소한 식당',
+    rating: 4.8,
+  },
+  {
+    restaurantId: 3,
+    name: '스시 아오이',
+    rating: 4.7,
+    area: '신주쿠',
+    foodCategory: 'sushi',
+    summary: '현지인이 즐겨 찾는 스시야',
+  },
+  {
+    restaurantId: 4,
+    name: '쿠로다',
+    rating: 4.6,
+    area: '시부야',
+    foodCategory: 'grill',
+    summary: '숯불 향이 좋은 구이 전문점',
+  },
+  {
+    restaurantId: 5,
+    name: '다이닝 하시',
+    rating: 4.5,
+  },
+]
+
+const renderPage = () => {
+  const queryClient = createQueryClient()
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReservationRescuePage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ReservationRescuePage', () => {
+  beforeEach(() => {
+    mockReservationParams.reservationId = '12'
+    mockNavigate.mockReset()
+    mockedGetReservationDetail.mockResolvedValue(canceledReservationFixture)
+    mockedGetRestaurants.mockResolvedValue({
+      hasNext: false,
+      nextCursor: undefined,
+      restaurants: restaurantFixtures,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders up to three HASHI PICK restaurants without the canceled restaurant', async () => {
+    renderPage()
+
+    expect(
+      await screen.findByRole('heading', {
+        name: '예약은 취소됐지만, 맛있는 일정은 계속돼요',
+      }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('취소한 식당')).not.toBeInTheDocument()
+    expect(await screen.findByText('긴자 사사키')).toBeInTheDocument()
+    expect(screen.getByText('스시 아오이')).toBeInTheDocument()
+    expect(screen.getByText('쿠로다')).toBeInTheDocument()
+    expect(screen.queryByText('다이닝 하시')).not.toBeInTheDocument()
+  })
+
+  it('keeps the canceled reservations action fixed without covering the list', async () => {
+    renderPage()
+
+    const canceledReservationsButton = await screen.findByRole('button', {
+      name: '취소된 예약 보기',
+    })
+
+    expect(screen.getByRole('main')).toHaveClass(
+      'pb-[calc(82px+var(--safe-area-bottom,0px))]',
+    )
+    expect(canceledReservationsButton.parentElement).toHaveClass(
+      'app-mobile-fixed-bottom',
+      'z-fixed',
+      'bg-white',
+      'px-5',
+      'pt-4',
+      'pb-[calc(17px+var(--safe-area-bottom,0px))]',
+    )
+  })
+
+  it('moves to restaurant detail when a recommendation is selected', async () => {
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: /긴자 사사키/ }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/restaurants/1')
+  })
+
+  it('moves to canceled reservations from the header and secondary action', async () => {
+    renderPage()
+
+    await screen.findByText('긴자 사사키')
+    fireEvent.click(screen.getByRole('button', { name: '뒤로가기' }))
+    fireEvent.click(screen.getByRole('button', { name: '취소된 예약 보기' }))
+
+    expect(mockNavigate).toHaveBeenNthCalledWith(
+      1,
+      `${ROUTES.myReservations}?status=CANCELED`,
+      { replace: true },
+    )
+    expect(mockNavigate).toHaveBeenNthCalledWith(
+      2,
+      `${ROUTES.myReservations}?status=CANCELED`,
+    )
+  })
+
+  it('shows an empty state and links to HASHI PICK when no recommendation remains', async () => {
+    mockedGetRestaurants.mockResolvedValue({
+      hasNext: false,
+      nextCursor: undefined,
+      restaurants: [restaurantFixtures[1]],
+    })
+
+    renderPage()
+
+    expect(
+      await screen.findByText('지금 추천할 식당을 찾지 못했어요'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '하시 PICK 둘러보기' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.hashiPickRestaurants)
+  })
+
+  it('shows a local error and retries only the recommendation query', async () => {
+    mockedGetRestaurants
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({
+        hasNext: false,
+        nextCursor: undefined,
+        restaurants: [],
+      })
+
+    renderPage()
+
+    expect(
+      await screen.findByText('식당 목록을 불러오지 못했어요'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }))
+
+    await waitFor(() => {
+      expect(mockedGetRestaurants).toHaveBeenCalledTimes(2)
+    })
+    expect(mockedGetReservationDetail).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows recommendation skeletons while the restaurant query is pending', async () => {
+    mockedGetRestaurants.mockImplementation(
+      () =>
+        new Promise(() => {
+          // 추천 요청을 pending 상태로 유지합니다.
+        }),
+    )
+
+    renderPage()
+
+    expect(
+      await screen.findByLabelText('추천 식당 목록 로딩 중'),
+    ).toBeInTheDocument()
+  })
+
+  it('replaces to canceled reservations when the route is invalid', async () => {
+    mockReservationParams.reservationId = 'invalid'
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.myReservations}?status=CANCELED`,
+        { replace: true },
+      )
+    })
+    expect(mockedGetReservationDetail).not.toHaveBeenCalled()
+    expect(mockedGetRestaurants).not.toHaveBeenCalled()
+  })
+
+  it('replaces to canceled reservations when the reservation is not canceled', async () => {
+    mockedGetReservationDetail.mockResolvedValue({
+      ...canceledReservationFixture,
+      reservationStatus: 'CONFIRMED',
+    })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${ROUTES.myReservations}?status=CANCELED`,
+        { replace: true },
+      )
+    })
+    expect(mockedGetRestaurants).not.toHaveBeenCalled()
+  })
+})

--- a/apps/client/src/pages/reservationRescue/ReservationRescuePage.tsx
+++ b/apps/client/src/pages/reservationRescue/ReservationRescuePage.tsx
@@ -1,0 +1,92 @@
+import { BackIcon } from '@hashi/hds-icons'
+import { Button, Header, IconButton } from '@hashi/hds-ui'
+
+import { NotFoundPage } from '@/pages/notFound'
+import { ReservationRescueIntro } from '@/pages/reservationRescue/components/ReservationRescueIntro'
+import { ReservationRescueRestaurantList } from '@/pages/reservationRescue/components/ReservationRescueRestaurantList'
+import { useReservationRescuePage } from '@/pages/reservationRescue/hooks/useReservationRescuePage'
+import { checkIsNotFoundError } from '@/shared/api'
+import { LoadingScreen } from '@/shared/components/loadingScreen'
+
+export const ReservationRescuePage = () => {
+  const {
+    error,
+    isInvalidReservationId,
+    isReservationError,
+    isReservationLoading,
+    isRestaurantsError,
+    isRestaurantsLoading,
+    restaurants,
+    shouldRedirect,
+    handleBack,
+    handleCanceledReservations,
+    handleHashiPick,
+    handleRestaurant,
+    handleRetry,
+  } = useReservationRescuePage()
+
+  if (isInvalidReservationId || shouldRedirect) {
+    return null
+  }
+
+  if (isReservationError) {
+    if (checkIsNotFoundError(error)) {
+      return <NotFoundPage />
+    }
+
+    throw error
+  }
+
+  if (isReservationLoading) {
+    return <LoadingScreen />
+  }
+
+  return (
+    <main className="min-h-dvh bg-white pt-18.75 pb-[calc(82px+var(--safe-area-bottom,0px))]">
+      <Header
+        className="app-mobile-fixed-top z-fixed text-primary-200 fixed"
+        leftAction={
+          <IconButton aria-label="뒤로가기" onClick={handleBack} size="xs">
+            <BackIcon className="size-6" />
+          </IconButton>
+        }
+        title={<h1>식당 다시 찾기</h1>}
+      />
+
+      <ReservationRescueIntro />
+
+      <section className="mt-7" aria-labelledby="rescue-restaurants-heading">
+        <div className="px-5">
+          <h2
+            className="typo-sub-header-1 text-primary-200"
+            id="rescue-restaurants-heading"
+          >
+            하시가 다시 골라봤어요
+          </h2>
+          <p className="typo-body-7 text-cool-gray-600 mt-1">
+            하시 PICK 중 평점이 높은 순서예요.
+          </p>
+        </div>
+        <ReservationRescueRestaurantList
+          isError={isRestaurantsError}
+          isLoading={isRestaurantsLoading}
+          onHashiPick={handleHashiPick}
+          onRestaurant={handleRestaurant}
+          onRetry={handleRetry}
+          restaurants={restaurants}
+        />
+      </section>
+
+      <div className="app-mobile-fixed-bottom z-fixed bg-white px-5 pt-4 pb-[calc(17px+var(--safe-area-bottom,0px))]">
+        <Button
+          onClick={handleCanceledReservations}
+          size="lg"
+          variant="neutral"
+          width="full"
+        >
+          취소된 예약 보기
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/apps/client/src/pages/reservationRescue/components/ReservationRescueIntro.tsx
+++ b/apps/client/src/pages/reservationRescue/components/ReservationRescueIntro.tsx
@@ -1,0 +1,23 @@
+import { HashiPickIcon } from '@hashi/hds-icons'
+
+export const ReservationRescueIntro = () => {
+  return (
+    <section className="bg-cool-gray-900 mx-5 mt-6 rounded-2xl px-5 py-6 text-white">
+      <div
+        aria-hidden="true"
+        className="flex size-12 items-center justify-center rounded-full bg-white text-5xl"
+      >
+        <HashiPickIcon />
+      </div>
+      <p className="typo-caption-2 text-primary-400 mt-5">HASHI PICK</p>
+      <h2 className="typo-header-2 mt-2 break-keep">
+        예약은 취소됐지만,
+        <br />
+        맛있는 일정은 계속돼요
+      </h2>
+      <p className="typo-body-7 text-cool-gray-200 mt-3 break-keep">
+        하시가 엄선한 평점 높은 식당을 다시 골라봤어요.
+      </p>
+    </section>
+  )
+}

--- a/apps/client/src/pages/reservationRescue/components/ReservationRescueRestaurantList.tsx
+++ b/apps/client/src/pages/reservationRescue/components/ReservationRescueRestaurantList.tsx
@@ -1,0 +1,90 @@
+import { Button } from '@hashi/hds-ui'
+
+import { RestaurantCard } from '@/features/restaurantList'
+import type { Restaurant } from '@/features/restaurantList/types'
+import { ListEmptyState } from '@/shared/components/listEmptyState'
+
+interface ReservationRescueRestaurantListProps {
+  isError: boolean
+  isLoading: boolean
+  restaurants: Restaurant[]
+  onHashiPick: () => void
+  onRestaurant: (restaurantId: string) => void
+  onRetry: () => void
+}
+
+const ReservationRescueRestaurantListSkeleton = () => {
+  return (
+    <ul aria-label="추천 식당 목록 로딩 중" className="flex flex-col px-5">
+      {Array.from({ length: 3 }, (_, index) => (
+        <li
+          aria-hidden="true"
+          className="border-warm-gray-50 w-full border-b py-4.75 last:border-b-0"
+          key={index}
+        >
+          <div className="bg-secondary-200 h-5 w-40 animate-pulse rounded" />
+          <div className="bg-secondary-200 mt-2 h-5 w-28 animate-pulse rounded" />
+          <div className="mt-2.75 flex gap-2 overflow-hidden">
+            {Array.from({ length: 3 }, (_, imageIndex) => (
+              <div
+                className="bg-secondary-200 size-33.75 shrink-0 animate-pulse rounded-[5px]"
+                key={imageIndex}
+              />
+            ))}
+          </div>
+          <div className="bg-secondary-200 mt-3 h-4 w-full animate-pulse rounded" />
+          <div className="bg-secondary-200 mt-2 h-4 w-3/4 animate-pulse rounded" />
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export const ReservationRescueRestaurantList = ({
+  isError,
+  isLoading,
+  restaurants,
+  onHashiPick,
+  onRestaurant,
+  onRetry,
+}: ReservationRescueRestaurantListProps) => {
+  if (isLoading) {
+    return <ReservationRescueRestaurantListSkeleton />
+  }
+
+  if (isError) {
+    return (
+      <div className="flex min-h-80 flex-col items-center justify-center gap-4 px-5 text-center">
+        <p className="typo-body-4 text-primary-200">
+          식당 목록을 불러오지 못했어요
+        </p>
+        <Button onClick={onRetry} size="sm" variant="neutral">
+          다시 시도
+        </Button>
+      </div>
+    )
+  }
+
+  if (restaurants.length === 0) {
+    return (
+      <div className="flex min-h-80 flex-col items-center justify-center gap-5 px-5">
+        <ListEmptyState description="지금 추천할 식당을 찾지 못했어요" />
+        <Button onClick={onHashiPick} size="md">
+          하시 PICK 둘러보기
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <ul aria-label="추천 식당 목록" className="flex flex-col px-5">
+      {restaurants.map((restaurant) => (
+        <RestaurantCard
+          key={restaurant.id}
+          onClick={onRestaurant}
+          restaurant={restaurant}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/apps/client/src/pages/reservationRescue/hooks/useReservationRescuePage.ts
+++ b/apps/client/src/pages/reservationRescue/hooks/useReservationRescuePage.ts
@@ -1,0 +1,91 @@
+import { useQuery } from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { ROUTES } from '@/app/router/path'
+import { useReservationDetailQuery } from '@/pages/reservationDetail/hooks/useReservationDetailQuery'
+import { parseReservationId } from '@/pages/reservationDetail/utils/reservationDetailPolicy'
+import {
+  createReservationRescueRestaurants,
+  reservationRescueQueryOptions,
+} from '@/pages/reservationRescue/queries/reservationRescueQueryOptions'
+
+const CANCELED_RESERVATIONS_PATH = `${ROUTES.myReservations}?status=CANCELED`
+
+const getRestaurantDetailPath = (restaurantId: string) =>
+  ROUTES.restaurantDetail.replace(
+    ':restaurantId',
+    encodeURIComponent(restaurantId),
+  )
+
+export const useReservationRescuePage = () => {
+  const navigate = useNavigate()
+  const params = useParams<{ reservationId: string }>()
+  const reservationId = parseReservationId(params.reservationId)
+  const reservationDetailQuery = useReservationDetailQuery(reservationId)
+  const reservationDetail = reservationDetailQuery.data
+  const excludedRestaurantId =
+    reservationDetail?.reservationStatus === 'CANCELED'
+      ? reservationDetail.restaurantId
+      : undefined
+  const hasValidCanceledReservation =
+    excludedRestaurantId !== undefined && excludedRestaurantId > 0
+  const restaurantsQuery = useQuery({
+    ...reservationRescueQueryOptions(),
+    enabled: hasValidCanceledReservation,
+    throwOnError: false,
+  })
+  const restaurants = hasValidCanceledReservation
+    ? createReservationRescueRestaurants(
+        restaurantsQuery.data?.restaurants ?? [],
+        excludedRestaurantId,
+      )
+    : []
+  const shouldRedirect =
+    reservationId === null ||
+    (reservationDetailQuery.isSuccess && !hasValidCanceledReservation)
+
+  useEffect(() => {
+    if (!shouldRedirect) {
+      return
+    }
+
+    navigate(CANCELED_RESERVATIONS_PATH, { replace: true })
+  }, [navigate, shouldRedirect])
+
+  const handleBack = () => {
+    navigate(CANCELED_RESERVATIONS_PATH, { replace: true })
+  }
+
+  const handleCanceledReservations = () => {
+    navigate(CANCELED_RESERVATIONS_PATH)
+  }
+
+  const handleHashiPick = () => {
+    navigate(ROUTES.hashiPickRestaurants)
+  }
+
+  const handleRestaurant = (restaurantIdToOpen: string) => {
+    navigate(getRestaurantDetailPath(restaurantIdToOpen))
+  }
+
+  const handleRetry = () => {
+    void restaurantsQuery.refetch()
+  }
+
+  return {
+    error: reservationDetailQuery.error,
+    isInvalidReservationId: reservationId === null,
+    isReservationError: reservationDetailQuery.isError,
+    isReservationLoading: reservationDetailQuery.isPending,
+    isRestaurantsError: restaurantsQuery.isError,
+    isRestaurantsLoading: restaurantsQuery.isPending,
+    restaurants,
+    shouldRedirect,
+    handleBack,
+    handleCanceledReservations,
+    handleHashiPick,
+    handleRestaurant,
+    handleRetry,
+  }
+}

--- a/apps/client/src/pages/reservationRescue/index.ts
+++ b/apps/client/src/pages/reservationRescue/index.ts
@@ -1,0 +1,1 @@
+export { ReservationRescuePage as default } from './ReservationRescuePage'

--- a/apps/client/src/pages/reservationRescue/queries/reservationRescueQueryOptions.test.ts
+++ b/apps/client/src/pages/reservationRescue/queries/reservationRescueQueryOptions.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getRestaurants } from '@/features/restaurantList/api/getRestaurants'
+import {
+  createReservationRescueRestaurants,
+  fetchReservationRescueRestaurants,
+} from '@/pages/reservationRescue/queries/reservationRescueQueryOptions'
+
+vi.mock('@/features/restaurantList/api/getRestaurants', () => ({
+  getRestaurants: vi.fn(),
+}))
+
+const mockedGetRestaurants = vi.mocked(getRestaurants)
+
+const restaurantFixtures = [
+  {
+    restaurantId: 1,
+    name: '긴자 사사키',
+    rating: 4.9,
+  },
+  {
+    restaurantId: 2,
+    name: '취소한 식당',
+    rating: 4.8,
+  },
+  {
+    restaurantId: 3,
+    name: '스시 아오이',
+    rating: 4.7,
+  },
+  {
+    restaurantId: 4,
+    name: '쿠로다',
+    rating: 4.6,
+  },
+  {
+    restaurantId: 5,
+    name: '다이닝 하시',
+    rating: 4.5,
+  },
+]
+
+describe('reservationRescueQueryOptions', () => {
+  beforeEach(() => {
+    mockedGetRestaurants.mockReset()
+  })
+
+  it('requests HASHI PICK restaurants in rating order', async () => {
+    mockedGetRestaurants.mockResolvedValue({
+      hasNext: false,
+      nextCursor: undefined,
+      restaurants: [],
+    })
+
+    await fetchReservationRescueRestaurants()
+
+    expect(mockedGetRestaurants).toHaveBeenCalledWith({
+      genre: 'all',
+      size: 5,
+      sort: 'rating',
+      type: 'hashi-pick',
+    })
+  })
+
+  it('excludes the canceled restaurant and returns at most three mapped results', () => {
+    const restaurants = createReservationRescueRestaurants(
+      restaurantFixtures,
+      2,
+    )
+
+    expect(restaurants.map(({ id }) => id)).toEqual(['1', '3', '4'])
+  })
+
+  it('excludes responses that cannot be mapped to a restaurant', () => {
+    const restaurants = createReservationRescueRestaurants(
+      [{ name: '식당 ID가 없는 응답' }, ...restaurantFixtures],
+      2,
+    )
+
+    expect(restaurants.map(({ id }) => id)).toEqual(['1', '3', '4'])
+  })
+})

--- a/apps/client/src/pages/reservationRescue/queries/reservationRescueQueryOptions.ts
+++ b/apps/client/src/pages/reservationRescue/queries/reservationRescueQueryOptions.ts
@@ -1,0 +1,48 @@
+import { queryOptions } from '@tanstack/react-query'
+
+import {
+  getRestaurants,
+  type GetRestaurantsParams,
+  type RestaurantSummaryResponse,
+} from '@/features/restaurantList/api/getRestaurants'
+import type { Restaurant } from '@/features/restaurantList/types'
+import { mapRestaurantSummaryToRestaurant } from '@/features/restaurantList/utils'
+
+export const RESERVATION_RESCUE_RESTAURANT_PARAMS = {
+  genre: 'all',
+  size: 5,
+  sort: 'rating',
+  type: 'hashi-pick',
+} satisfies GetRestaurantsParams
+
+export const reservationRescueQueryKeys = {
+  all: ['reservationRescue'] as const,
+  restaurants: () =>
+    [...reservationRescueQueryKeys.all, 'restaurants'] as const,
+}
+
+export const fetchReservationRescueRestaurants = () =>
+  getRestaurants(RESERVATION_RESCUE_RESTAURANT_PARAMS)
+
+export const reservationRescueQueryOptions = () =>
+  queryOptions({
+    queryFn: fetchReservationRescueRestaurants,
+    queryKey: reservationRescueQueryKeys.restaurants(),
+  })
+
+export const createReservationRescueRestaurants = (
+  restaurants: RestaurantSummaryResponse[],
+  excludedRestaurantId: number,
+): Restaurant[] => {
+  return restaurants
+    .flatMap((restaurant) => {
+      if (restaurant.restaurantId === excludedRestaurantId) {
+        return []
+      }
+
+      const mappedRestaurant = mapRestaurantSummaryToRestaurant(restaurant)
+
+      return mappedRestaurant ? [mappedRestaurant] : []
+    })
+    .slice(0, 3)
+}

--- a/docs/architecture/routing-and-access-policy.md
+++ b/docs/architecture/routing-and-access-policy.md
@@ -53,21 +53,22 @@
 
 ## Auth Only Routes
 
-| Page               | Path                                          | Notes                                                                                                        |
-| ------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| 리뷰 작성 페이지   | `/restaurants/:restaurantId/reviews/new`      |                                                                                                              |
-| 마이 리뷰 페이지   | `/my-reviews`                                 | 리뷰 쓰기, 작성한 리뷰보기 탭을 가집니다.                                                                    |
-| 리뷰 상세 페이지   | `/reviews/:reviewId`                          |                                                                                                              |
-| 리뷰 수정 페이지   | `/reviews/:reviewId/edit`                     |                                                                                                              |
-| 저장 페이지        | `/saved`                                      | 준비중 페이지를 렌더링합니다.                                                                                |
-| 마이 페이지        | `/mypage`                                     |                                                                                                              |
-| 프로필 생성 페이지 | `/profile/new`                                | 신규 회원 onboarding session만 접근하며, 인증 완료 회원은 홈으로 이동합니다.                                 |
-| 탈퇴 페이지        | `/withdrawal`                                 | 유지 여부 논의 중입니다.                                                                                     |
-| 예약 페이지        | `/restaurants/:restaurantId/reservations/new` |                                                                                                              |
-| 어디든 예약 페이지 | `/reservations/anywhere`                      |                                                                                                              |
-| 예약 요청 페이지   | `/reservations/request`                       |                                                                                                              |
-| 예약 정보 페이지   | `/my-reservations`                            | 진행 중, 방문 예정, 방문 완료, 예약 취소 chip 상태에 따라 카드 디자인과 데이터가 달라지는 단일 페이지입니다. |
-| 예약 상세 페이지   | `/reservations/:reservationId`                |                                                                                                              |
+| Page                     | Path                                          | Notes                                                                                                        |
+| ------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| 리뷰 작성 페이지         | `/restaurants/:restaurantId/reviews/new`      |                                                                                                              |
+| 마이 리뷰 페이지         | `/my-reviews`                                 | 리뷰 쓰기, 작성한 리뷰보기 탭을 가집니다.                                                                    |
+| 리뷰 상세 페이지         | `/reviews/:reviewId`                          |                                                                                                              |
+| 리뷰 수정 페이지         | `/reviews/:reviewId/edit`                     |                                                                                                              |
+| 저장 페이지              | `/saved`                                      | 준비중 페이지를 렌더링합니다.                                                                                |
+| 마이 페이지              | `/mypage`                                     |                                                                                                              |
+| 프로필 생성 페이지       | `/profile/new`                                | 신규 회원 onboarding session만 접근하며, 인증 완료 회원은 홈으로 이동합니다.                                 |
+| 탈퇴 페이지              | `/withdrawal`                                 | 유지 여부 논의 중입니다.                                                                                     |
+| 예약 페이지              | `/restaurants/:restaurantId/reservations/new` |                                                                                                              |
+| 어디든 예약 페이지       | `/reservations/anywhere`                      |                                                                                                              |
+| 예약 요청 페이지         | `/reservations/request`                       |                                                                                                              |
+| 예약 정보 페이지         | `/my-reservations`                            | 진행 중, 방문 예정, 방문 완료, 예약 취소 chip 상태에 따라 카드 디자인과 데이터가 달라지는 단일 페이지입니다. |
+| 예약 상세 페이지         | `/reservations/:reservationId`                |                                                                                                              |
+| 예약 취소 후 추천 페이지 | `/reservations/:reservationId/rescue`         | 예약 취소 직후 기존 HASHI PICK 식당 탐색을 이어갑니다.                                                       |
 
 ## Auth Gate Policy
 


### PR DESCRIPTION
## 📌 Summary

예약 취소 직후 기존 HASHI PICK 식당을 대안으로 보여주는 추천 화면을 추가했습니다. 목록 캐시 동기화보다 추천 화면 전환을 먼저 수행해 취소 직후 404가 잠시 노출되던 문제도 방지했습니다.

Jira: HASHI-139

## 📚 Tasks

- 예약 취소 성공 시 식당 추천 화면으로 이동하도록 플로우 변경
- HASHI PICK 평점순 목록에서 취소한 식당을 제외해 최대 3개 추천
- 로딩·오류·빈 상태와 식당 상세/취소 예약 목록 이동 처리
- 하단 취소된 예약 보기 액션을 safe-area를 고려한 고정 바 형태로 적용
- 라우팅·페이지 스펙·회귀 테스트 추가

## 🔎 Description

신규 추천 API 없이 기존 예약 상세 API와 식당 목록 API를 조합했습니다. 추천 근거는 HASHI PICK과 평점순이며, 유사도나 실시간 예약 가능 여부 같은 API 미제공 정보는 노출하지 않습니다.

## ✅ Verification

- [x] pnpm format:check
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm build
- [x] pnpm --filter @hashi/client test (123 files, 606 tests)
- [x] 로컬 모바일 화면에서 하단 고정 액션 확인