### PR TITLE
Fix(client): HASHI 137 리스트 로딩 및 empty 상태 UI 개선

### DIFF
--- a/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
@@ -62,8 +62,8 @@ describe('AuthSessionRestoreGate', () => {
 
     expect(screen.queryByText('앱 화면')).not.toBeInTheDocument()
     expect(
-      screen.getByText('로그인 상태를 확인하고 있어요'),
-    ).toBeInTheDocument()
+      screen.queryByText('로그인 상태를 확인하고 있어요'),
+    ).not.toBeInTheDocument()
 
     await waitFor(() => {
       expect(screen.getByText('앱 화면')).toBeInTheDocument()

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
@@ -10,7 +10,6 @@ import {
   setOnboardingSession,
 } from '@/features/auth/session/authSession'
 import { getApiAccessToken } from '@/shared/api/accessToken'
-import { LoadingScreen } from '@/shared/components/loadingScreen'
 
 interface AuthSessionRestoreGateProps {
   children: ReactNode
@@ -117,7 +116,7 @@ export const AuthSessionRestoreGate = ({
   }, [])
 
   if (!isRestoreCompleted) {
-    return <LoadingScreen message="로그인 상태를 확인하고 있어요" />
+    return null
   }
 
   return children

--- a/apps/client/src/pages/magazines/MagazinesPage.spec.md
+++ b/apps/client/src/pages/magazines/MagazinesPage.spec.md
@@ -148,7 +148,7 @@ Jira: HASHI-77
   - next-page fetching must not shift existing list items.
 - empty:
   - if `banners` is empty or all banner items are unusable, do not render the hero banner section.
-  - if all magazine pages are empty, show `MagazineEmptyState` with `아직 추천 매거진이 없어요.`
+  - if all magazine pages are empty, show shared `ListEmptyState` with `매거진 리스트를 준비중이에요.`
   - if no usable list item is rendered yet but `hasNextPage` is true, do not show the empty state until the next page fetch resolves.
 - error:
   - expected `4xx` stays local to the page/query state.
@@ -229,7 +229,7 @@ MagazinesPage
       Carousel.Indicator
   RecommendedMagazineSection
     MagazineListItem x n
-    MagazineEmptyState?
+    ListEmptyState?
 ```
 
 ## Component Mapping
@@ -239,13 +239,12 @@ MagazinesPage
   - `IconButton`: 뒤로가기 아이콘 버튼
   - `Carousel`: 대표 매거진 배너 swipe/indicator
 - app shared component:
-  - none
+  - `ListEmptyState`: 추천 매거진 목록 empty 상태
 - page-local component:
   - `MagazineHeroBannerSection`
   - `MagazineHeroBannerSlide`
   - `RecommendedMagazineSection`
   - `MagazineListItem`
-  - `MagazineEmptyState`
 - page-local hook:
   - `useMagazinesPage`
 - shared hook:
@@ -308,7 +307,7 @@ Hero banners and magazine cards render semantic `<a>` elements only when the hoo
   - missing or invalid external URL: normalize to `null` in `useMagazinesPage`, then render the item as disabled-looking text content; do not crash the page.
   - broken image URL: rely on browser image behavior unless product approves a page-local or shared fallback.
 - user-facing message:
-  - empty recommended list: `아직 추천 매거진이 없어요.`
+  - empty recommended list: `매거진 리스트를 준비중이에요.`
 - retry or fallback:
   - use TanStack Query refetch/reset; do not call endpoint helpers directly from UI events.
 
@@ -372,7 +371,8 @@ Hero banners and magazine cards render semantic `<a>` elements only when the hoo
 - scroll area:
   - whole page scrolls vertically.
 - empty/loading/error layout:
-  - list empty state is rendered by `RecommendedMagazineSection`.
+  - list empty state is rendered by `RecommendedMagazineSection` using shared `ListEmptyState`.
+  - list empty state is vertically centered in the remaining page area below the fixed header.
   - loading/error states come from TanStack Query and page-local sections render section-level states.
 
 ## Accessibility

--- a/apps/client/src/pages/magazines/MagazinesPage.test.tsx
+++ b/apps/client/src/pages/magazines/MagazinesPage.test.tsx
@@ -289,6 +289,35 @@ describe('MagazinesPage', () => {
     expect(firstSkeletonImage).toHaveClass('w-[156px]')
   })
 
+  it('renders ListEmptyState when recommended magazines are empty', async () => {
+    mockGetMagazines.mockResolvedValueOnce({
+      hasNext: false,
+      magazines: [],
+    })
+
+    renderMagazinesPage()
+
+    const recommendedSection = screen.getByRole('region', {
+      name: '추천 매거진 목록',
+    })
+
+    expect(
+      await within(recommendedSection).findByText(
+        '매거진 리스트를 준비중이에요.',
+      ),
+    ).toHaveClass('typo-body-5', 'text-warm-gray-300')
+    expect(
+      within(recommendedSection).getByText('매거진 리스트를 준비중이에요.')
+        .parentElement?.parentElement,
+    ).toHaveClass(
+      'flex',
+      'min-h-[calc(100dvh-75px)]',
+      'items-center',
+      'justify-center',
+    )
+    expect(within(recommendedSection).queryByRole('list')).toBeNull()
+  })
+
   it('keeps the load-more sentinel when the current page has only filtered-out items and another page remains', async () => {
     mockGetMagazines
       .mockResolvedValueOnce({

--- a/apps/client/src/pages/magazines/components/MagazineEmptyState.tsx
+++ b/apps/client/src/pages/magazines/components/MagazineEmptyState.tsx
@@ -1,7 +1,0 @@
-export const MagazineEmptyState = () => {
-  return (
-    <p className="typo-body-3 text-cool-gray-500 py-10 text-center">
-      아직 추천 매거진이 없어요.
-    </p>
-  )
-}

--- a/apps/client/src/pages/magazines/sections/RecommendedMagazineSection.tsx
+++ b/apps/client/src/pages/magazines/sections/RecommendedMagazineSection.tsx
@@ -1,8 +1,8 @@
 import type { Ref } from 'react'
 
-import { MagazineEmptyState } from '@/pages/magazines/components/MagazineEmptyState'
 import { MagazineListItem } from '@/pages/magazines/components/MagazineListItem'
 import type { RecommendedMagazine } from '@/pages/magazines/types'
+import { ListEmptyState } from '@/shared/components/listEmptyState'
 
 interface Props {
   hasNextPage: boolean
@@ -90,7 +90,14 @@ export const RecommendedMagazineSection = ({
           {isFetchingNextPage ? renderSkeletonItems().slice(0, 1) : null}
         </ul>
       ) : null}
-      {shouldRenderEmptyState ? <MagazineEmptyState /> : null}
+      {shouldRenderEmptyState ? (
+        <div className="flex min-h-[calc(100dvh-75px)] items-center justify-center px-5 pb-20">
+          <ListEmptyState
+            className="min-h-0"
+            description="매거진 리스트를 준비중이에요."
+          />
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/apps/client/src/pages/myReservations/MyReservationsPage.test.tsx
+++ b/apps/client/src/pages/myReservations/MyReservationsPage.test.tsx
@@ -94,6 +94,15 @@ const renderMyReservationsPage = (
   )
 }
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
 describe('MyReservationsPage', () => {
   beforeEach(() => {
     mockedUseMyProfileSummaryQuery.mockReturnValue({
@@ -169,6 +178,37 @@ describe('MyReservationsPage', () => {
       screen.getByText((_, element) => element?.textContent === '총 7건'),
     ).toBeInTheDocument()
     expect(screen.getByText('3일')).toBeInTheDocument()
+  })
+
+  it('renders a skeleton instead of a loading message while reservations are loading', async () => {
+    const reservationsDeferred =
+      createDeferred<Awaited<ReturnType<typeof getMyReservations>>>()
+    mockedGetMyReservations.mockReturnValueOnce(reservationsDeferred.promise)
+
+    renderMyReservationsPage()
+
+    expect(screen.getByTestId('my-reservations-skeleton')).toBeInTheDocument()
+    expect(
+      screen.queryByText('예약 정보를 불러오는 중'),
+    ).not.toBeInTheDocument()
+
+    reservationsDeferred.resolve({
+      reservations: [
+        {
+          reservationId: 12,
+          restaurantId: 34,
+          restaurantName: '스시 하시',
+          reservedAt: '2026-07-20T18:30:00',
+          adultCount: 2,
+          reservationStatus: 'REQUESTED',
+          confirmDDay: 3,
+        },
+      ],
+      hasNext: false,
+      totalCount: 1,
+    })
+
+    expect(await screen.findByText('스시 하시')).toBeInTheDocument()
   })
 
   it('loads the next reservation page when the bottom sentinel intersects', async () => {

--- a/apps/client/src/pages/myReservations/components/ReservationListSection.tsx
+++ b/apps/client/src/pages/myReservations/components/ReservationListSection.tsx
@@ -1,13 +1,14 @@
-import { Empty } from '@/shared/components/empty'
 import type { Ref } from 'react'
 
 import { ReservationCardsByStatus } from '@/pages/myReservations/components/ReservationCardsByStatus'
 import { ReservationListSummary } from '@/pages/myReservations/components/ReservationListSummary'
+import { ReservationListSkeleton } from '@/pages/myReservations/components/ReservationListSkeleton'
 import type { ReservationStatusFilterValue } from '@/pages/myReservations/constants/reservationStatus'
 import type {
   MyReservation,
   VisitedReservation,
 } from '@/pages/myReservations/types'
+import { Empty } from '@/shared/components/empty'
 
 type ReservationListSectionProps = {
   selectedStatus: ReservationStatusFilterValue
@@ -42,9 +43,7 @@ export const ReservationListSection = ({
     <section className="flex min-h-0 flex-1 flex-col">
       <ReservationListSummary totalCount={totalCount} sortLabel="최신순" />
       {isLoading ? (
-        <p className="typo-body-6 text-cool-gray-600 py-10 text-center">
-          예약 정보를 불러오는 중
-        </p>
+        <ReservationListSkeleton selectedStatus={selectedStatus} />
       ) : hasReservations ? (
         <div className="mb-2 flex flex-col gap-4">
           <ReservationCardsByStatus

--- a/apps/client/src/pages/myReservations/components/ReservationListSkeleton.tsx
+++ b/apps/client/src/pages/myReservations/components/ReservationListSkeleton.tsx
@@ -1,0 +1,91 @@
+import type { ReservationStatusFilterValue } from '@/pages/myReservations/constants/reservationStatus'
+import { cn } from '@/shared/utils'
+
+type ReservationListSkeletonProps = {
+  selectedStatus: ReservationStatusFilterValue
+}
+
+const skeletonBlockClassName = 'bg-secondary-200 animate-pulse rounded-[4px]'
+
+const InProgressReservationSkeleton = () => {
+  return (
+    <article className="border-warm-gray-100 overflow-hidden rounded-[10px] border bg-white">
+      <div className="border-warm-gray-100 flex items-center gap-1 border-b px-5 py-2.5">
+        <div className={cn(skeletonBlockClassName, 'size-4 shrink-0')} />
+        <div className={cn(skeletonBlockClassName, 'h-5 w-48')} />
+      </div>
+
+      <div className="px-4.5 pt-6 pb-5">
+        <div className="flex gap-3">
+          <div className={cn(skeletonBlockClassName, 'size-[60px] shrink-0')} />
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <div className={cn(skeletonBlockClassName, 'h-6 w-full')} />
+            <div className={cn(skeletonBlockClassName, 'h-4 w-32')} />
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-4">
+          {Array.from({ length: 3 }, (_, index) => (
+            <div key={index} className="flex flex-col items-center gap-1.5">
+              <div
+                className={cn(skeletonBlockClassName, 'size-6 rounded-full')}
+              />
+              <div className={cn(skeletonBlockClassName, 'h-4 w-16')} />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <div className={cn(skeletonBlockClassName, 'h-12.5 rounded-[5px]')} />
+          <div className={cn(skeletonBlockClassName, 'h-12.5 rounded-[5px]')} />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+const DefaultReservationSkeleton = () => {
+  return (
+    <article className="border-secondary-200 border-b pb-4 last:border-b-0 last:pb-0">
+      <div className="flex gap-3">
+        <div
+          className={cn(
+            skeletonBlockClassName,
+            'size-23 shrink-0 rounded-[5px]',
+          )}
+        />
+        <div className="flex min-w-0 flex-1 flex-col pt-0.5">
+          <div className={cn(skeletonBlockClassName, 'h-6 w-full')} />
+          <div className={cn(skeletonBlockClassName, 'mt-2 h-4 w-40')} />
+          <div className={cn(skeletonBlockClassName, 'mt-1 h-4 w-24')} />
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className={cn(skeletonBlockClassName, 'h-11 rounded-[5px]')} />
+        <div className={cn(skeletonBlockClassName, 'h-11 rounded-[5px]')} />
+      </div>
+    </article>
+  )
+}
+
+export const ReservationListSkeleton = ({
+  selectedStatus,
+}: ReservationListSkeletonProps) => {
+  const skeletonItems = Array.from({ length: 3 }, (_, index) => index)
+
+  return (
+    <div
+      aria-hidden="true"
+      className="mb-2 flex flex-col gap-4"
+      data-testid="my-reservations-skeleton"
+    >
+      {skeletonItems.map((index) =>
+        selectedStatus === 'IN_PROGRESS' ? (
+          <InProgressReservationSkeleton key={index} />
+        ) : (
+          <DefaultReservationSkeleton key={index} />
+        ),
+      )}
+    </div>
+  )
+}

--- a/apps/client/src/pages/myReviews/MyReviewsPage.spec.md
+++ b/apps/client/src/pages/myReviews/MyReviewsPage.spec.md
@@ -83,7 +83,7 @@ Jira: HASHI-83, HASHI-114
     - 작성한 리뷰 탭의 `총 N건`
     - 마이페이지 리뷰 개수와 같은 query cache 공유
 - loading state:
-  - 활성 탭의 첫 페이지 요청 중 로딩 문구를 표시한다.
+  - 활성 탭의 첫 페이지 요청 중 문구형 로딩을 표시하지 않고 page-local skeleton을 표시한다.
 - error state:
   - 활성 탭의 목록 요청 실패 시 로컬 오류와 `다시 시도` 버튼을 표시한다.
 - empty state:

--- a/apps/client/src/pages/myReviews/MyReviewsPage.test.tsx
+++ b/apps/client/src/pages/myReviews/MyReviewsPage.test.tsx
@@ -91,6 +91,15 @@ const renderPage = (initialEntry: string = ROUTES.myReviews) => {
   )
 }
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
 describe('MyReviewsPage', () => {
   beforeEach(() => {
     vi.mocked(getVisitedReservations).mockResolvedValue({
@@ -115,7 +124,10 @@ describe('MyReviewsPage', () => {
   it('renders API-backed writable reviews and their server count', async () => {
     renderPage()
 
-    expect(screen.getByText('리뷰 목록을 불러오는 중입니다.')).toBeVisible()
+    expect(screen.getByTestId('my-review-list-skeleton')).toBeInTheDocument()
+    expect(
+      screen.queryByText('리뷰 목록을 불러오는 중입니다.'),
+    ).not.toBeInTheDocument()
     expect(
       await screen.findByRole('tab', { name: '리뷰 쓰기 2' }),
     ).toHaveAttribute('aria-selected', 'true')
@@ -128,6 +140,32 @@ describe('MyReviewsPage', () => {
       screen.getByText((_, element) => element?.textContent === '총 2건'),
     ).toBeVisible()
     expect(screen.getAllByRole('button', { name: '리뷰 작성' })).toHaveLength(2)
+  })
+
+  it('uses secondary color for my review list skeletons', async () => {
+    const writableDeferred =
+      createDeferred<Awaited<ReturnType<typeof getVisitedReservations>>>()
+    vi.mocked(getVisitedReservations).mockReturnValueOnce(
+      writableDeferred.promise,
+    )
+
+    renderPage()
+
+    const skeleton = screen.getByTestId('my-review-list-skeleton')
+
+    expect(skeleton.querySelector('.bg-secondary-200')).toBeTruthy()
+    expect(skeleton.querySelector('.bg-warm-gray-50')).toBeNull()
+    expect(
+      screen.queryByText('리뷰 목록을 불러오는 중입니다.'),
+    ).not.toBeInTheDocument()
+
+    writableDeferred.resolve({
+      content: writableReservations,
+      hasNext: false,
+      totalCount: 2,
+    })
+
+    expect(await screen.findByText('아키토리 라멘')).toBeVisible()
   })
 
   it('opens the written reviews tab from the tab search parameter', async () => {

--- a/apps/client/src/pages/myReviews/MyReviewsPage.tsx
+++ b/apps/client/src/pages/myReviews/MyReviewsPage.tsx
@@ -1,6 +1,7 @@
 import { BackIcon } from '@hashi/hds-icons'
 import { Header, IconButton } from '@hashi/hds-ui'
 
+import { MyReviewListSkeleton } from '@/pages/myReviews/components/MyReviewListSkeleton'
 import { MyReviewTabs } from '@/pages/myReviews/components/MyReviewTabs'
 import { MyReviewTotalCount } from '@/pages/myReviews/components/MyReviewTotalCount'
 import { MyReviewsErrorState } from '@/pages/myReviews/components/MyReviewsErrorState'
@@ -60,9 +61,9 @@ export const MyReviewsPage = () => {
       />
 
       {isPending ? (
-        <p className="typo-body-4 text-primary-200 flex min-h-[360px] items-center justify-center px-5 text-center">
-          리뷰 목록을 불러오는 중입니다.
-        </p>
+        <MyReviewListSkeleton
+          variant={isWritableTab ? 'writable' : 'written'}
+        />
       ) : isError ? (
         <MyReviewsErrorState onRetry={handleRetry} />
       ) : isEmpty ? (
@@ -120,11 +121,7 @@ export const MyReviewsPage = () => {
             </div>
           )}
           <div aria-hidden="true" className="h-px" ref={loadMoreRef} />
-          {isFetchingNextPage ? (
-            <p className="typo-body-7 text-cool-gray-500 py-4 text-center">
-              리뷰를 더 불러오는 중입니다.
-            </p>
-          ) : null}
+          {isFetchingNextPage ? <div className="h-4" /> : null}
         </main>
       )}
       <ComingSoonDialog

--- a/apps/client/src/pages/myReviews/components/MyReviewListSkeleton.tsx
+++ b/apps/client/src/pages/myReviews/components/MyReviewListSkeleton.tsx
@@ -1,0 +1,58 @@
+import { cn } from '@/shared/utils'
+
+type MyReviewListSkeletonProps = {
+  variant: 'writable' | 'written'
+}
+
+const skeletonBlockClassName = 'bg-secondary-200 animate-pulse rounded-[4px]'
+
+const ReviewCardContentSkeleton = () => {
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <div className={cn(skeletonBlockClassName, 'size-[92px] shrink-0')} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className={cn(skeletonBlockClassName, 'h-6 w-full')} />
+        <div className={cn(skeletonBlockClassName, 'mt-2 h-4 w-32')} />
+        <div className={cn(skeletonBlockClassName, 'mt-1 h-4 w-24')} />
+      </div>
+    </div>
+  )
+}
+
+const WritableReviewSkeleton = () => {
+  return (
+    <article className="flex min-w-0 flex-col gap-3">
+      <ReviewCardContentSkeleton />
+      <div className={cn(skeletonBlockClassName, 'h-9 rounded-[5px]')} />
+    </article>
+  )
+}
+
+const WrittenReviewSkeleton = () => {
+  return (
+    <article className="border-warm-gray-50 flex h-[120px] min-w-0 items-center gap-3 border-b">
+      <ReviewCardContentSkeleton />
+      <div className={cn(skeletonBlockClassName, 'size-[18px] shrink-0')} />
+    </article>
+  )
+}
+
+export const MyReviewListSkeleton = ({
+  variant,
+}: MyReviewListSkeletonProps) => {
+  return (
+    <div
+      aria-hidden="true"
+      className="flex min-w-0 flex-col gap-3 px-5 pt-5"
+      data-testid="my-review-list-skeleton"
+    >
+      {Array.from({ length: 3 }, (_, index) =>
+        variant === 'writable' ? (
+          <WritableReviewSkeleton key={index} />
+        ) : (
+          <WrittenReviewSkeleton key={index} />
+        ),
+      )}
+    </div>
+  )
+}

--- a/apps/client/src/pages/search/SearchPage.test.tsx
+++ b/apps/client/src/pages/search/SearchPage.test.tsx
@@ -189,6 +189,15 @@ const renderSearchPage = () => {
   )
 }
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
 describe('SearchPage', () => {
   afterEach(() => {
     cleanup()
@@ -307,6 +316,40 @@ describe('SearchPage', () => {
       JSON.stringify(['아끼소바']),
     )
     expect(mockGetSearchKeywordRecommendations).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders search result skeletons with secondary color while searching', async () => {
+    const user = userEvent.setup()
+    const searchDeferred =
+      createDeferred<Awaited<ReturnType<typeof mockGetRestaurants>>>()
+    mockGetRestaurants.mockReturnValueOnce(searchDeferred.promise)
+
+    renderSearchPage()
+
+    await user.type(
+      screen.getByRole('searchbox', { name: '식당 또는 메뉴 검색' }),
+      '스시',
+    )
+    await user.keyboard('{Enter}')
+
+    const loadingList = screen.getByRole('list', {
+      name: '검색 결과 로딩 중',
+    })
+    const firstSkeletonItem = within(loadingList).getAllByRole('listitem')[0]
+
+    expect(firstSkeletonItem.querySelector('.bg-secondary-200')).toBeTruthy()
+    expect(firstSkeletonItem.querySelector('.bg-warm-gray-50')).toBeNull()
+
+    searchDeferred.resolve({
+      hasNext: false,
+      restaurants: searchRestaurantFixtures
+        .slice(0, 1)
+        .map(convertSearchRestaurantFixtureToSummary),
+    })
+
+    expect(
+      await screen.findByText(searchRestaurantFixtures[0].name),
+    ).toBeInTheDocument()
   })
 
   it('does not request recommended keywords after search results are shown', async () => {

--- a/apps/client/src/pages/search/components/SearchResultSkeleton.tsx
+++ b/apps/client/src/pages/search/components/SearchResultSkeleton.tsx
@@ -6,11 +6,11 @@ export const SearchResultSkeleton = () => {
     >
       {Array.from({ length: 3 }, (_, index) => (
         <li className="flex gap-3" key={index}>
-          <div className="bg-warm-gray-50 h-[92px] w-[92px] shrink-0 animate-pulse rounded-[5px]" />
+          <div className="bg-secondary-200 h-[92px] w-[92px] shrink-0 animate-pulse rounded-[5px]" />
           <div className="flex min-w-0 flex-1 flex-col gap-3 self-center">
-            <div className="bg-warm-gray-50 h-5 w-full animate-pulse rounded" />
-            <div className="bg-warm-gray-50 h-5 w-3/4 animate-pulse rounded" />
-            <div className="bg-warm-gray-50 h-4 w-1/2 animate-pulse rounded" />
+            <div className="bg-secondary-200 h-5 w-full animate-pulse rounded" />
+            <div className="bg-secondary-200 h-5 w-3/4 animate-pulse rounded" />
+            <div className="bg-secondary-200 h-4 w-1/2 animate-pulse rounded" />
           </div>
         </li>
       ))}


### PR DESCRIPTION
## 📌 Summary
> 예약 정보, 마이 리뷰, 검색, 매거진 페이지의 로딩/empty 상태 UI를 정리했습니다.  
문구형 로딩 상태는 리스트 스켈레톤으로 대체하고, 스켈레톤 색상은 `secondary-200` 기준으로 통일했습니다. 매거진 빈 목록 상태는 page-local 컴포넌트 대신 shared `ListEmptyState`를 사용하도록 변경했습니다.

Jira: HASHI-137

## 📚 Tasks

- 예약 정보 페이지 초기 로딩 문구 제거 및 스켈레톤 적용
- 마이 리뷰 페이지 초기 로딩 문구 제거 및 스켈레톤 적용
- 마이 리뷰 무한스크롤 추가 로딩 문구 제거
- 검색 결과 스켈레톤 색상 `secondary-200`으로 통일
- 매거진 빈 목록 상태에 shared `ListEmptyState` 적용
- 기존 `MagazineEmptyState` 제거
- 매거진 empty 상태 세로/가로 가운데 정렬 적용
- 관련 spec 문서 및 테스트 갱신

## 🔎 Description

### 예약 정보 로딩 UI

예약 정보 페이지에서 초기 목록 조회 중 노출되던 `예약 정보를 불러오는 중` 문구를 제거하고, 예약 카드 구조에 맞춘 `ReservationListSkeleton`을 추가했습니다.

진행 중 예약은 진행 단계 UI가 포함된 카드 형태라 별도 스켈레톤 구조를 사용했고, 방문 예정/방문 완료/예약 취소 상태는 일반 예약 리스트 카드 형태에 맞춘 스켈레톤을 사용합니다.

### 마이 리뷰 로딩 UI

마이 리뷰 페이지에서 `리뷰 목록을 불러오는 중입니다.` 문구를 제거하고 `MyReviewListSkeleton`을 추가했습니다.

`리뷰 쓰기` 탭과 `작성한 리뷰` 탭의 카드 구조가 다르기 때문에 `writable`, `written` variant로 분기해 각 탭의 실제 리스트 형태와 유사한 스켈레톤을 보여주도록 했습니다.

무한스크롤로 다음 페이지를 불러오는 중에는 기존 목록을 유지하고, 별도의 로딩 문구는 노출하지 않도록 정리했습니다.

### 스켈레톤 색상 통일

검색 결과 스켈레톤에 남아 있던 `warm-gray` 계열 색상을 `secondary-200`으로 변경했습니다.

현재 `animate-pulse`가 적용된 리스트 스켈레톤은 모두 `secondary-200` 색상을 사용하도록 맞췄고, 관련 테스트도 추가했습니다.

### 매거진 empty 상태

매거진 추천 목록이 비어 있을 때 사용하던 page-local `MagazineEmptyState`를 제거하고 shared `ListEmptyState`를 적용했습니다.

문구는 `매거진 리스트를 준비중이에요.`로 변경했고, 화면의 남은 영역 기준으로 세로/가로 가운데 정렬되도록 wrapper 높이를 조정했습니다.

### 문서/테스트 갱신

변경된 UI 상태와 실제 코드가 맞도록 spec 문서를 갱신했습니다.

- 마이 리뷰 spec: 문구형 로딩 대신 page-local skeleton 표시로 수정
- 매거진 spec: `MagazineEmptyState` 대신 shared `ListEmptyState` 사용으로 수정
- 매거진 empty 문구 및 중앙 정렬 기준 반영

테스트는 각 페이지의 주요 변경 동작을 검증하도록 추가/수정했습니다.

## 👀 To Reviewer

- 스켈레톤 색상은 `secondary-200` 기준으로 통일했습니다.
- 매거진 empty 상태는 다른 리스트 empty UI와 맞추기 위해 shared `ListEmptyState`를 사용했습니다.
- 무한스크롤 추가 로딩에서는 별도 문구를 제거하고 기존 리스트가 유지되도록 했습니다.