### PR TITLE
Fix(client): HASHI-141 검색 결과 페이지 URL 상태 복원 처리

### DIFF
--- a/apps/client/src/pages/search/SearchPage.spec.md
+++ b/apps/client/src/pages/search/SearchPage.spec.md
@@ -116,10 +116,10 @@
 
 ### API Integration Map
 
-| UI area          | Endpoint                                                 | Params                                                               | Response data                                              | Query key                                                    | Mode       | Enabled                                 | States                                                 |
-| ---------------- | -------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ | ---------- | --------------------------------------- | ------------------------------------------------------ |
-| 검색 결과 리스트 | `GET /api/v1/restaurants`                                | `keyword`, `genre`, `foodCategory`, `sort`, `type`, `cursor`, `size` | `RestaurantListResponse.content`, `nextCursor`, `hasNext`  | `restaurantListQueryKeys.infiniteList(params)`               | `infinite` | trim 처리한 submitted keyword가 있을 때 | loading, next-page fetching, error, empty, success     |
-| 추천 검색어      | `GET /api/v1/restaurants/search-keyword-recommendations` | optional `size`                                                      | `RestaurantSearchKeywordRecommendationResponse.keywords[]` | `searchRestaurantQueryKeys.keywordRecommendations({ size })` | `query`    | 검색 전 idle panel 렌더링 시            | loading, empty fallback, error local fallback, success |
+| UI area          | Endpoint                                                 | Params                                                               | Response data                                              | Query key                                                    | Mode       | Enabled                           | States                                                 |
+| ---------------- | -------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ | ---------- | --------------------------------- | ------------------------------------------------------ |
+| 검색 결과 리스트 | `GET /api/v1/restaurants`                                | `keyword`, `genre`, `foodCategory`, `sort`, `type`, `cursor`, `size` | `RestaurantListResponse.content`, `nextCursor`, `hasNext`  | `restaurantListQueryKeys.infiniteList(params)`               | `infinite` | trim 처리한 URL keyword가 있을 때 | loading, next-page fetching, error, empty, success     |
+| 추천 검색어      | `GET /api/v1/restaurants/search-keyword-recommendations` | optional `size`                                                      | `RestaurantSearchKeywordRecommendationResponse.keywords[]` | `searchRestaurantQueryKeys.keywordRecommendations({ size })` | `query`    | 검색 전 idle panel 렌더링 시      | loading, empty fallback, error local fallback, success |
 
 ### Endpoint Type Mapping
 
@@ -270,13 +270,15 @@ export const searchRestaurantQueryKeys = {
   - food category bottom sheet open state
   - pending sort value
   - pending food category value
-  - has submitted search state
   - recent search keywords
 - form state:
   - 검색창 단일 입력값
 - URL state:
-  - 기본 구현에서는 URL query string 동기화를 하지 않습니다.
-  - 공유 가능한 검색 URL이 필요해지면 `keyword`, `sort`, `category`를 search params로 승격합니다.
+  - 검색 제출 또는 최근/추천 검색어 선택 시 `keyword` search param을 갱신합니다.
+  - 정렬 필터가 기본값이 아니면 `sort` search param을 갱신합니다.
+  - 음식 장르 필터가 기본값이 아니면 `category` search param을 갱신합니다.
+  - `/search?keyword=...`로 진입하면 검색창과 검색 결과 상태를 URL에서 복원합니다.
+  - 식당 상세로 이동한 뒤 브라우저 뒤로가기를 하면 직전 검색 URL이 복원되어 같은 검색 결과 상태로 돌아옵니다.
 - server state:
   - 검색 결과 식당 목록
   - loading / error / empty state
@@ -508,7 +510,9 @@ SearchPage
 - route params:
   - 없음
 - search params:
-  - 없음
+  - `keyword`: 제출된 검색어
+  - `sort`: `default`가 아닌 적용 정렬값
+  - `category`: `all`이 아닌 적용 음식 장르값
 - success redirect:
   - 없음
 - failure redirect:

--- a/apps/client/src/pages/search/SearchPage.test.tsx
+++ b/apps/client/src/pages/search/SearchPage.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
 import { SearchPage } from '@/pages/search/SearchPage'
@@ -189,6 +189,40 @@ const renderSearchPage = () => {
   )
 }
 
