### PR TITLE
Fix(admin): HASHI-140 예약 테이블 줄바꿈 방지

### DIFF
--- a/apps/admin/src/pages/reservations/ReservationsPage.test.tsx
+++ b/apps/admin/src/pages/reservations/ReservationsPage.test.tsx
@@ -140,6 +140,24 @@ describe('ReservationsPage', () => {
     )
   })
 
+  it('keeps compact reservation fields on one line in a scrollable table', () => {
+    render(<ReservationsPage />)
+
+    expect(screen.getByRole('table')).toHaveClass('w-full', 'min-w-[103rem]')
+    expect(screen.getByText('RSV-91').closest('td')).toHaveClass(
+      'whitespace-nowrap',
+    )
+    expect(screen.getByText('김하시').closest('td')).toHaveClass(
+      'whitespace-nowrap',
+    )
+    expect(screen.getByText('일반').closest('td')).toHaveClass(
+      'whitespace-nowrap',
+    )
+    expect(screen.getByText('30,000원').closest('td')).toHaveClass(
+      'whitespace-nowrap',
+    )
+  })
+
   it('warns on active reservations for the same restaurant in the same minute', () => {
     useReservationsQueryMock.mockReturnValue({
       data: {

--- a/apps/admin/src/pages/reservations/ReservationsPage.tsx
+++ b/apps/admin/src/pages/reservations/ReservationsPage.tsx
@@ -38,16 +38,20 @@ const statusChangeOptions: SelectOption<DocumentedReservationStatus>[] =
   statusOptions.slice(1) as SelectOption<DocumentedReservationStatus>[]
 
 const tableColumns = [
-  { key: 'id', label: '예약 ID', className: 'w-28' },
-  { key: 'reservedAt', label: '방문 일시', className: 'w-44' },
-  { key: 'reserver', label: '예약자', className: 'w-32' },
+  { key: 'id', label: '예약 ID', className: 'w-28 whitespace-nowrap' },
+  {
+    key: 'reservedAt',
+    label: '방문 일시',
+    className: 'w-44 whitespace-nowrap',
+  },
+  { key: 'reserver', label: '예약자', className: 'w-32 whitespace-nowrap' },
   { key: 'restaurant', label: '식당', className: 'w-56' },
-  { key: 'guestCount', label: '인원', className: 'w-44' },
-  { key: 'type', label: '예약 유형', className: 'w-28' },
-  { key: 'payment', label: '결제', className: 'w-28' },
-  { key: 'amount', label: '결제 금액', className: 'w-28' },
-  { key: 'status', label: '예약 상태', className: 'w-28' },
-  { key: 'actions', label: '액션', className: 'w-56' },
+  { key: 'guestCount', label: '인원', className: 'w-44 whitespace-nowrap' },
+  { key: 'type', label: '예약 유형', className: 'w-28 whitespace-nowrap' },
+  { key: 'payment', label: '결제', className: 'w-28 whitespace-nowrap' },
+  { key: 'amount', label: '결제 금액', className: 'w-28 whitespace-nowrap' },
+  { key: 'status', label: '예약 상태', className: 'w-28 whitespace-nowrap' },
+  { key: 'actions', label: '액션', className: 'w-56 whitespace-nowrap' },
 ]
 
 const paymentStatusLabel: Record<ReservationPaymentStatus, string> = {
@@ -184,6 +188,7 @@ export const ReservationsPage = () => {
         <div className="border-cool-gray-100 overflow-hidden rounded-lg border">
           <AdminTable
             columns={tableColumns}
+            tableClassName="w-full min-w-[103rem]"
             isLoading={reservationsQuery.isLoading}
             isError={reservationsQuery.isError}
             isEmpty={reservations.length === 0}
@@ -203,7 +208,7 @@ export const ReservationsPage = () => {
                       : 'hover:bg-cool-gray-50'
                   }
                 >
-                  <td className="text-cool-gray-700 px-3 py-3 text-sm font-bold">
+                  <td className="text-cool-gray-700 px-3 py-3 text-sm font-bold whitespace-nowrap">
                     {formatReservationId(reservation.id)}
                   </td>
                   <td className="text-cool-gray-600 px-3 py-3 text-sm">
@@ -219,7 +224,7 @@ export const ReservationsPage = () => {
                       ) : null}
                     </div>
                   </td>
-                  <td className="text-cool-gray-900 px-3 py-3 text-sm font-bold">
+                  <td className="text-cool-gray-900 px-3 py-3 text-sm font-bold whitespace-nowrap">
                     {reservation.reserverName}
                   </td>
                   <td className="px-3 py-3 text-sm">
@@ -233,13 +238,13 @@ export const ReservationsPage = () => {
                   <td className="text-cool-gray-700 px-3 py-3 text-sm font-semibold">
                     <ReservationGuestLabel reservation={reservation} />
                   </td>
-                  <td className="text-cool-gray-600 px-3 py-3 text-sm">
+                  <td className="text-cool-gray-600 px-3 py-3 text-sm whitespace-nowrap">
                     {reservationTypeLabel[reservation.reservationType]}
                   </td>
                   <td className="px-3 py-3">
                     <PaymentStatusBadge status={reservation.paymentStatus} />
                   </td>
-                  <td className="text-cool-gray-600 px-3 py-3 text-sm">
+                  <td className="text-cool-gray-600 px-3 py-3 text-sm whitespace-nowrap">
                     {reservation.amount.toLocaleString()}원
                   </td>
                   <td className="px-3 py-3">

--- a/apps/admin/src/shared/components/AdminTable.tsx
+++ b/apps/admin/src/shared/components/AdminTable.tsx
@@ -11,6 +11,7 @@ export interface AdminTableColumn {
 interface AdminTableProps {
   columns: AdminTableColumn[]
   children: ReactNode
+  tableClassName?: string
   isLoading?: boolean
   isError?: boolean
   isEmpty?: boolean
@@ -22,6 +23,7 @@ interface AdminTableProps {
 export const AdminTable = ({
   columns,
   children,
+  tableClassName,
   isLoading = false,
   isError = false,
   isEmpty = false,
@@ -34,7 +36,12 @@ export const AdminTable = ({
   return (
     <div className="min-h-0 overflow-hidden bg-white">
       <div className="overflow-x-auto">
-        <table className="min-w-full table-fixed border-separate border-spacing-0 text-left">
+        <table
+          className={cn(
+            'min-w-full table-fixed border-separate border-spacing-0 text-left',
+            tableClassName,
+          )}
+        >
           <thead>
             <tr>
               {columns.map((column) => (


### PR DESCRIPTION
## 📌 Summary

예약 관리 테이블의 열 폭을 안정화하고, 핵심 예약 정보가 셀 안에서 분절되지 않도록 수정했습니다.

Jira: HASHI-140

## 📚 Tasks

- 예약 테이블에 최소 폭과 가로 스크롤 적용
- 예약 ID·예약자·예약 유형·결제 금액의 줄바꿈 방지
- 레이아웃 회귀 테스트 추가

## 🔎 Description

공통 `AdminTable`에 화면별 테이블 폭을 지정할 수 있는 선택 prop을 추가했습니다. 예약 화면은 넓은 열 구성을 유지하고, 좁은 화면에서는 가로 스크롤로 확인합니다.

## ✅ Checks

- `pnpm --filter @hashi/admin test`
- `pnpm --filter @hashi/admin lint`
- `pnpm --filter @hashi/admin typecheck`
- `pnpm --filter @hashi/admin build`