### PR TITLE
Feat (admin): HASHI-142 회원 관리와 인증 복구 구현 

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ pnpm exec vercel build --local-config vercel.admin.json
 pnpm exec vercel deploy --prebuilt --local-config vercel.admin.json
 ```
 
+Admin 배포는 과거 `admin.hashi.kr`에 설치된 client PWA service worker를 제거하기 위해
+`apps/admin/public/sw.js`를 같은 경로의 self-destroying worker로 유지합니다. 해당 파일은
+기존 등록과 Cache Storage를 정리하므로 임의로 삭제하거나 이름을 변경하지 않습니다.
+
 ---
 
 ## 📖 Convention

--- a/apps/admin/public/sw.js
+++ b/apps/admin/public/sw.js
@@ -1,0 +1,24 @@
+/* global self */
+
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    Promise.all([
+      self.registration.unregister(),
+      self.caches
+        .keys()
+        .then((cacheNames) =>
+          Promise.all(
+            cacheNames.map((cacheName) => self.caches.delete(cacheName)),
+          ),
+        ),
+    ])
+      .then(() => self.clients.matchAll({ type: 'window' }))
+      .then((clients) =>
+        Promise.all(clients.map((client) => client.navigate(client.url))),
+      ),
+  )
+})

--- a/apps/admin/src/app/AdminApiIntegration.spec.md
+++ b/apps/admin/src/app/AdminApiIntegration.spec.md
@@ -2,7 +2,8 @@
 
 ## Goal
 
-- admin OpenAPI의 11개 operation과 user OpenAPI의 공개 식당·매거진 조회 및 이미지 업로드를 관리자 UI에 연결합니다.
+- published admin OpenAPI operation과 user OpenAPI의 공개 식당·매거진 조회, 이미지 업로드, token reissue를 관리자 UI에 연결합니다.
+- 아직 admin OpenAPI에 배포되지 않은 회원 목록은 HASHI-142 backend spec을 page-local 계약으로 연결하고 schema 배포 후 generated 타입으로 교체합니다.
 - 실제 schema URL과 관리자 credential은 repository에 기록하지 않습니다.
 
 ## Query Map
@@ -10,6 +11,7 @@
 | UI                        | Endpoint                                     | Query mode/key                                                 | States                                   |
 | ------------------------- | -------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------- |
 | Dashboard/reservations    | `GET /api/v1/admin/reservations`             | finite query, `adminQueryKeys.reservations.*`                  | loading/error/empty/success              |
+| Users                     | `GET /api/v1/admin/users`                    | finite query, `userQueryKeys.list(params)`                     | loading/error/empty/success/fetching     |
 | Reservation user          | `GET /api/v1/admin/reservations/{id}/user`   | enabled finite query                                           | loading/error/success                    |
 | Published restaurants     | `GET /api/v1/restaurants`                    | infinite query, `restaurantQueryKeys.list(params)`             | loading/error/empty/success/next pending |
 | Restaurant update prefill | summary + store-information + all menu pages | enabled composed query, `restaurantQueryKeys.prefill(id, row)` | loading/error/success                    |
@@ -18,6 +20,15 @@
 - restaurant cursor는 opaque string으로 그대로 전달합니다.
 - magazine/menu cursor는 schema의 number를 그대로 전달합니다.
 - response를 바꾸는 filter와 size는 query key에 포함합니다.
+- user list는 `sort`, trimmed optional `keyword`, zero-based `page`, `size=20`을 key와 request에 포함합니다.
+
+## Auth Recovery
+
+1. 보호 API의 첫 `401`은 `POST /api/v1/auth/reissue`를 호출합니다.
+2. 동시 `401` 요청은 하나의 in-flight reissue를 공유합니다.
+3. 새 access token을 session에 반영한 뒤 각 원 요청을 한 번만 재시도합니다.
+4. auth endpoint는 recursive reissue 대상에서 제외합니다.
+5. reissue 실패 또는 재시도 `401`은 session을 지우고 route guard가 `/admin/login`으로 이동합니다.
 
 ## Mutation Map
 
@@ -63,6 +74,8 @@
 ## Done Criteria
 
 - query key factory, explicit initialPageParam/getNextPageParam, mutation invalidation이 구현됩니다.
+- 회원 목록의 search, sort, offset pagination과 loading/error/empty/fetching 상태가 구현됩니다.
+- access token 만료 시 single-flight reissue, one-time replay, terminal login redirect가 구현됩니다.
 - loading/error/empty/success/upload states가 UI에 연결됩니다.
 - 식당·매거진 raw image key 입력을 primary UI로 노출하지 않습니다.
 - `adminService`, `mockStore`, `Mock 상태` production 의존성이 없습니다.

--- a/apps/admin/src/app/AdminConsole.spec.md
+++ b/apps/admin/src/app/AdminConsole.spec.md
@@ -13,6 +13,7 @@
 | `/admin/login`        | guest only | 관리자 로그인              |
 | `/admin/dashboard`    | admin only | 예약 기반 대시보드         |
 | `/admin/reservations` | admin only | 예약 목록 및 상태 관리     |
+| `/admin/users`        | admin only | 회원 목록 조회             |
 | `/admin/restaurants`  | admin only | 공개 식당 및 관리자 쓰기   |
 | `/admin/magazines`    | admin only | 공개 매거진 및 관리자 쓰기 |
 
@@ -23,9 +24,28 @@
 
 - 로그인은 `POST /api/v1/auth/admin/login`, 로그아웃은 `POST /api/v1/auth/admin/logout`을 사용합니다.
 - bearer token과 credential cookie를 함께 사용합니다.
+- access token 만료로 보호 API가 `401`을 반환하면 `POST /api/v1/auth/reissue`를 한 번 호출하고 원 요청을 한 번 재시도합니다.
+- 동시 `401` 요청은 하나의 token reissue를 공유합니다. 재발급 실패 또는 재시도 `401`은 session을 지우고 `/admin/login`으로 이동합니다.
 - 예약 목록은 `GET /api/v1/admin/reservations`, 예약자 조회와 상태 변경은 각 admin endpoint를 사용합니다.
 - 예약 목록 query는 상태·page·size를 key에 포함하고 상태 변경 성공 후 목록 prefix를 invalidate합니다.
+- 회원·예약의 offset 목록은 공용 숫자 pagination을 사용합니다.
+- 식당·매거진의 cursor 목록은 `더 보기`를 유지합니다.
 - 현재 조회한 페이지와 상태 필터 안에서 같은 식당·같은 분의 취소되지 않은 예약이 2건 이상이면 해당 행에 충돌 경고를 표시합니다.
+
+## Users
+
+### Data Dependencies
+
+- 회원 목록: `GET /api/v1/admin/users` (`sort`, optional trimmed `keyword`, zero-based `page`, `size=20`)
+- 기본 `CREATED_AT` 최신순 정렬과 `NICKNAME` 가나다순 정렬을 지원합니다.
+- 2026-07-17 기준 dev admin OpenAPI에 endpoint가 아직 없으므로 supplied backend spec 기반 page-local 타입을 사용합니다.
+
+### UX And Contract
+
+- 닉네임 부분 일치 검색은 입력이 멈춘 뒤 300ms 디바운스하여 적용하고 첫 페이지로 돌아갑니다.
+- 정렬 변경도 즉시 적용하고 첫 페이지로 돌아갑니다.
+- 표는 프로필, 닉네임, 영문 이름, 생년월일, 전화번호, 이메일, 가입일을 표시합니다.
+- loading, error/retry, keyword-aware empty, success, background fetching, pagination 상태를 구분합니다.
 
 ## Restaurants
 
@@ -77,6 +97,7 @@
 - 환경변수: `ADMIN_OPENAPI_SCHEMA_URL`, `USER_OPENAPI_SCHEMA_URL`
 - 명령: `pnpm gen:admin-api-types`, `pnpm gen:admin-user-api-types`, `pnpm gen:admin-all-api-types`
 - generated 파일은 직접 수정하지 않습니다.
+- `GET /api/v1/admin/users`가 admin OpenAPI에 배포되면 page-local 회원 타입을 generated 타입 alias로 교체합니다.
 
 ## UI States and Verification
 

--- a/apps/admin/src/app/layout/AdminLayout.test.tsx
+++ b/apps/admin/src/app/layout/AdminLayout.test.tsx
@@ -1,0 +1,30 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { AdminLayout } from '@/app/layout/AdminLayout'
+
+describe('AdminLayout', () => {
+  it('links to member management in the sidebar', () => {
+    const queryClient = new QueryClient()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/admin/dashboard']}>
+          <Routes>
+            <Route path="/admin" element={<AdminLayout />}>
+              <Route path="dashboard" element={<p>대시보드</p>} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const userLinks = screen.getAllByRole('link', { name: '회원 관리' })
+
+    expect(userLinks).toHaveLength(2)
+    userLinks.forEach((link) =>
+      expect(link).toHaveAttribute('href', '/admin/users'),
+    )
+  })
+})

--- a/apps/admin/src/app/layout/AdminLayout.tsx
+++ b/apps/admin/src/app/layout/AdminLayout.tsx
@@ -3,6 +3,7 @@ import {
   HomeIcon,
   MagazineIcon,
   MenuIcon,
+  PeopleIcon,
   ReservationIcon,
   TodayRestaurantIcon,
 } from '@hashi/hds-icons'
@@ -25,6 +26,11 @@ const navigationItems = [
     label: '식당 관리',
     to: ROUTES.restaurants,
     icon: <TodayRestaurantIcon aria-hidden="true" className="size-5" />,
+  },
+  {
+    label: '회원 관리',
+    to: ROUTES.users,
+    icon: <PeopleIcon aria-hidden="true" className="size-5" />,
   },
   {
     label: '예약 관리',

--- a/apps/admin/src/app/legacyPwaDeployment.test.ts
+++ b/apps/admin/src/app/legacyPwaDeployment.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+interface VercelConfig {
+  headers?: Array<{
+    source: string
+    headers: Array<{ key: string; value: string }>
+  }>
+}
+
+const workerPath = resolve(process.cwd(), 'public/sw.js')
+const vercelConfigPath = resolve(process.cwd(), '../../vercel.admin.json')
+
+describe('legacy PWA deployment cleanup', () => {
+  it('ships a self-destroying worker at the original service worker path', () => {
+    expect(existsSync(workerPath)).toBe(true)
+
+    const workerSource = readFileSync(workerPath, 'utf8')
+
+    expect(workerSource).toContain("self.addEventListener('install'")
+    expect(workerSource).toContain('self.skipWaiting()')
+    expect(workerSource).toContain('self.registration.unregister()')
+    expect(workerSource).toContain('self.caches.delete(cacheName)')
+  })
+
+  it('prevents the cleanup worker from being cached by browsers or the CDN', () => {
+    const config = JSON.parse(
+      readFileSync(vercelConfigPath, 'utf8'),
+    ) as VercelConfig
+    const workerHeaders = config.headers?.find(
+      ({ source }) => source === '/sw.js',
+    )
+
+    expect(workerHeaders?.headers).toEqual(
+      expect.arrayContaining([
+        { key: 'Cache-Control', value: 'no-store, max-age=0' },
+        { key: 'Vercel-CDN-Cache-Control', value: 'no-store' },
+      ]),
+    )
+  })
+})

--- a/apps/admin/src/app/main.test.tsx
+++ b/apps/admin/src/app/main.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const renderMock = vi.fn()
+
+vi.mock('react-dom/client', () => ({
+  createRoot: () => ({ render: renderMock }),
+}))
+
+vi.mock('@/app/App', () => ({
+  App: () => null,
+}))
+
+describe('admin app bootstrap', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    renderMock.mockReset()
+    document.body.innerHTML = '<div id="root"></div>'
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'serviceWorker')
+    Reflect.deleteProperty(globalThis, 'caches')
+    document.body.innerHTML = ''
+  })
+
+  it('removes legacy service workers and their caches on startup', async () => {
+    const unregister = vi.fn().mockResolvedValue(true)
+    const getRegistrations = vi
+      .fn()
+      .mockResolvedValue([
+        { unregister },
+      ] as unknown as ServiceWorkerRegistration[])
+    const deleteCache = vi.fn().mockResolvedValue(true)
+    const cacheKeys = vi.fn().mockResolvedValue(['workbox-precache-v1'])
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { getRegistrations },
+    })
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: { delete: deleteCache, keys: cacheKeys },
+    })
+
+    await import('@/app/main')
+
+    await vi.waitFor(() => {
+      expect(unregister).toHaveBeenCalledOnce()
+      expect(deleteCache).toHaveBeenCalledWith('workbox-precache-v1')
+    })
+    expect(renderMock).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/admin/src/app/main.tsx
+++ b/apps/admin/src/app/main.tsx
@@ -3,6 +3,35 @@ import { createRoot } from 'react-dom/client'
 import { App } from '@/app/App'
 import '@/app/styles/global.css'
 
+const removeLegacyPwaState = async () => {
+  const unregisterWorkers =
+    'serviceWorker' in navigator
+      ? navigator.serviceWorker
+          .getRegistrations()
+          .then((registrations) =>
+            Promise.all(
+              registrations.map((registration) => registration.unregister()),
+            ),
+          )
+      : Promise.resolve([])
+  const deleteCaches =
+    'caches' in globalThis
+      ? globalThis.caches
+          .keys()
+          .then((cacheNames) =>
+            Promise.all(
+              cacheNames.map((cacheName) =>
+                globalThis.caches.delete(cacheName),
+              ),
+            ),
+          )
+      : Promise.resolve([])
+
+  await Promise.all([unregisterWorkers, deleteCaches])
+}
+
+void removeLegacyPwaState().catch(() => undefined)
+
 const rootElement = document.getElementById('root')
 
 if (!rootElement) {

--- a/apps/admin/src/app/providers/QueryProvider.test.tsx
+++ b/apps/admin/src/app/providers/QueryProvider.test.tsx
@@ -1,0 +1,49 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { QueryProvider } from '@/app/providers/QueryProvider'
+import { queryClient } from '@/shared/lib/queryClient'
+import { clearAdminSession, setAdminSession } from '@/shared/auth/adminSession'
+
+const adminUsersQueryKey = [
+  'admin',
+  'users',
+  'list',
+  { page: 0, size: 20, sort: 'CREATED_AT' },
+] as const
+
+describe('QueryProvider', () => {
+  beforeEach(() => {
+    queryClient.clear()
+    clearAdminSession()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+    clearAdminSession()
+  })
+
+  it('clears cached admin data when the active session is invalidated', () => {
+    setAdminSession({
+      accessToken: 'admin-access-token',
+      issuedAt: '2026-07-21T00:00:00Z',
+      loginId: 'hashi-admin',
+    })
+    const view = render(
+      <QueryProvider>
+        <div />
+      </QueryProvider>,
+    )
+    const cachedUsers = {
+      totalCount: 1,
+      users: [{ email: 'admin@example.com', userId: 1 }],
+    }
+
+    queryClient.setQueryData(adminUsersQueryKey, cachedUsers)
+
+    act(() => clearAdminSession())
+
+    expect(queryClient.getQueryData(adminUsersQueryKey)).toBeUndefined()
+
+    view.unmount()
+  })
+})

--- a/apps/admin/src/app/providers/QueryProvider.tsx
+++ b/apps/admin/src/app/providers/QueryProvider.tsx
@@ -1,12 +1,24 @@
 import { QueryClientProvider } from '@tanstack/react-query'
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { queryClient } from '@/shared/lib/queryClient'
+import {
+  getAdminSession,
+  subscribeAdminSession,
+} from '@/shared/auth/adminSession'
 
 interface QueryProviderProps {
   children: ReactNode
 }
 
 export const QueryProvider = ({ children }: QueryProviderProps) => {
+  useEffect(() => {
+    return subscribeAdminSession(() => {
+      if (!getAdminSession()) {
+        queryClient.clear()
+      }
+    })
+  }, [])
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )

--- a/apps/admin/src/app/router/RouteGuards.test.tsx
+++ b/apps/admin/src/app/router/RouteGuards.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { AdminOnlyRoute } from '@/app/router/RouteGuards'
+import { clearAdminSession, setAdminSession } from '@/shared/auth/adminSession'
+
+describe('AdminOnlyRoute', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setAdminSession({
+      accessToken: 'expired-token',
+      issuedAt: '2026-07-17T00:00:00Z',
+      loginId: 'hashi-admin',
+    })
+  })
+
+  it('redirects when the mounted admin session is cleared', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/admin/dashboard']}>
+        <Routes>
+          <Route element={<AdminOnlyRoute />}>
+            <Route
+              path="/admin/dashboard"
+              element={
+                <button type="button" onClick={clearAdminSession}>
+                  세션 만료
+                </button>
+              }
+            />
+          </Route>
+          <Route path="/admin/login" element={<p>로그인 화면</p>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: '세션 만료' }))
+
+    expect(await screen.findByText('로그인 화면')).toBeInTheDocument()
+  })
+})

--- a/apps/admin/src/app/router/RouteGuards.tsx
+++ b/apps/admin/src/app/router/RouteGuards.tsx
@@ -1,10 +1,10 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { ROUTES } from '@/app/router/path'
-import { getAdminSession } from '@/shared/auth/adminSession'
+import { useAdminSession } from '@/shared/auth/useAdminSession'
 
 export const AdminOnlyRoute = () => {
   const location = useLocation()
-  const session = getAdminSession()
+  const session = useAdminSession()
 
   if (!session) {
     return <Navigate to={ROUTES.login} replace state={{ from: location }} />
@@ -14,7 +14,7 @@ export const AdminOnlyRoute = () => {
 }
 
 export const GuestOnlyRoute = () => {
-  const session = getAdminSession()
+  const session = useAdminSession()
 
   if (session) {
     return <Navigate to={ROUTES.dashboard} replace />

--- a/apps/admin/src/app/router/lazy.ts
+++ b/apps/admin/src/app/router/lazy.ts
@@ -11,6 +11,11 @@ export const lazyPages = {
       default: DashboardPage,
     })),
   ),
+  UsersPage: lazy(() =>
+    import('@/pages/users/UsersPage').then(({ UsersPage }) => ({
+      default: UsersPage,
+    })),
+  ),
   RestaurantsPage: lazy(() =>
     import('@/pages/restaurants/RestaurantsPage').then(
       ({ RestaurantsPage }) => ({

--- a/apps/admin/src/app/router/path.ts
+++ b/apps/admin/src/app/router/path.ts
@@ -2,6 +2,7 @@ export const ROUTES = {
   adminRoot: '/admin',
   login: '/admin/login',
   dashboard: '/admin/dashboard',
+  users: '/admin/users',
   restaurants: '/admin/restaurants',
   reservations: '/admin/reservations',
   magazines: '/admin/magazines',

--- a/apps/admin/src/app/router/routes.test.tsx
+++ b/apps/admin/src/app/router/routes.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { appRoutes } from '@/app/router/routes'
+import { ROUTES } from '@/app/router/path'
+
+interface RouteNode {
+  path?: string
+  children?: RouteNode[]
+}
+
+const collectPaths = (routes: RouteNode[]): string[] =>
+  routes.flatMap((route) => [
+    ...(route.path ? [route.path] : []),
+    ...collectPaths(route.children ?? []),
+  ])
+
+describe('admin routes', () => {
+  it('registers the protected member list route', () => {
+    expect(collectPaths(appRoutes as RouteNode[])).toContain(ROUTES.users)
+  })
+})

--- a/apps/admin/src/app/router/routes.tsx
+++ b/apps/admin/src/app/router/routes.tsx
@@ -10,6 +10,7 @@ import { RouteLoading } from '@/shared/components/RouteLoading'
 const {
   LoginPage,
   DashboardPage,
+  UsersPage,
   RestaurantsPage,
   ReservationsPage,
   MagazinesPage,
@@ -43,6 +44,10 @@ export const appRoutes = [
           {
             path: ROUTES.dashboard,
             element: withSuspense(<DashboardPage />),
+          },
+          {
+            path: ROUTES.users,
+            element: withSuspense(<UsersPage />),
           },
           {
             path: ROUTES.restaurants,

--- a/apps/admin/src/pages/reservations/ReservationsPage.test.tsx
+++ b/apps/admin/src/pages/reservations/ReservationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ReservationsPage } from '@/pages/reservations/ReservationsPage'
@@ -42,6 +42,23 @@ const reservation = {
   userId: 3,
 }
 
+const createReservationsQueryResult = ({
+  isFetching = false,
+}: { isFetching?: boolean } = {}) =>
+  ({
+    data: {
+      page: 0,
+      reservations: [reservation],
+      size: 20,
+      totalCount: 21,
+      totalPages: 2,
+    },
+    isError: false,
+    isFetching,
+    isLoading: false,
+    refetch: vi.fn(),
+  }) as unknown as ReturnType<typeof useReservationsQuery>
+
 describe('ReservationsPage', () => {
   beforeEach(() => {
     mutateMock.mockReset()
@@ -49,19 +66,7 @@ describe('ReservationsPage', () => {
     useReservationUserQueryMock.mockReset()
     useUpdateReservationStatusMutationMock.mockReset()
 
-    useReservationsQueryMock.mockReturnValue({
-      data: {
-        page: 0,
-        reservations: [reservation],
-        size: 20,
-        totalCount: 21,
-        totalPages: 2,
-      },
-      isError: false,
-      isFetching: false,
-      isLoading: false,
-      refetch: vi.fn(),
-    } as unknown as ReturnType<typeof useReservationsQuery>)
+    useReservationsQueryMock.mockReturnValue(createReservationsQueryResult())
     useReservationUserQueryMock.mockReturnValue({
       data: {
         birthDate: '1999-01-01',
@@ -92,13 +97,33 @@ describe('ReservationsPage', () => {
     expect(screen.queryByLabelText('Mock 상태')).not.toBeInTheDocument()
     expect(screen.queryByPlaceholderText(/검색/)).not.toBeInTheDocument()
     expect(screen.queryByLabelText('날짜')).not.toBeInTheDocument()
+    expect(screen.queryByText('1 / 2 페이지')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '1페이지' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
 
-    await user.click(screen.getByRole('button', { name: '다음 페이지' }))
+    await user.click(screen.getByRole('button', { name: '2페이지' }))
 
     expect(useReservationsQueryMock).toHaveBeenLastCalledWith({
       page: 1,
       size: 20,
     })
+  })
+
+  it('announces updates and disables reservation pagination while fetching', () => {
+    useReservationsQueryMock.mockReturnValue(
+      createReservationsQueryResult({ isFetching: true }),
+    )
+
+    render(<ReservationsPage />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('목록 갱신 중')
+    expect(
+      within(screen.getByRole('navigation', { name: '관리자 목록 페이지' }))
+        .getAllByRole('button')
+        .every((button) => button.hasAttribute('disabled')),
+    ).toBe(true)
   })
 
   it('loads the selected reservation user in a drawer', async () => {

--- a/apps/admin/src/pages/reservations/ReservationsPage.tsx
+++ b/apps/admin/src/pages/reservations/ReservationsPage.tsx
@@ -11,6 +11,7 @@ import type {
   ReservationPaymentStatus,
 } from '@/shared/api/reservationViewModel'
 import { ActionButton } from '@/shared/components/ActionButton'
+import { AdminPagination } from '@/shared/components/AdminPagination'
 import { AdminSelect, type SelectOption } from '@/shared/components/AdminSelect'
 import { AdminTable } from '@/shared/components/AdminTable'
 import { AdminToolbar } from '@/shared/components/AdminToolbar'
@@ -141,7 +142,6 @@ export const ReservationsPage = () => {
   const userQuery = useReservationUserQuery(userTargetId)
   const result = reservationsQuery.data
   const reservations = result?.reservations ?? []
-  const currentPage = result?.page ?? page
   const totalPages = result?.totalPages ?? 0
   const conflictCounts = getReservationConflictCounts(reservations)
 
@@ -180,9 +180,11 @@ export const ReservationsPage = () => {
       <div className="px-5 py-5 lg:px-8">
         <div className="text-cool-gray-500 mb-3 flex flex-wrap items-center justify-between gap-2 text-sm">
           <span>총 {(result?.totalCount ?? 0).toLocaleString()}개 예약</span>
-          <span>
-            {totalPages === 0 ? 0 : currentPage + 1} / {totalPages} 페이지
-          </span>
+          {reservationsQuery.isFetching && !reservationsQuery.isLoading ? (
+            <span role="status" className="text-primary-200 font-semibold">
+              목록 갱신 중
+            </span>
+          ) : null}
         </div>
 
         <div className="border-cool-gray-100 overflow-hidden rounded-lg border">
@@ -281,22 +283,12 @@ export const ReservationsPage = () => {
           </AdminTable>
         </div>
 
-        <div className="mt-4 flex justify-end gap-2">
-          <PaginationButton
-            label="이전 페이지"
-            disabled={page === 0 || reservationsQuery.isFetching}
-            onClick={() => setPage((current) => Math.max(0, current - 1))}
-          />
-          <PaginationButton
-            label="다음 페이지"
-            disabled={
-              reservationsQuery.isFetching ||
-              totalPages === 0 ||
-              page + 1 >= totalPages
-            }
-            onClick={() => setPage((current) => current + 1)}
-          />
-        </div>
+        <AdminPagination
+          currentPage={page}
+          totalPages={totalPages}
+          isDisabled={reservationsQuery.isFetching}
+          onPageChange={setPage}
+        />
       </div>
 
       <Drawer
@@ -366,26 +358,6 @@ const PaymentStatusBadge = ({
   >
     {paymentStatusLabel[status]}
   </span>
-)
-
-const PaginationButton = ({
-  label,
-  disabled,
-  onClick,
-}: {
-  label: string
-  disabled: boolean
-  onClick: () => void
-}) => (
-  <button
-    type="button"
-    aria-label={label}
-    disabled={disabled}
-    onClick={onClick}
-    className="border-cool-gray-100 text-cool-gray-700 hover:bg-cool-gray-50 h-9 rounded-md border bg-white px-4 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-40"
-  >
-    {label.replace(' 페이지', '')}
-  </button>
 )
 
 const DrawerLoading = () => (

--- a/apps/admin/src/pages/users/UsersPage.spec.md
+++ b/apps/admin/src/pages/users/UsersPage.spec.md
@@ -1,0 +1,111 @@
+# Page Spec: `UsersPage`
+
+## Purpose
+
+- 관리자가 전체 회원의 기본 정보를 확인합니다.
+- 닉네임 부분 일치 검색과 정렬로 필요한 회원을 찾습니다.
+- 서버의 offset 페이지네이션 결과와 전체 회원 수를 표시합니다.
+
+## Route
+
+| Item        | Value                          |
+| ----------- | ------------------------------ |
+| Path        | `/admin/users`                 |
+| Route key   | `ROUTES.users`                 |
+| Access      | `AdminOnlyRoute`               |
+| Layout      | `AdminLayout`                  |
+| Loading     | `lazyPages.UsersPage` Suspense |
+| Guest entry | `/admin/login` redirect        |
+
+## Requirements
+
+- 기본 정렬은 가입일 최신순(`CREATED_AT`)입니다.
+- 정렬을 닉네임 가나다순(`NICKNAME`)으로 바꾸면 첫 페이지부터 다시 조회합니다.
+- 닉네임 입력이 멈춘 뒤 300ms가 지나면 앞뒤 공백을 제거한 마지막 검색어로 자동 조회하고 첫 페이지로 초기화합니다.
+- 300ms 안에 입력이 이어지면 중간 검색어는 적용하지 않습니다.
+- 공백 검색어는 query에서 생략해 전체 목록을 조회합니다.
+- 페이지 번호는 0부터 시작하고 페이지 크기는 20으로 고정합니다.
+- 표에는 프로필, 닉네임, 영문 이름, 생년월일, 전화번호, 이메일, 가입일을 표시합니다.
+- `nameEng`, `profileImageUrl`이 `null`이면 각각 `-`와 프로필 fallback을 표시합니다.
+- 검색·정렬·페이지 이동 중 기존 데이터를 유지하고 목록 갱신 상태를 알립니다.
+- 숫자 pagination은 현재 페이지를 강조하고 원하는 페이지로 직접 이동합니다.
+- 전체 페이지가 8개 이상이면 첫·마지막 페이지와 현재 페이지 주변을 유지하고 생략 구간을 `…`로 표시합니다.
+- 전체 페이지가 0이면 pagination을 표시하지 않습니다.
+- 이전·다음 화살표는 서버의 `page`, `totalPages` 범위를 넘지 않습니다.
+
+## API Integration Map
+
+### Target
+
+- Page: `UsersPage`
+- Route params: 없음
+- Search params: 없음. 검색·정렬·페이지는 페이지 local state입니다.
+- Required auth: `Authorization: Bearer {token}` (`ROLE_ADMIN`)
+
+### Source Docs
+
+- API spec: HASHI-142 회원 목록 명세
+- Published admin OpenAPI: `/v3/api-docs/admin`
+- OpenAPI status: 2026-07-17 기준 `GET /api/v1/admin/users`가 아직 배포되지 않았습니다.
+
+### Queries
+
+| UI area | Endpoint                  | Params                            | Response data                                       | Query key                    | Mode       | States                                   |
+| ------- | ------------------------- | --------------------------------- | --------------------------------------------------- | ---------------------------- | ---------- | ---------------------------------------- |
+| 회원 표 | `GET /api/v1/admin/users` | `sort`, `keyword`, `page`, `size` | `users`, `page`, `size`, `totalCount`, `totalPages` | `userQueryKeys.list(params)` | `useQuery` | loading, error, empty, success, fetching |
+
+### Mutations
+
+- 없음
+
+### Type Mapping
+
+| API field         | UI use    | Nullable | Transform                          |
+| ----------------- | --------- | -------- | ---------------------------------- |
+| `userId`          | row key   | no       | 없음                               |
+| `nickname`        | 닉네임    | no       | 없음                               |
+| `nameEng`         | 영문 이름 | yes      | `null`이면 `-`                     |
+| `birthDate`       | 생년월일  | no       | ISO date 문자열 그대로 표시        |
+| `phone`           | 전화번호  | no       | 서버 문자열 그대로 표시            |
+| `email`           | 이메일    | no       | 없음                               |
+| `profileImageUrl` | 프로필    | yes      | `null`이면 닉네임 첫 글자 fallback |
+| `createdAt`       | 가입일    | no       | `yyyy-MM-dd HH:mm` 형태로 축약     |
+
+### Missing Questions
+
+- dev admin OpenAPI에 endpoint가 배포되면 page-local 타입을 generated 타입 alias로 교체해야 합니다.
+
+## State
+
+- Local: 입력 중인 검색어, 적용된 검색어, 정렬, 현재 페이지
+- Server: 회원 목록 query 결과
+- Derived: 빈 결과 문구, pagination item과 disabled, background fetching 상태
+
+## Component Mapping
+
+- Admin shared: `PageHeader`, `AdminToolbar`, `AdminSearchInput`, `AdminSelect`, `AdminTable`, `AdminPagination`
+- Page-local: `UserTable`
+- HDS: 없음
+- Icon: sidebar `PeopleIcon`, pagination `BackIcon`, `NextIcon`
+
+## Error And Empty States
+
+- 초기 loading은 `AdminTable` skeleton row를 표시합니다.
+- `400`, `403`, network/server 실패는 table error와 `다시 시도`를 표시합니다.
+- 검색어가 적용된 빈 결과는 `검색 결과가 없습니다`를 표시합니다.
+- 전체 목록이 빈 결과면 `가입한 회원이 없습니다`를 표시합니다.
+- terminal `401`은 공통 auth refresh 실패 처리 후 로그인 페이지로 이동합니다.
+
+## Verification
+
+```bash
+pnpm --filter @hashi/admin lint
+pnpm --filter @hashi/admin typecheck
+pnpm --filter @hashi/admin test
+pnpm --filter @hashi/admin build
+git diff --check
+```
+
+- 직접 URL `/admin/users` 진입과 비로그인 redirect를 확인합니다.
+- 닉네임 입력이 300ms 디바운스된 뒤 마지막 값만 trim되어 전송되고 검색 시 page가 0으로 초기화되는지 확인합니다.
+- loading, error/retry, empty, success, background fetching, 숫자 직접 이동, 첫/마지막 페이지를 확인합니다.

--- a/apps/admin/src/pages/users/UsersPage.test.tsx
+++ b/apps/admin/src/pages/users/UsersPage.test.tsx
@@ -1,0 +1,261 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UsersPage } from '@/pages/users/UsersPage'
+import { useAdminUsersQuery } from '@/pages/users/queries/useAdminUsersQuery'
+
+vi.mock('@/pages/users/queries/useAdminUsersQuery', () => ({
+  useAdminUsersQuery: vi.fn(),
+}))
+
+const useAdminUsersQueryMock = vi.mocked(useAdminUsersQuery)
+const refetchMock = vi.fn()
+
+const userRecord = {
+  userId: 7,
+  nickname: '더미',
+  nameEng: null,
+  birthDate: '1972-03-23',
+  phone: '01076929234',
+  email: 'dummy@hashi.dev',
+  profileImageUrl: null,
+  createdAt: '2026-07-14T18:08:31.114514',
+}
+
+const createQueryResult = ({
+  data = {
+    users: [userRecord],
+    page: 0,
+    size: 20,
+    totalCount: 21,
+    totalPages: 2,
+  },
+  isError = false,
+  isFetching = false,
+  isLoading = false,
+}: {
+  data?: {
+    users: (typeof userRecord)[]
+    page: number
+    size: number
+    totalCount: number
+    totalPages: number
+  }
+  isError?: boolean
+  isFetching?: boolean
+  isLoading?: boolean
+} = {}) =>
+  ({
+    data,
+    isError,
+    isFetching,
+    isLoading,
+    refetch: refetchMock,
+  }) as unknown as ReturnType<typeof useAdminUsersQuery>
+
+describe('UsersPage', () => {
+  beforeEach(() => {
+    refetchMock.mockReset()
+    useAdminUsersQueryMock.mockReset()
+    useAdminUsersQueryMock.mockReturnValue(createQueryResult())
+  })
+
+  it('loads members with the newest-registration sort by default', () => {
+    render(<UsersPage />)
+
+    expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+      sort: 'CREATED_AT',
+      page: 0,
+      size: 20,
+    })
+    expect(
+      screen.getByRole('button', { name: /정렬 기준 가입일 최신순/ }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('더미')).toBeInTheDocument()
+    expect(screen.getByText('dummy@hashi.dev')).toBeInTheDocument()
+    expect(screen.getByText('총 21명')).toBeInTheDocument()
+    expect(screen.queryByText('1 / 2 페이지')).not.toBeInTheDocument()
+  })
+
+  it('debounces nickname input and searches with the last trimmed value', () => {
+    vi.useFakeTimers()
+
+    try {
+      render(<UsersPage />)
+
+      fireEvent.click(screen.getByRole('button', { name: '다음 페이지' }))
+      fireEvent.change(screen.getByPlaceholderText('닉네임 검색'), {
+        target: { value: '  더' },
+      })
+      act(() => vi.advanceTimersByTime(200))
+      fireEvent.change(screen.getByPlaceholderText('닉네임 검색'), {
+        target: { value: '  더미  ' },
+      })
+      act(() => vi.advanceTimersByTime(299))
+
+      expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+        sort: 'CREATED_AT',
+        page: 1,
+        size: 20,
+      })
+
+      act(() => vi.advanceTimersByTime(1))
+
+      expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+        sort: 'CREATED_AT',
+        keyword: '더미',
+        page: 0,
+        size: 20,
+      })
+      expect(
+        screen.queryByRole('button', { name: '검색' }),
+      ).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns to the full member list after clearing the search input', () => {
+    vi.useFakeTimers()
+
+    try {
+      render(<UsersPage />)
+      const input = screen.getByPlaceholderText('닉네임 검색')
+
+      fireEvent.change(input, { target: { value: '더미' } })
+      act(() => vi.advanceTimersByTime(300))
+
+      expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+        sort: 'CREATED_AT',
+        keyword: '더미',
+        page: 0,
+        size: 20,
+      })
+
+      fireEvent.change(input, { target: { value: '' } })
+      act(() => vi.advanceTimersByTime(300))
+
+      expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+        sort: 'CREATED_AT',
+        page: 0,
+        size: 20,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('changes to nickname sorting and resets pagination', async () => {
+    const user = userEvent.setup()
+    render(<UsersPage />)
+
+    await user.click(screen.getByRole('button', { name: '다음 페이지' }))
+    await user.click(
+      screen.getByRole('button', { name: /정렬 기준 가입일 최신순/ }),
+    )
+    await user.click(
+      await screen.findByRole('option', { name: '닉네임 가나다순' }),
+    )
+
+    expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+      sort: 'NICKNAME',
+      page: 0,
+      size: 20,
+    })
+  })
+
+  it('renders nullable profile fields with visible fallbacks', () => {
+    render(<UsersPage />)
+
+    expect(screen.getByText('-')).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: '더미 프로필 이미지 없음' }),
+    ).toHaveTextContent('더')
+    expect(screen.getByText('2026-07-14 18:08')).toBeInTheDocument()
+  })
+
+  it('describes an empty nickname result', () => {
+    vi.useFakeTimers()
+    useAdminUsersQueryMock.mockImplementation((params) =>
+      createQueryResult({
+        data: {
+          users: params.keyword ? [] : [userRecord],
+          page: 0,
+          size: 20,
+          totalCount: params.keyword ? 0 : 1,
+          totalPages: params.keyword ? 0 : 1,
+        },
+      }),
+    )
+
+    try {
+      render(<UsersPage />)
+
+      fireEvent.change(screen.getByPlaceholderText('닉네임 검색'), {
+        target: { value: '없는회원' },
+      })
+      act(() => vi.advanceTimersByTime(300))
+
+      expect(screen.getByText('검색 결과가 없습니다')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('offers retry after a list error', async () => {
+    const user = userEvent.setup()
+    useAdminUsersQueryMock.mockReturnValue(createQueryResult({ isError: true }))
+    render(<UsersPage />)
+
+    await user.click(screen.getByRole('button', { name: '다시 시도' }))
+
+    expect(refetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('announces background list updates', () => {
+    useAdminUsersQueryMock.mockReturnValue(
+      createQueryResult({ isFetching: true }),
+    )
+    render(<UsersPage />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('목록 갱신 중')
+  })
+
+  it('moves directly by page number and disables navigation at boundaries', async () => {
+    const user = userEvent.setup()
+    useAdminUsersQueryMock.mockImplementation((params) =>
+      createQueryResult({
+        data: {
+          users: [userRecord],
+          page: params.page,
+          size: 20,
+          totalCount: 21,
+          totalPages: 2,
+        },
+      }),
+    )
+    render(<UsersPage />)
+
+    expect(screen.getByRole('button', { name: '이전 페이지' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '1페이지' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+
+    await user.click(screen.getByRole('button', { name: '2페이지' }))
+
+    expect(useAdminUsersQueryMock).toHaveBeenLastCalledWith({
+      sort: 'CREATED_AT',
+      page: 1,
+      size: 20,
+    })
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: '2페이지' })).toHaveAttribute(
+        'aria-current',
+        'page',
+      ),
+    )
+    expect(screen.getByRole('button', { name: '다음 페이지' })).toBeDisabled()
+  })
+})

--- a/apps/admin/src/pages/users/UsersPage.tsx
+++ b/apps/admin/src/pages/users/UsersPage.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { AdminUserSort } from '@/pages/users/api/getAdminUsers'
+import { UserTable } from '@/pages/users/components/UserTable'
+import { useAdminUsersQuery } from '@/pages/users/queries/useAdminUsersQuery'
+import { AdminSearchInput } from '@/shared/components/AdminSearchInput'
+import { AdminPagination } from '@/shared/components/AdminPagination'
+import { AdminSelect } from '@/shared/components/AdminSelect'
+import { AdminToolbar } from '@/shared/components/AdminToolbar'
+import { PageHeader } from '@/shared/components/PageHeader'
+
+const PAGE_SIZE = 20
+const SEARCH_DEBOUNCE_MS = 300
+
+const sortOptions = [
+  { value: 'NICKNAME', label: '닉네임 가나다순' },
+  { value: 'CREATED_AT', label: '가입일 최신순' },
+] satisfies { value: AdminUserSort; label: string }[]
+
+export const UsersPage = () => {
+  const [draftKeyword, setDraftKeyword] = useState('')
+  const [keyword, setKeyword] = useState('')
+  const [sort, setSort] = useState<AdminUserSort>('CREATED_AT')
+  const [page, setPage] = useState(0)
+
+  useEffect(() => {
+    const timerId = window.setTimeout(() => {
+      setKeyword(draftKeyword.trim())
+      setPage(0)
+    }, SEARCH_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timerId)
+  }, [draftKeyword])
+
+  const queryParams = useMemo(
+    () => ({
+      sort,
+      ...(keyword ? { keyword } : {}),
+      page,
+      size: PAGE_SIZE,
+    }),
+    [keyword, page, sort],
+  )
+  const usersQuery = useAdminUsersQuery(queryParams)
+  const result = usersQuery.data
+  const users = result?.users ?? []
+  const totalPages = result?.totalPages ?? 0
+  const hasKeyword = keyword.length > 0
+
+  const handleSortChange = (nextSort: AdminUserSort) => {
+    setSort(nextSort)
+    setPage(0)
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="회원 관리"
+        description="가입한 회원을 검색하고 기본 정보를 확인합니다."
+      />
+
+      <AdminToolbar>
+        <div className="flex min-w-0 flex-1 items-end gap-2">
+          <AdminSearchInput
+            value={draftKeyword}
+            placeholder="닉네임 검색"
+            onChange={setDraftKeyword}
+          />
+        </div>
+        <AdminSelect
+          label="정렬 기준"
+          value={sort}
+          options={sortOptions}
+          onChange={handleSortChange}
+          className="xl:w-52"
+        />
+      </AdminToolbar>
+
+      <section className="px-5 py-5 lg:px-8">
+        <div className="text-cool-gray-500 mb-3 flex min-h-5 flex-wrap items-center justify-between gap-2 text-sm">
+          <span>총 {(result?.totalCount ?? 0).toLocaleString()}명</span>
+          {usersQuery.isFetching && !usersQuery.isLoading ? (
+            <span role="status" className="text-primary-200 font-semibold">
+              목록 갱신 중
+            </span>
+          ) : null}
+        </div>
+
+        <UserTable
+          users={users}
+          isLoading={usersQuery.isLoading}
+          isError={usersQuery.isError}
+          emptyTitle={
+            hasKeyword ? '검색 결과가 없습니다' : '가입한 회원이 없습니다'
+          }
+          emptyDescription={
+            hasKeyword
+              ? '다른 닉네임으로 다시 검색해주세요.'
+              : '회원이 가입하면 이곳에 표시됩니다.'
+          }
+          onRetry={() => void usersQuery.refetch()}
+        />
+
+        <AdminPagination
+          currentPage={page}
+          totalPages={totalPages}
+          isDisabled={usersQuery.isFetching}
+          onPageChange={setPage}
+        />
+      </section>
+    </>
+  )
+}

--- a/apps/admin/src/pages/users/api/getAdminUsers.test.ts
+++ b/apps/admin/src/pages/users/api/getAdminUsers.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAdminUsers } from '@/pages/users/api/getAdminUsers'
+import { request } from '@/shared/api/request'
+
+vi.mock('@/shared/api/request', () => ({
+  request: vi.fn(),
+}))
+
+const requestMock = vi.mocked(request)
+
+describe('getAdminUsers', () => {
+  beforeEach(() => {
+    requestMock.mockReset()
+    requestMock.mockResolvedValue({
+      page: 0,
+      size: 20,
+      totalCount: 0,
+      totalPages: 0,
+      users: [],
+    })
+  })
+
+  it('requests the member list with every response-changing parameter', async () => {
+    await getAdminUsers({
+      sort: 'CREATED_AT',
+      keyword: '더미',
+      page: 2,
+      size: 20,
+    })
+
+    expect(requestMock).toHaveBeenCalledWith('/api/v1/admin/users', {
+      searchParams: {
+        sort: 'CREATED_AT',
+        keyword: '더미',
+        page: 2,
+        size: 20,
+      },
+    })
+  })
+
+  it('trims a nickname keyword', async () => {
+    await getAdminUsers({
+      sort: 'NICKNAME',
+      keyword: '  더미  ',
+      page: 0,
+      size: 20,
+    })
+
+    expect(requestMock).toHaveBeenCalledWith('/api/v1/admin/users', {
+      searchParams: {
+        sort: 'NICKNAME',
+        keyword: '더미',
+        page: 0,
+        size: 20,
+      },
+    })
+  })
+
+  it('omits a blank nickname keyword', async () => {
+    await getAdminUsers({
+      sort: 'NICKNAME',
+      keyword: '   ',
+      page: 0,
+      size: 20,
+    })
+
+    expect(requestMock).toHaveBeenCalledWith('/api/v1/admin/users', {
+      searchParams: {
+        sort: 'NICKNAME',
+        page: 0,
+        size: 20,
+      },
+    })
+  })
+})

--- a/apps/admin/src/pages/users/api/getAdminUsers.ts
+++ b/apps/admin/src/pages/users/api/getAdminUsers.ts
@@ -1,0 +1,42 @@
+import { request } from '@/shared/api/request'
+
+export type AdminUserSort = 'NICKNAME' | 'CREATED_AT'
+
+export interface ListAdminUsersQuery {
+  sort: AdminUserSort
+  keyword?: string
+  page: number
+  size: number
+}
+
+export interface AdminUser {
+  userId: number
+  nickname: string
+  nameEng: string | null
+  birthDate: string
+  phone: string
+  email: string
+  profileImageUrl: string | null
+  createdAt: string
+}
+
+export interface AdminUserListData {
+  users: AdminUser[]
+  page: number
+  size: number
+  totalCount: number
+  totalPages: number
+}
+
+export const getAdminUsers = (params: ListAdminUsersQuery) => {
+  const keyword = params.keyword?.trim()
+
+  return request<AdminUserListData>('/api/v1/admin/users', {
+    searchParams: {
+      sort: params.sort,
+      ...(keyword ? { keyword } : {}),
+      page: params.page,
+      size: params.size,
+    },
+  })
+}

--- a/apps/admin/src/pages/users/components/UserTable.tsx
+++ b/apps/admin/src/pages/users/components/UserTable.tsx
@@ -1,0 +1,93 @@
+import type { AdminUser } from '@/pages/users/api/getAdminUsers'
+import {
+  AdminTable,
+  type AdminTableColumn,
+} from '@/shared/components/AdminTable'
+
+const tableColumns: AdminTableColumn[] = [
+  { key: 'profile', label: '프로필', className: 'w-20' },
+  { key: 'nickname', label: '닉네임', className: 'w-36' },
+  { key: 'nameEng', label: '영문 이름', className: 'w-36' },
+  { key: 'birthDate', label: '생년월일', className: 'w-32' },
+  { key: 'phone', label: '전화번호', className: 'w-36' },
+  { key: 'email', label: '이메일', className: 'w-64' },
+  { key: 'createdAt', label: '가입일', className: 'w-44' },
+]
+
+interface UserTableProps {
+  users: AdminUser[]
+  isLoading: boolean
+  isError: boolean
+  emptyTitle: string
+  emptyDescription: string
+  onRetry: () => void
+}
+
+const formatCreatedAt = (value: string) =>
+  value ? value.replace('T', ' ').slice(0, 16) : '-'
+
+export const UserTable = ({
+  users,
+  isLoading,
+  isError,
+  emptyTitle,
+  emptyDescription,
+  onRetry,
+}: UserTableProps) => {
+  return (
+    <div className="border-cool-gray-100 overflow-hidden rounded-lg border">
+      <AdminTable
+        columns={tableColumns}
+        tableClassName="w-full min-w-[72rem]"
+        isLoading={isLoading}
+        isError={isError}
+        isEmpty={users.length === 0}
+        emptyTitle={emptyTitle}
+        emptyDescription={emptyDescription}
+        onRetry={onRetry}
+      >
+        {users.map((user) => (
+          <tr key={user.userId} className="hover:bg-cool-gray-50">
+            <td className="px-3 py-3">
+              {user.profileImageUrl ? (
+                <img
+                  src={user.profileImageUrl}
+                  alt={`${user.nickname} 프로필`}
+                  className="bg-cool-gray-100 size-10 rounded-full object-cover"
+                />
+              ) : (
+                <span
+                  role="img"
+                  aria-label={`${user.nickname} 프로필 이미지 없음`}
+                  className="bg-primary-100 text-primary-200 flex size-10 items-center justify-center rounded-full text-sm font-extrabold"
+                >
+                  {user.nickname.slice(0, 1)}
+                </span>
+              )}
+            </td>
+            <td className="text-cool-gray-900 px-3 py-3 text-sm font-bold whitespace-nowrap">
+              {user.nickname}
+            </td>
+            <td className="text-cool-gray-600 px-3 py-3 text-sm whitespace-nowrap">
+              {user.nameEng ?? '-'}
+            </td>
+            <td className="text-cool-gray-600 px-3 py-3 text-sm whitespace-nowrap">
+              {user.birthDate}
+            </td>
+            <td className="text-cool-gray-600 px-3 py-3 text-sm whitespace-nowrap">
+              {user.phone}
+            </td>
+            <td className="text-cool-gray-700 px-3 py-3 text-sm">
+              <span className="block truncate" title={user.email}>
+                {user.email}
+              </span>
+            </td>
+            <td className="text-cool-gray-600 px-3 py-3 text-sm whitespace-nowrap">
+              {formatCreatedAt(user.createdAt)}
+            </td>
+          </tr>
+        ))}
+      </AdminTable>
+    </div>
+  )
+}

--- a/apps/admin/src/pages/users/queries/useAdminUsersQuery.test.tsx
+++ b/apps/admin/src/pages/users/queries/useAdminUsersQuery.test.tsx
@@ -1,0 +1,45 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAdminUsers } from '@/pages/users/api/getAdminUsers'
+import { useAdminUsersQuery } from '@/pages/users/queries/useAdminUsersQuery'
+
+vi.mock('@/pages/users/api/getAdminUsers', () => ({
+  getAdminUsers: vi.fn(),
+}))
+
+const getAdminUsersMock = vi.mocked(getAdminUsers)
+
+describe('useAdminUsersQuery', () => {
+  beforeEach(() => {
+    getAdminUsersMock.mockReset()
+    getAdminUsersMock.mockResolvedValue({
+      page: 0,
+      size: 20,
+      totalCount: 0,
+      totalPages: 0,
+      users: [],
+    })
+  })
+
+  it('fetches the list with the supplied parameters', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const params = {
+      sort: 'NICKNAME' as const,
+      keyword: '더미',
+      page: 0,
+      size: 20,
+    }
+    const { result } = renderHook(() => useAdminUsersQuery(params), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(getAdminUsersMock).toHaveBeenCalledWith(params)
+  })
+})

--- a/apps/admin/src/pages/users/queries/useAdminUsersQuery.ts
+++ b/apps/admin/src/pages/users/queries/useAdminUsersQuery.ts
@@ -1,0 +1,13 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import {
+  getAdminUsers,
+  type ListAdminUsersQuery,
+} from '@/pages/users/api/getAdminUsers'
+import { userQueryKeys } from '@/pages/users/queries/userQueryKeys'
+
+export const useAdminUsersQuery = (params: ListAdminUsersQuery) =>
+  useQuery({
+    placeholderData: keepPreviousData,
+    queryFn: () => getAdminUsers(params),
+    queryKey: userQueryKeys.list(params),
+  })

--- a/apps/admin/src/pages/users/queries/userQueryKeys.test.ts
+++ b/apps/admin/src/pages/users/queries/userQueryKeys.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { userQueryKeys } from '@/pages/users/queries/userQueryKeys'
+
+describe('userQueryKeys', () => {
+  it('includes every member list parameter', () => {
+    const params = {
+      sort: 'CREATED_AT' as const,
+      keyword: '더미',
+      page: 2,
+      size: 20,
+    }
+
+    expect(userQueryKeys.list(params)).toEqual([
+      'admin',
+      'users',
+      'list',
+      params,
+    ])
+  })
+
+  it('provides a stable member-list prefix', () => {
+    expect(userQueryKeys.lists()).toEqual(['admin', 'users', 'list'])
+  })
+})

--- a/apps/admin/src/pages/users/queries/userQueryKeys.ts
+++ b/apps/admin/src/pages/users/queries/userQueryKeys.ts
@@ -1,0 +1,8 @@
+import type { ListAdminUsersQuery } from '@/pages/users/api/getAdminUsers'
+
+export const userQueryKeys = {
+  all: ['admin', 'users'] as const,
+  lists: () => [...userQueryKeys.all, 'list'] as const,
+  list: (params: ListAdminUsersQuery) =>
+    [...userQueryKeys.lists(), params] as const,
+}

--- a/apps/admin/src/shared/api/apiResponse.ts
+++ b/apps/admin/src/shared/api/apiResponse.ts
@@ -1,0 +1,51 @@
+export interface AdminFieldError {
+  field: string
+  rejectedValue: unknown
+  reason: string
+}
+
+export interface AdminApiSuccessResponse<TData> {
+  success: true
+  code: string
+  message: string
+  data: TData
+}
+
+export interface AdminApiErrorResponse {
+  success: false
+  code: string
+  message: string
+  data: null
+  timestamp: string
+  path: string
+  errors?: AdminFieldError[]
+}
+
+export type AdminApiResponse<TData> =
+  | AdminApiSuccessResponse<TData>
+  | AdminApiErrorResponse
+
+export class AdminApiRequestError extends Error {
+  status: number
+  responseBody: AdminApiErrorResponse | null
+
+  constructor(status: number, responseBody: AdminApiErrorResponse | null) {
+    super(responseBody?.message ?? `HTTP ${status}`)
+    this.name = 'AdminApiRequestError'
+    this.status = status
+    this.responseBody = responseBody
+  }
+}
+
+export const parseAdminApiResponse = async <TData>(response: Response) => {
+  const responseBody = (await response.json()) as AdminApiResponse<TData>
+
+  if (!response.ok || !responseBody.success) {
+    throw new AdminApiRequestError(
+      response.status,
+      responseBody.success ? null : responseBody,
+    )
+  }
+
+  return responseBody.data
+}

--- a/apps/admin/src/shared/api/authApi.test.ts
+++ b/apps/admin/src/shared/api/authApi.test.ts
@@ -85,4 +85,15 @@ describe('authApi', () => {
       credentials: 'include',
     })
   })
+
+  it('returns the reissued access token', async () => {
+    postMock.mockResolvedValue(
+      createResponse({ authorization: 'Bearer renewed-admin-token' }),
+    )
+
+    await expect(authApi.reissue()).resolves.toBe('renewed-admin-token')
+    expect(postMock).toHaveBeenCalledWith('api/v1/auth/reissue', {
+      credentials: 'include',
+    })
+  })
 })

--- a/apps/admin/src/shared/api/authApi.ts
+++ b/apps/admin/src/shared/api/authApi.ts
@@ -1,26 +1,15 @@
 import type { components } from '@/shared/api/generated/openapi'
+import type { paths as UserApiPaths } from '@/shared/api/generated/user-openapi'
 import { apiClient } from '@/shared/api/apiClient'
-import {
-  AdminApiRequestError,
-  type AdminApiResponse,
-} from '@/shared/api/request'
+import { parseAdminApiResponse } from '@/shared/api/apiResponse'
 import type { AdminSession } from '@/shared/auth/adminSession'
 
 export type AdminLoginBody = components['schemas']['AdminLoginRequest']
 
 const LOGIN_PATH = 'api/v1/auth/admin/login'
 const LOGOUT_PATH = 'api/v1/auth/admin/logout'
-
-const parseResponse = async (response: Response) => {
-  const responseBody = (await response.json()) as AdminApiResponse<unknown>
-
-  if (!response.ok || !responseBody.success) {
-    throw new AdminApiRequestError(
-      response.status,
-      responseBody.success ? null : responseBody,
-    )
-  }
-}
+const REISSUE_OPENAPI_PATH = '/api/v1/auth/reissue' satisfies keyof UserApiPaths
+const REISSUE_PATH = REISSUE_OPENAPI_PATH.replace(/^\/+/, '')
 
 const getAccessToken = (response: Response) => {
   const authorization = response.headers.get('Authorization')?.trim()
@@ -40,7 +29,7 @@ export const authApi = {
       json: body,
     })
 
-    await parseResponse(response)
+    await parseAdminApiResponse<unknown>(response)
 
     return {
       accessToken: getAccessToken(response),
@@ -53,6 +42,15 @@ export const authApi = {
       credentials: 'include',
     })
 
-    await parseResponse(response)
+    await parseAdminApiResponse<unknown>(response)
+  },
+  async reissue() {
+    const response = await apiClient.post(REISSUE_PATH, {
+      credentials: 'include',
+    })
+
+    await parseAdminApiResponse<unknown>(response)
+
+    return getAccessToken(response)
   },
 }

--- a/apps/admin/src/shared/api/generated/openapi.ts
+++ b/apps/admin/src/shared/api/generated/openapi.ts
@@ -216,7 +216,10 @@ export interface components {
        */
       password: string
     }
-    /** @description 요일별 영업시간 — 휴무일(closed=true)은 시간 없이 보내고, 영업일은 openTime·closeTime이 필수다. */
+    /**
+     * @description 요일별 영업시간 — 휴무일(closed=true)은 시간 없이 보내고, 영업일은 openTime·closeTime이 필수다.
+     *      마감 시각이 오픈 시각보다 이르면 익일 마감(자정 넘김), 같으면 24시간 영업으로 해석한다.
+     */
     BusinessHourRequest: {
       /**
        * @description 요일
@@ -237,7 +240,7 @@ export interface components {
        */
       openTime?: string
       /**
-       * @description 마감 시각(HH:mm)
+       * @description 마감 시각(HH:mm) — 오픈 시각보다 이르면 익일 마감, 같으면 24시간 영업
        * @example 22:00
        */
       closeTime?: string
@@ -259,7 +262,7 @@ export interface components {
     }
     /**
      * @description 어드민 식당 등록 요청. imageKeys·메뉴 imageKey는 presigned URL로 업로드 완료된 S3 object key다.
-     *      genre·foodCategory·curationTypes는 사용자 API와 같은 소문자 케밥 값이다.
+     *      genre·curationTypes는 사용자 API와 같은 소문자 케밥 값이고, foodCategory는 카드 표시용 자유 텍스트다(#145).
      *      businessHours는 7개 요일(MONDAY~SUNDAY)을 중복 없이 모두 포함해야 한다(시간은 "HH:mm").
      */
     CreateRestaurantRequest: {
@@ -299,8 +302,8 @@ export interface components {
        */
       genre: string
       /**
-       * @description 음식 카테고리(소문자 케밥)
-       * @example sushi
+       * @description 음식 카테고리(카드 표시용 자유 텍스트)
+       * @example 야키니쿠
        */
       foodCategory: string
       /**
@@ -569,8 +572,8 @@ export interface components {
        */
       genre?: string
       /**
-       * @description 음식 카테고리(소문자 케밥, 선택)
-       * @example sushi
+       * @description 음식 카테고리(카드 표시용 자유 텍스트, 선택, 공백 불가)
+       * @example 야키니쿠
        */
       foodCategory?: string
       /**
@@ -1009,6 +1012,15 @@ export interface operations {
       }
       /** @description 에러 응답 */
       403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description 에러 응답 */
+      404: {
         headers: {
           [name: string]: unknown
         }

--- a/apps/admin/src/shared/api/request.test.ts
+++ b/apps/admin/src/shared/api/request.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiClient } from '@/shared/api/apiClient'
+import { request } from '@/shared/api/request'
+import {
+  clearAdminSession,
+  getAdminSession,
+  setAdminSession,
+} from '@/shared/auth/adminSession'
+import { reissueAdminSession } from '@/shared/auth/reissueAdminSession'
+
+vi.mock('@/shared/api/apiClient', () => ({
+  apiClient: vi.fn(),
+}))
+
+vi.mock('@/shared/auth/reissueAdminSession', () => ({
+  reissueAdminSession: vi.fn(),
+}))
+
+const apiClientMock = vi.mocked(apiClient)
+const reissueAdminSessionMock = vi.mocked(reissueAdminSession)
+
+const createResponse = ({
+  status,
+  success,
+  data = null,
+}: {
+  status: number
+  success: boolean
+  data?: unknown
+}) =>
+  new Response(
+    JSON.stringify({
+      success,
+      code: success ? 'COMMON-200' : `COMMON-${status}`,
+      message: success ? '요청에 성공했습니다' : '인증이 필요합니다',
+      data,
+      timestamp: '2026-07-17T16:30:00.123',
+      path: '/api/v1/admin/users',
+    }),
+    { status },
+  )
+
+describe('admin request auth recovery', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    apiClientMock.mockReset()
+    reissueAdminSessionMock.mockReset()
+    reissueAdminSessionMock.mockResolvedValue()
+    setAdminSession({
+      accessToken: 'expired-token',
+      issuedAt: '2026-07-17T00:00:00Z',
+      loginId: 'hashi-admin',
+    })
+  })
+
+  it('reissues and replays one unauthorized request', async () => {
+    apiClientMock
+      .mockResolvedValueOnce(createResponse({ status: 401, success: false }))
+      .mockResolvedValueOnce(
+        createResponse({
+          status: 200,
+          success: true,
+          data: { users: [] },
+        }),
+      )
+
+    await expect(request('/api/v1/admin/users')).resolves.toEqual({ users: [] })
+
+    expect(reissueAdminSessionMock).toHaveBeenCalledOnce()
+    expect(apiClientMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the session when token reissue fails', async () => {
+    apiClientMock.mockResolvedValueOnce(
+      createResponse({ status: 401, success: false }),
+    )
+    reissueAdminSessionMock.mockRejectedValue(new Error('refresh failed'))
+
+    await expect(request('/api/v1/admin/users')).rejects.toThrow(
+      'refresh failed',
+    )
+
+    expect(getAdminSession()).toBeNull()
+  })
+
+  it('clears the session when the replay is still unauthorized', async () => {
+    apiClientMock
+      .mockResolvedValueOnce(createResponse({ status: 401, success: false }))
+      .mockResolvedValueOnce(createResponse({ status: 401, success: false }))
+
+    await expect(request('/api/v1/admin/users')).rejects.toMatchObject({
+      status: 401,
+    })
+
+    expect(reissueAdminSessionMock).toHaveBeenCalledOnce()
+    expect(getAdminSession()).toBeNull()
+  })
+
+  it('does not reissue forbidden requests', async () => {
+    apiClientMock.mockResolvedValueOnce(
+      createResponse({ status: 403, success: false }),
+    )
+
+    await expect(request('/api/v1/admin/users')).rejects.toMatchObject({
+      status: 403,
+    })
+
+    expect(reissueAdminSessionMock).not.toHaveBeenCalled()
+    expect(getAdminSession()).not.toBeNull()
+  })
+
+  it('does not recursively reissue an auth endpoint', async () => {
+    apiClientMock.mockResolvedValueOnce(
+      createResponse({ status: 401, success: false }),
+    )
+
+    await expect(request('/api/v1/auth/reissue')).rejects.toMatchObject({
+      status: 401,
+    })
+
+    expect(reissueAdminSessionMock).not.toHaveBeenCalled()
+  })
+
+  afterEach(() => {
+    clearAdminSession()
+  })
+})

--- a/apps/admin/src/shared/api/request.test.ts
+++ b/apps/admin/src/shared/api/request.test.ts
@@ -83,6 +83,27 @@ describe('admin request auth recovery', () => {
     expect(getAdminSession()).toBeNull()
   })
 
+  it('keeps a newer session when reissue fails after another admin signs in', async () => {
+    const newerSession = {
+      accessToken: 'newer-token',
+      issuedAt: '2026-07-21T00:00:00Z',
+      loginId: 'new-admin',
+    }
+    apiClientMock.mockResolvedValueOnce(
+      createResponse({ status: 401, success: false }),
+    )
+    reissueAdminSessionMock.mockImplementation(async () => {
+      setAdminSession(newerSession)
+      throw new Error('세션이 변경되었습니다.')
+    })
+
+    await expect(request('/api/v1/admin/users')).rejects.toThrow(
+      '세션이 변경되었습니다.',
+    )
+
+    expect(getAdminSession()).toEqual(newerSession)
+  })
+
   it('clears the session when the replay is still unauthorized', async () => {
     apiClientMock
       .mockResolvedValueOnce(createResponse({ status: 401, success: false }))
@@ -94,6 +115,28 @@ describe('admin request auth recovery', () => {
 
     expect(reissueAdminSessionMock).toHaveBeenCalledOnce()
     expect(getAdminSession()).toBeNull()
+  })
+
+  it('keeps a newer session when the replay is still unauthorized', async () => {
+    const newerSession = {
+      accessToken: 'newer-token',
+      issuedAt: '2026-07-21T00:00:00Z',
+      loginId: 'new-admin',
+    }
+    apiClientMock
+      .mockResolvedValueOnce(createResponse({ status: 401, success: false }))
+      .mockImplementationOnce(() => {
+        setAdminSession(newerSession)
+        return Promise.resolve(
+          createResponse({ status: 401, success: false }),
+        ) as ReturnType<typeof apiClient>
+      })
+
+    await expect(request('/api/v1/admin/users')).rejects.toMatchObject({
+      status: 401,
+    })
+
+    expect(getAdminSession()).toEqual(newerSession)
   })
 
   it('does not reissue forbidden requests', async () => {

--- a/apps/admin/src/shared/api/request.ts
+++ b/apps/admin/src/shared/api/request.ts
@@ -1,60 +1,38 @@
 import type { Options } from 'ky'
 import { apiClient } from '@/shared/api/apiClient'
+import { parseAdminApiResponse } from '@/shared/api/apiResponse'
+import { clearAdminSession, getAdminSession } from '@/shared/auth/adminSession'
+import { reissueAdminSession } from '@/shared/auth/reissueAdminSession'
 
-export interface AdminFieldError {
-  field: string
-  rejectedValue: unknown
-  reason: string
-}
-
-export interface AdminApiSuccessResponse<TData> {
-  success: true
-  code: string
-  message: string
-  data: TData
-}
-
-export interface AdminApiErrorResponse {
-  success: false
-  code: string
-  message: string
-  data: null
-  timestamp: string
-  path: string
-  errors?: AdminFieldError[]
-}
-
-export type AdminApiResponse<TData> =
-  | AdminApiSuccessResponse<TData>
-  | AdminApiErrorResponse
+export { AdminApiRequestError } from '@/shared/api/apiResponse'
 
 const normalizePath = (path: string) => path.replace(/^\/+/, '')
-
-export class AdminApiRequestError extends Error {
-  status: number
-  responseBody: AdminApiErrorResponse | null
-
-  constructor(status: number, responseBody: AdminApiErrorResponse | null) {
-    super(responseBody?.message ?? `HTTP ${status}`)
-    this.name = 'AdminApiRequestError'
-    this.status = status
-    this.responseBody = responseBody
-  }
-}
+const checkIsAuthPath = (path: string) => path.startsWith('api/v1/auth/')
 
 export const request = async <TData>(
   path: string,
   options?: Options,
 ): Promise<TData> => {
-  const response = await apiClient(normalizePath(path), options)
-  const responseBody = await response.json<AdminApiResponse<TData>>()
+  const normalizedPath = normalizePath(path)
+  let response = await apiClient(normalizedPath, options)
 
-  if (!response.ok || !responseBody.success) {
-    throw new AdminApiRequestError(
-      response.status,
-      responseBody.success ? null : responseBody,
-    )
+  if (
+    response.status === 401 &&
+    getAdminSession() &&
+    !checkIsAuthPath(normalizedPath)
+  ) {
+    try {
+      await reissueAdminSession()
+      response = await apiClient(normalizedPath, options)
+    } catch (error) {
+      clearAdminSession()
+      throw error
+    }
   }
 
-  return responseBody.data
+  if (response.status === 401) {
+    clearAdminSession()
+  }
+
+  return parseAdminApiResponse<TData>(response)
 }

--- a/apps/admin/src/shared/api/request.ts
+++ b/apps/admin/src/shared/api/request.ts
@@ -1,7 +1,11 @@
 import type { Options } from 'ky'
 import { apiClient } from '@/shared/api/apiClient'
 import { parseAdminApiResponse } from '@/shared/api/apiResponse'
-import { clearAdminSession, getAdminSession } from '@/shared/auth/adminSession'
+import {
+  checkIsSameAdminSession,
+  clearAdminSession,
+  getAdminSession,
+} from '@/shared/auth/adminSession'
 import { reissueAdminSession } from '@/shared/auth/reissueAdminSession'
 
 export { AdminApiRequestError } from '@/shared/api/apiResponse'
@@ -14,23 +18,30 @@ export const request = async <TData>(
   options?: Options,
 ): Promise<TData> => {
   const normalizedPath = normalizePath(path)
+  let sessionToClear = getAdminSession()
   let response = await apiClient(normalizedPath, options)
 
   if (
     response.status === 401 &&
-    getAdminSession() &&
+    sessionToClear &&
     !checkIsAuthPath(normalizedPath)
   ) {
     try {
       await reissueAdminSession()
+      sessionToClear = getAdminSession()
       response = await apiClient(normalizedPath, options)
     } catch (error) {
-      clearAdminSession()
+      if (checkIsSameAdminSession(getAdminSession(), sessionToClear)) {
+        clearAdminSession()
+      }
       throw error
     }
   }
 
-  if (response.status === 401) {
+  if (
+    response.status === 401 &&
+    checkIsSameAdminSession(getAdminSession(), sessionToClear)
+  ) {
     clearAdminSession()
   }
 

--- a/apps/admin/src/shared/auth/adminSession.ts
+++ b/apps/admin/src/shared/auth/adminSession.ts
@@ -7,6 +7,14 @@ export interface AdminSession {
   issuedAt: string
 }
 
+export const checkIsSameAdminSession = (
+  first: AdminSession | null,
+  second: AdminSession | null,
+) =>
+  first?.accessToken === second?.accessToken &&
+  first?.loginId === second?.loginId &&
+  first?.issuedAt === second?.issuedAt
+
 const checkIsAdminSession = (value: unknown): value is AdminSession => {
   if (!value || typeof value !== 'object') {
     return false

--- a/apps/admin/src/shared/auth/adminSession.ts
+++ b/apps/admin/src/shared/auth/adminSession.ts
@@ -1,4 +1,5 @@
 const ADMIN_SESSION_STORAGE_KEY = 'hashi.admin.session.v1'
+const sessionListeners = new Set<() => void>()
 
 export interface AdminSession {
   accessToken: string
@@ -47,10 +48,31 @@ export const setAdminSession = (session: AdminSession) => {
     ADMIN_SESSION_STORAGE_KEY,
     JSON.stringify(session),
   )
+  sessionListeners.forEach((listener) => listener())
 }
 
 export const clearAdminSession = () => {
   window.localStorage.removeItem(ADMIN_SESSION_STORAGE_KEY)
+  sessionListeners.forEach((listener) => listener())
 }
 
 export const getAdminAccessToken = () => getAdminSession()?.accessToken ?? null
+
+export const getAdminSessionSnapshot = () =>
+  window.localStorage.getItem(ADMIN_SESSION_STORAGE_KEY)
+
+export const subscribeAdminSession = (listener: () => void) => {
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === ADMIN_SESSION_STORAGE_KEY) {
+      listener()
+    }
+  }
+
+  sessionListeners.add(listener)
+  window.addEventListener('storage', handleStorage)
+
+  return () => {
+    sessionListeners.delete(listener)
+    window.removeEventListener('storage', handleStorage)
+  }
+}

--- a/apps/admin/src/shared/auth/reissueAdminSession.test.ts
+++ b/apps/admin/src/shared/auth/reissueAdminSession.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { authApi } from '@/shared/api/authApi'
+import {
+  clearAdminSession,
+  getAdminSession,
+  setAdminSession,
+} from '@/shared/auth/adminSession'
+import { reissueAdminSession } from '@/shared/auth/reissueAdminSession'
+
+vi.mock('@/shared/api/authApi', () => ({
+  authApi: {
+    reissue: vi.fn(),
+  },
+}))
+
+const reissueMock = vi.mocked(authApi.reissue)
+
+describe('reissueAdminSession', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    reissueMock.mockReset()
+    setAdminSession({
+      accessToken: 'expired-token',
+      issuedAt: '2026-07-17T00:00:00Z',
+      loginId: 'hashi-admin',
+    })
+  })
+
+  it('shares one in-flight reissue and preserves the admin identity', async () => {
+    let resolveReissue: (accessToken: string) => void = () => undefined
+    reissueMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReissue = resolve
+      }),
+    )
+
+    const firstReissue = reissueAdminSession()
+    const secondReissue = reissueAdminSession()
+
+    expect(firstReissue).toBe(secondReissue)
+    expect(reissueMock).toHaveBeenCalledOnce()
+
+    resolveReissue('renewed-token')
+    await Promise.all([firstReissue, secondReissue])
+
+    expect(getAdminSession()).toMatchObject({
+      accessToken: 'renewed-token',
+      loginId: 'hashi-admin',
+    })
+  })
+
+  it('rejects reissue when no admin session exists', async () => {
+    clearAdminSession()
+
+    await expect(reissueAdminSession()).rejects.toThrow(
+      '관리자 세션이 없습니다.',
+    )
+    expect(reissueMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/src/shared/auth/reissueAdminSession.test.ts
+++ b/apps/admin/src/shared/auth/reissueAdminSession.test.ts
@@ -49,6 +49,27 @@ describe('reissueAdminSession', () => {
     })
   })
 
+  it('does not overwrite a newer login for the same admin ID', async () => {
+    let resolveReissue: (accessToken: string) => void = () => undefined
+    reissueMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReissue = resolve
+      }),
+    )
+    const reissue = reissueAdminSession()
+    const newerSession = {
+      accessToken: 'newer-token',
+      issuedAt: '2026-07-21T00:00:00Z',
+      loginId: 'hashi-admin',
+    }
+
+    setAdminSession(newerSession)
+    resolveReissue('renewed-token')
+
+    await expect(reissue).rejects.toThrow('관리자 세션이 변경되었습니다.')
+    expect(getAdminSession()).toEqual(newerSession)
+  })
+
   it('rejects reissue when no admin session exists', async () => {
     clearAdminSession()
 

--- a/apps/admin/src/shared/auth/reissueAdminSession.ts
+++ b/apps/admin/src/shared/auth/reissueAdminSession.ts
@@ -1,5 +1,9 @@
 import { authApi } from '@/shared/api/authApi'
-import { getAdminSession, setAdminSession } from '@/shared/auth/adminSession'
+import {
+  checkIsSameAdminSession,
+  getAdminSession,
+  setAdminSession,
+} from '@/shared/auth/adminSession'
 
 let inFlightReissue: Promise<void> | null = null
 
@@ -13,7 +17,7 @@ const runReissue = async () => {
   const accessToken = await authApi.reissue()
   const currentSession = getAdminSession()
 
-  if (!currentSession || currentSession.loginId !== session.loginId) {
+  if (!currentSession || !checkIsSameAdminSession(currentSession, session)) {
     throw new Error('관리자 세션이 변경되었습니다.')
   }
 

--- a/apps/admin/src/shared/auth/reissueAdminSession.ts
+++ b/apps/admin/src/shared/auth/reissueAdminSession.ts
@@ -1,0 +1,35 @@
+import { authApi } from '@/shared/api/authApi'
+import { getAdminSession, setAdminSession } from '@/shared/auth/adminSession'
+
+let inFlightReissue: Promise<void> | null = null
+
+const runReissue = async () => {
+  const session = getAdminSession()
+
+  if (!session) {
+    throw new Error('관리자 세션이 없습니다.')
+  }
+
+  const accessToken = await authApi.reissue()
+  const currentSession = getAdminSession()
+
+  if (!currentSession || currentSession.loginId !== session.loginId) {
+    throw new Error('관리자 세션이 변경되었습니다.')
+  }
+
+  setAdminSession({
+    ...currentSession,
+    accessToken,
+    issuedAt: new Date().toISOString(),
+  })
+}
+
+export const reissueAdminSession = () => {
+  if (!inFlightReissue) {
+    inFlightReissue = runReissue().finally(() => {
+      inFlightReissue = null
+    })
+  }
+
+  return inFlightReissue
+}

--- a/apps/admin/src/shared/auth/useAdminSession.ts
+++ b/apps/admin/src/shared/auth/useAdminSession.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from 'react'
+import {
+  getAdminSession,
+  getAdminSessionSnapshot,
+  subscribeAdminSession,
+} from '@/shared/auth/adminSession'
+
+export const useAdminSession = () => {
+  useSyncExternalStore(
+    subscribeAdminSession,
+    getAdminSessionSnapshot,
+    () => null,
+  )
+
+  return getAdminSession()
+}

--- a/apps/admin/src/shared/components/AdminPagination.test.tsx
+++ b/apps/admin/src/shared/components/AdminPagination.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AdminPagination } from '@/shared/components/AdminPagination'
+
+describe('AdminPagination', () => {
+  it('marks the current page and moves directly to a selected page', () => {
+    const onPageChange = vi.fn()
+
+    render(
+      <AdminPagination
+        currentPage={0}
+        totalPages={3}
+        isDisabled={false}
+        onPageChange={onPageChange}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: '1페이지' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+    expect(screen.getByRole('button', { name: '이전 페이지' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: '3페이지' }))
+
+    expect(onPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it('keeps edge pages and condenses omitted ranges', () => {
+    render(
+      <AdminPagination
+        currentPage={5}
+        totalPages={10}
+        isDisabled={false}
+        onPageChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: '1페이지' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '10페이지' })).toBeInTheDocument()
+    expect(screen.getAllByText('…')).toHaveLength(2)
+  })
+
+  it('disables every page control during a list update', () => {
+    render(
+      <AdminPagination
+        currentPage={1}
+        totalPages={3}
+        isDisabled
+        onPageChange={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen
+        .getAllByRole('button')
+        .every((button) => button.hasAttribute('disabled')),
+    ).toBe(true)
+  })
+
+  it('renders nothing when there are no result pages', () => {
+    render(
+      <AdminPagination
+        currentPage={0}
+        totalPages={0}
+        isDisabled={false}
+        onPageChange={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.queryByRole('navigation', { name: '관리자 목록 페이지' }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/admin/src/shared/components/AdminPagination.tsx
+++ b/apps/admin/src/shared/components/AdminPagination.tsx
@@ -1,0 +1,123 @@
+import { BackIcon, NextIcon } from '@hashi/hds-icons'
+
+type PaginationItem = number | 'start-ellipsis' | 'end-ellipsis'
+
+interface AdminPaginationProps {
+  currentPage: number
+  totalPages: number
+  isDisabled: boolean
+  onPageChange: (page: number) => void
+}
+
+const MAX_VISIBLE_PAGES = 7
+
+const getPaginationItems = (
+  currentPage: number,
+  totalPages: number,
+): PaginationItem[] => {
+  if (totalPages <= MAX_VISIBLE_PAGES) {
+    return Array.from({ length: totalPages }, (_, index) => index)
+  }
+
+  if (currentPage <= 3) {
+    return [0, 1, 2, 3, 4, 'end-ellipsis', totalPages - 1]
+  }
+
+  if (currentPage >= totalPages - 4) {
+    return [
+      0,
+      'start-ellipsis',
+      totalPages - 5,
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+    ]
+  }
+
+  return [
+    0,
+    'start-ellipsis',
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    'end-ellipsis',
+    totalPages - 1,
+  ]
+}
+
+const baseButtonClassName =
+  'flex size-9 items-center justify-center rounded-md border text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-40'
+
+export const AdminPagination = ({
+  currentPage,
+  totalPages,
+  isDisabled,
+  onPageChange,
+}: AdminPaginationProps) => {
+  if (totalPages <= 0) {
+    return null
+  }
+
+  const items = getPaginationItems(currentPage, totalPages)
+
+  return (
+    <nav aria-label="관리자 목록 페이지" className="mt-4 flex justify-center">
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          aria-label="이전 페이지"
+          disabled={isDisabled || currentPage === 0}
+          onClick={() => onPageChange(currentPage - 1)}
+          className={`${baseButtonClassName} border-cool-gray-100 text-cool-gray-700 hover:bg-cool-gray-50 bg-white`}
+        >
+          <BackIcon aria-hidden="true" className="size-4" />
+        </button>
+
+        {items.map((item) => {
+          if (typeof item !== 'number') {
+            return (
+              <span
+                key={item}
+                aria-hidden="true"
+                className="text-cool-gray-400 flex size-9 items-center justify-center text-sm"
+              >
+                …
+              </span>
+            )
+          }
+
+          const isCurrent = item === currentPage
+
+          return (
+            <button
+              key={item}
+              type="button"
+              aria-label={`${item + 1}페이지`}
+              aria-current={isCurrent ? 'page' : undefined}
+              disabled={isDisabled}
+              onClick={() => onPageChange(item)}
+              className={`${baseButtonClassName} ${
+                isCurrent
+                  ? 'border-cool-gray-900 bg-cool-gray-900 text-white'
+                  : 'border-cool-gray-100 text-cool-gray-700 hover:bg-cool-gray-50 bg-white'
+              }`}
+            >
+              {item + 1}
+            </button>
+          )
+        })}
+
+        <button
+          type="button"
+          aria-label="다음 페이지"
+          disabled={isDisabled || currentPage + 1 >= totalPages}
+          onClick={() => onPageChange(currentPage + 1)}
+          className={`${baseButtonClassName} border-cool-gray-100 text-cool-gray-700 hover:bg-cool-gray-50 bg-white`}
+        >
+          <NextIcon aria-hidden="true" className="size-4" />
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -25,7 +25,7 @@ HASHI 앱의 데이터 레이어는 앱 내부에서 먼저 조립하고, 실제
 - public read/upload generated output: `apps/admin/src/shared/api/generated/user-openapi.ts`
 - Query provider/client: `apps/admin/src/app/providers/QueryProvider.tsx`, `apps/admin/src/shared/lib/queryClient.ts`
 - admin 인증은 response `Authorization` header의 bearer token과 credential cookie를 함께 사용합니다.
-- 보호 API가 `401`을 반환하면 user OpenAPI의 `POST /api/v1/auth/reissue`로 access token을 한 번 재발급하고 원 요청을 한 번 재시도합니다. 동시 `401`은 하나의 재발급 요청을 공유하며, 실패하면 admin session을 지웁니다.
+- 보호 API가 `401`을 반환하면 user OpenAPI의 `POST /api/v1/auth/reissue`로 access token을 한 번 재발급하고 원 요청을 한 번 재시도합니다. 동시 `401`은 하나의 재발급 요청을 공유하며, 실패하면 재발급을 시작한 동일 session만 지우고 admin query cache도 함께 비웁니다.
 - 예약 query와 모든 admin mutation은 실제 endpoint를 사용합니다. 식당·매거진 공개 목록과 수정 prefill은 user API를 사용하며 전체 관리자 재고로 표현하지 않습니다.
 
 새 dependency를 추가하거나 버전을 바꾸는 경우 `docs/conventions/package-management.md`를 따릅니다.

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -25,6 +25,7 @@ HASHI 앱의 데이터 레이어는 앱 내부에서 먼저 조립하고, 실제
 - public read/upload generated output: `apps/admin/src/shared/api/generated/user-openapi.ts`
 - Query provider/client: `apps/admin/src/app/providers/QueryProvider.tsx`, `apps/admin/src/shared/lib/queryClient.ts`
 - admin 인증은 response `Authorization` header의 bearer token과 credential cookie를 함께 사용합니다.
+- 보호 API가 `401`을 반환하면 user OpenAPI의 `POST /api/v1/auth/reissue`로 access token을 한 번 재발급하고 원 요청을 한 번 재시도합니다. 동시 `401`은 하나의 재발급 요청을 공유하며, 실패하면 admin session을 지웁니다.
 - 예약 query와 모든 admin mutation은 실제 endpoint를 사용합니다. 식당·매거진 공개 목록과 수정 prefill은 user API를 사용하며 전체 관리자 재고로 표현하지 않습니다.
 
 새 dependency를 추가하거나 버전을 바꾸는 경우 `docs/conventions/package-management.md`를 따릅니다.

--- a/vercel.admin.json
+++ b/vercel.admin.json
@@ -5,6 +5,21 @@
   "installCommand": "pnpm install",
   "framework": "vite",
   "outputDirectory": "apps/admin/dist",
+  "headers": [
+    {
+      "source": "/sw.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0"
+        },
+        {
+          "key": "Vercel-CDN-Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 📋 작업 사항

- **목표**
  - 어드민이 전체 회원 목록을 조회하고 닉네임 검색·정렬·offset pagination으로 관리할 수 있도록 합니다.
  - access token 만료와 과거 PWA service worker 캐시 때문에 관리자 접근이 끊기는 문제를 복구합니다.

## 🧭 설계 의도 (핵심 구조)

### 1) 회원 목록 API 경계

- `GET /api/v1/admin/users`를 page-local 계약으로 연결했습니다.
- `sort`, trim한 optional `keyword`, 0-based `page`, `size=20`을 query key와 요청에 동일하게 반영합니다.
- 기본 정렬은 가입일 최신순이며, 닉네임 검색은 입력 종료 300ms 후 자동 적용합니다.

### 2) 인증 복구

- 보호 API의 첫 `401`에서 token reissue를 한 번 수행하고 원 요청을 한 번 재시도합니다.
- 동시에 발생한 `401`은 하나의 in-flight reissue를 공유합니다.
- 재발급 실패 또는 재시도 `401`에서는 세션을 지워 route guard가 로그인 화면으로 이동하도록 했습니다.

### 3) 목록 UI와 배포 캐시 정리

- 회원·예약 offset 목록이 공용 숫자 pagination을 사용하도록 통일했습니다.
- `admin.hashi.kr`에 남은 과거 사용자 PWA service worker를 같은 `/sw.js` 경로의 self-destroying worker로 교체합니다.
- 어드민 부팅 시에도 남은 service worker 등록과 Cache Storage를 정리합니다.

## 🧩 구현 상세 (파일별)

### `apps/admin/src/pages/users`

- 회원 목록 API, query key, TanStack Query hook, table, 검색·정렬·pagination 화면을 추가했습니다.
- loading, error/retry, empty, background fetching 상태를 분리했습니다.

### `apps/admin/src/shared/api` / `shared/auth`

- 공통 응답 파싱과 typed API error 처리를 추가했습니다.
- single-flight token reissue, one-time replay, session 변경 구독을 구현했습니다.

### `apps/admin/src/shared/components/AdminPagination.tsx`

- 현재 페이지, 직접 이동, 이전·다음, 생략 구간을 지원하는 공용 pagination을 추가했습니다.
- background fetching 중 모든 이동을 비활성화합니다.

### `apps/admin/public/sw.js` / `vercel.admin.json`

- 레거시 worker 등록과 Cache Storage를 정리하는 self-destroying worker를 배포합니다.
- cleanup worker가 브라우저나 Vercel CDN에 캐시되지 않도록 설정했습니다.

## 🎨 스타일링 전략

- 기존 어드민 table, toolbar, HDS icon 및 color token 사용 방식을 유지했습니다.
- 회원·예약 목록의 pagination 위치와 상호작용을 동일하게 맞췄습니다.

## ⚙️ 성능 고려

- 검색 입력에 300ms debounce를 적용해 불필요한 API 요청을 줄였습니다.
- 동시 `401`이 발생해도 reissue 요청은 한 번만 수행합니다.
- 목록 조건 변경 중 기존 데이터를 유지해 화면 깜빡임을 줄였습니다.

## ✅ 검증

- `pnpm format:check`
- `pnpm --filter @hashi/admin lint`
- `pnpm --filter @hashi/admin typecheck`
- `pnpm --filter @hashi/admin test` — 36 files, 103 tests passed
- `pnpm --filter @hashi/admin build`

## 📢 공유 사항

- Admin OpenAPI에 회원 목록 endpoint가 배포되면 page-local 회원 타입을 generated alias로 교체할 수 있습니다.
- 이번 작업 중 생성된 `docs/superpowers` 설계·계획 파일은 PR에서 제외했습니다.
- 레거시 `sw.js`는 기존 사용자 브라우저 정리를 위해 이름을 변경하거나 삭제하지 않아야 합니다.

## 📚 참고 자료

- [Vite PWA - Unregister Service Worker](https://vite-pwa-org.netlify.app/guide/unregister-service-worker)