+const LocationState = () => {
+  const location = useLocation()
+
+  return <div data-testid="location-state">{location.search}</div>
+}
+
+const renderSearchPageWithRoutes = (initialEntry: string = ROUTES.search) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path={ROUTES.search}
+            element={
+              <>
+                <SearchPage />
+                <LocationState />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
 const createDeferred = <T,>() => {
   let resolve!: (value: T) => void
   const promise = new Promise<T>((promiseResolve) => {
@@ -316,6 +350,57 @@ describe('SearchPage', () => {
       JSON.stringify(['아끼소바']),
     )
     expect(mockGetSearchKeywordRecommendations).toHaveBeenCalledTimes(1)
+  })
+
+  it('stores submitted search state in the URL and restores results from the URL', async () => {
+    const user = userEvent.setup()
+
+    renderSearchPageWithRoutes()
+
+    await user.type(
+      screen.getByRole('searchbox', { name: '식당 또는 메뉴 검색' }),
+      '스시',
+    )
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-state')).toHaveTextContent(
+        '?keyword=%EC%8A%A4%EC%8B%9C',
+      )
+    })
+    expect(await screen.findByText('스시 하루')).toBeInTheDocument()
+
+    cleanup()
+    vi.clearAllMocks()
+    mockGetSearchKeywordRecommendations.mockResolvedValue(['아끼소바'])
+    mockGetRestaurants.mockImplementation(({ genre, keyword, sort }) => {
+      const normalizedKeyword = keyword.trim().toLowerCase()
+      const restaurants = searchRestaurantFixtures.filter((restaurant) => {
+        const matchesKeyword = [
+          restaurant.name,
+          restaurant.tag,
+          ...restaurant.keywords,
+        ].some((value) => value.toLowerCase().includes(normalizedKeyword))
+
+        return (
+          matchesKeyword && (genre === 'all' || restaurant.category === genre)
+        )
+      })
+
+      return Promise.resolve({
+        hasNext: false,
+        restaurants: restaurants.map(convertSearchRestaurantFixtureToSummary),
+        ...(sort && { sort }),
+      })
+    })
+
+    renderSearchPageWithRoutes(`${ROUTES.search}?keyword=스시`)
+
+    expect(
+      screen.getByRole('searchbox', { name: '식당 또는 메뉴 검색' }),
+    ).toHaveValue('스시')
+    expect(await screen.findByText('스시 하루')).toBeInTheDocument()
+    expect(mockGetSearchKeywordRecommendations).not.toHaveBeenCalled()
   })
 
   it('renders search result skeletons with secondary color while searching', async () => {

--- a/apps/client/src/pages/search/hooks/useSearchPage.ts
+++ b/apps/client/src/pages/search/hooks/useSearchPage.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
 import {
@@ -23,28 +23,42 @@ const getOptionLabel = <TValue extends string>(
   return options.find((option) => option.value === value)?.label ?? ''
 }
 
+const checkIsSearchSortValue = (
+  value: string | null,
+): value is SearchSortValue =>
+  sortOptions.some((option) => option.value === value)
+
+const checkIsFoodCategoryValue = (
+  value: string | null,
+): value is FoodCategoryValue =>
+  foodCategoryOptions.some((option) => option.value === value)
+
 export const useSearchPage = () => {
   const location = useLocation()
   const navigate = useNavigate()
+  const [urlSearchParams, setUrlSearchParams] = useSearchParams()
   const searchInputRef = useRef<HTMLInputElement>(null)
-  const [keyword, setKeyword] = useState('')
-  const [submittedKeyword, setSubmittedKeyword] = useState('')
-  const [sortValue, setSortValue] =
-    useState<SearchSortValue>(DEFAULT_SORT_VALUE)
+  const urlKeyword = urlSearchParams.get('keyword')?.trim() ?? ''
+  const urlSort = urlSearchParams.get('sort')
+  const urlFoodCategory = urlSearchParams.get('category')
+  const sortValue = checkIsSearchSortValue(urlSort)
+    ? urlSort
+    : DEFAULT_SORT_VALUE
+  const foodCategoryValue = checkIsFoodCategoryValue(urlFoodCategory)
+    ? urlFoodCategory
+    : DEFAULT_FOOD_CATEGORY_VALUE
+  const [keyword, setKeyword] = useState(urlKeyword)
   const [pendingSortValue, setPendingSortValue] =
-    useState<SearchSortValue>(DEFAULT_SORT_VALUE)
-  const [foodCategoryValue, setFoodCategoryValue] = useState<FoodCategoryValue>(
-    DEFAULT_FOOD_CATEGORY_VALUE,
-  )
+    useState<SearchSortValue>(sortValue)
   const [pendingFoodCategoryValue, setPendingFoodCategoryValue] =
-    useState<FoodCategoryValue>(DEFAULT_FOOD_CATEGORY_VALUE)
+    useState<FoodCategoryValue>(foodCategoryValue)
   const [isSortSheetOpen, setIsSortSheetOpen] = useState(false)
   const [isFoodCategorySheetOpen, setIsFoodCategorySheetOpen] = useState(false)
   const { recentSearchKeywords, saveRecentSearchKeyword } =
     useRecentSearchKeywords()
 
   const searchParams = useMemo(() => {
-    const normalizedKeyword = submittedKeyword.trim()
+    const normalizedKeyword = urlKeyword.trim()
 
     if (!normalizedKeyword) {
       return null
@@ -55,7 +69,7 @@ export const useSearchPage = () => {
       keyword: normalizedKeyword,
       sort: sortValue,
     }
-  }, [foodCategoryValue, sortValue, submittedKeyword])
+  }, [foodCategoryValue, sortValue, urlKeyword])
 
   const searchRestaurantsQuery = useSearchRestaurantsInfiniteQuery(searchParams)
   const searchKeywordRecommendationsQuery =
@@ -90,17 +104,46 @@ export const useSearchPage = () => {
     searchInputRef.current?.focus()
   }, [])
 
+  const updateSearchUrlParams = ({
+    category = foodCategoryValue,
+    keyword: nextKeyword = urlKeyword,
+    sort = sortValue,
+  }: {
+    category?: FoodCategoryValue
+    keyword?: string
+    sort?: SearchSortValue
+  }) => {
+    const normalizedKeyword = nextKeyword.trim()
+
+    if (!normalizedKeyword) {
+      setUrlSearchParams({}, { replace: true })
+      return
+    }
+
+    const nextSearchParams = new URLSearchParams({ keyword: normalizedKeyword })
+
+    if (sort !== DEFAULT_SORT_VALUE) {
+      nextSearchParams.set('sort', sort)
+    }
+
+    if (category !== DEFAULT_FOOD_CATEGORY_VALUE) {
+      nextSearchParams.set('category', category)
+    }
+
+    setUrlSearchParams(nextSearchParams, { replace: true })
+  }
+
   const submitSearch = (nextKeyword = keyword) => {
     const normalizedKeyword = nextKeyword.trim()
 
     if (!normalizedKeyword) {
       setKeyword('')
-      setSubmittedKeyword('')
+      updateSearchUrlParams({ keyword: '' })
       return
     }
 
     setKeyword(normalizedKeyword)
-    setSubmittedKeyword(normalizedKeyword)
+    updateSearchUrlParams({ keyword: normalizedKeyword })
     saveRecentSearchKeyword(normalizedKeyword)
   }
 
@@ -130,23 +173,23 @@ export const useSearchPage = () => {
   }
 
   const handleSortApply = () => {
-    setSortValue(pendingSortValue)
     setIsSortSheetOpen(false)
+    updateSearchUrlParams({ sort: pendingSortValue })
   }
 
   const handleFoodCategoryApply = () => {
-    setFoodCategoryValue(pendingFoodCategoryValue)
     setIsFoodCategorySheetOpen(false)
+    updateSearchUrlParams({ category: pendingFoodCategoryValue })
   }
 
   const handleSortReset = () => {
     setPendingSortValue(DEFAULT_SORT_VALUE)
-    setSortValue(DEFAULT_SORT_VALUE)
+    updateSearchUrlParams({ sort: DEFAULT_SORT_VALUE })
   }
 
   const handleFoodCategoryReset = () => {
     setPendingFoodCategoryValue(DEFAULT_FOOD_CATEGORY_VALUE)
-    setFoodCategoryValue(DEFAULT_FOOD_CATEGORY_VALUE)
+    updateSearchUrlParams({ category: DEFAULT_FOOD_CATEGORY_VALUE })
   }
 
   const handleSortSelect = (value: string) => {


### PR DESCRIPTION
## 📌 Summary
> 검색 페이지에서 키워드 검색 후 식당 상세로 이동했다가 뒤로가기 했을 때, 기존 검색어와 검색 결과 상태가 유지되도록 수정했습니다.

Jira: HASHI-141 

## 📚 Tasks
- 검색어 제출 시 `keyword`를 URL search params에 반영
- 정렬 필터가 기본값이 아닐 경우 `sort`를 URL search params에 반영
- 음식 장르 필터가 전체가 아닐 경우 `category`를 URL search params에 반영
- `/search?keyword=...` 직접 진입 시 검색창과 검색 결과 복원
- 식당 상세 이동 후 브라우저 뒤로가기 시 기존 검색 결과 상태 복원
- 검색 페이지 테스트 및 spec 문서 갱신

## 🔎 Description
기존 검색 페이지는 검색어와 적용된 필터 상태를 페이지 내부 state로만 관리하고 있었습니다. 그래서 검색 결과에서 식당 상세 페이지로 이동한 뒤 뒤로가기를 하면, 브라우저 history에는 `/search`만 남아 검색 전 초기 화면으로 돌아가는 문제가 있었습니다.

이번 수정에서는 검색 결과를 결정하는 상태를 URL search params로 승격했습니다.

- `keyword`: 제출된 검색어
- `sort`: 기본 정렬이 아닌 경우에만 저장
- `category`: 전체 장르가 아닌 경우에만 저장

검색 결과 API 요청은 URL에서 복원한 값을 기준으로 실행됩니다. 따라서 `/search?keyword=스시`처럼 직접 진입하거나, 검색 결과에서 상세 페이지로 이동한 뒤 뒤로가기를 해도 동일한 검색어와 결과 목록이 유지됩니다.

입력창 값은 로컬 draft state로 유지하되, 최초 진입 시 URL의 `keyword`를 초기값으로 사용합니다. 검색 제출 시에는 입력값을 trim 처리한 뒤 URL에 반영하고, 빈 검색어 제출 시에는 search params를 제거해 검색 전 상태로 돌아가도록 했습니다.