### PR TITLE
Refactor(reservation): HASHI-150 예약 폼 제어 로직 공통화

### DIFF
--- a/apps/client/src/features/reservation/hooks/useReservationFormControls.spec.md
+++ b/apps/client/src/features/reservation/hooks/useReservationFormControls.spec.md
@@ -1,0 +1,90 @@
+# Hook Spec: `useReservationFormControls`
+
+## Purpose
+
+식당 예약과 어디든 예약 화면에서 공통으로 사용하는 예약자명, 요청사항, 인원, 날짜, 시간 선택 상태와 UI controller를 제공합니다.
+
+## Hook Type
+
+- [x] feature hook
+- [x] form or interaction hook
+
+## Spec Location
+
+- spec path: `apps/client/src/features/reservation/hooks/useReservationFormControls.spec.md`
+- implementation path: `apps/client/src/features/reservation/hooks/useReservationFormControls.ts`
+
+## Usage
+
+- `apps/client/src/pages/restaurantReservationNew/hooks/useRestaurantReservationForm.ts`
+- `apps/client/src/pages/anywhereReservation/hooks/useAnywhereReservationForm.ts`
+
+호출하는 page hook은 예약 가능 날짜·시간 슬롯 정책, 추가 입력값, reservation draft 생성을 담당합니다.
+
+## Inputs
+
+### `checkIsDateReservable`
+
+- type: `(date: Date) => boolean`
+- required: `true`
+- description: 오늘 이후 날짜 중 page 정책상 예약 가능한 날짜인지 판단합니다. 식당 예약은 영업시간·휴무를, 어디든 예약은 항상 예약 가능을 전달합니다.
+
+### `getTimeSlots`
+
+- type: `(selectedDate: Date | undefined) => readonly string[]`
+- required: `true`
+- description: 현재 선택 날짜에 표시할 시간 슬롯을 반환합니다. 날짜가 선택되지 않은 경우에도 기존 화면의 초기 시간 슬롯을 반환할 수 있습니다.
+
+## Return Shape
+
+```ts
+const { fields, guestCounters, validity, values, calendar, timeSelector } =
+  useReservationFormControls(params)
+```
+
+- `fields`: 예약자명·요청사항 input value 및 change action
+- `guestCounters`: 인원별 증감 controller
+- `validity`: 인원 합계, 예약자명, 선택 날짜, 선택 시간의 기본 유효성
+- `values`: page-local draft 생성에 필요한 guest count·선택 날짜·선택 시간
+- `calendar`: visible month, selected date, disabled 판단 및 변경 action
+- `timeSelector`: 표시 시간 슬롯, 선택 시간, disabled 상태 및 선택 action
+
+## Behavior
+
+1. 초기 인원은 모든 유형이 0명이며, 현재 월을 visible month로 설정합니다.
+2. 인원 감소는 0명 미만으로 내려가지 않습니다.
+3. 오늘과 과거 날짜, 또는 `checkIsDateReservable`이 false인 날짜를 비활성화합니다.
+4. 유효 날짜를 선택하기 전 시간 선택은 반영하지 않습니다.
+5. 다른 날짜를 선택하면 선택된 시간을 초기화합니다. 같은 날짜를 다시 선택하면 시간을 유지합니다.
+6. `getTimeSlots` 결과를 현재 선택 날짜에 맞춰 `timeSelector`에 전달합니다.
+
+## Validation
+
+- `isGuestNameValid`: 예약자명 trim 결과가 비어 있지 않은지
+- `totalGuestCount`: 어른·청소년·어린이 합계
+- `isSelectedDateValid`: 선택 날짜가 있고 비활성 날짜가 아닌지
+- `hasSelectedTime`: 시간 선택 여부
+
+페이지별 추가 validation은 이 hook이 소유하지 않습니다.
+
+## Side Effects
+
+- API 호출, cache update, storage, navigation, toast는 수행하지 않습니다.
+
+## Non-Goals
+
+- 식당 영업시간·휴무·break time 정책
+- 어디든 예약의 고정 슬롯 정책
+- 식당명·주소 입력 및 validation
+- reservation draft·API payload 생성
+- UI markup·스타일·제품 copy
+
+## Verification
+
+- [x] 시간 선택 전 유효 날짜 필요 여부
+- [x] 날짜 변경 시 선택 시간 초기화
+- [x] 인원 수 0명 하한
+- [x] 공통 text field 및 기본 validity
+- [x] `pnpm --filter @hashi/client test`
+- [ ] `pnpm --filter @hashi/client typecheck`
+- [ ] `pnpm --filter @hashi/client lint`

--- a/apps/client/src/features/reservation/hooks/useReservationFormControls.test.ts
+++ b/apps/client/src/features/reservation/hooks/useReservationFormControls.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useReservationFormControls } from '@/features/reservation/hooks/useReservationFormControls'
+
+describe('useReservationFormControls', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 5, 1, 9))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ignores time selection before a valid date and clears selected time when the date changes', () => {
+    const { result } = renderHook(() =>
+      useReservationFormControls({
+        checkIsDateReservable: () => true,
+        getTimeSlots: (selectedDate) => (selectedDate ? ['12:00'] : ['11:00']),
+      }),
+    )
+
+    act(() => {
+      result.current.timeSelector.onTimeSelect('11:00')
+    })
+
+    expect(result.current.timeSelector.selectedTime).toBeUndefined()
+
+    act(() => {
+      result.current.calendar.onDateSelect(new Date(2026, 5, 2))
+    })
+
+    act(() => {
+      result.current.timeSelector.onTimeSelect('12:00')
+    })
+
+    expect(result.current.timeSelector.selectedTime).toBe('12:00')
+
+    act(() => {
+      result.current.calendar.onDateSelect(new Date(2026, 5, 3))
+    })
+
+    expect(result.current.timeSelector.selectedTime).toBeUndefined()
+  })
+
+  it('keeps guest counts non-negative and exposes shared text-field validity', () => {
+    const { result } = renderHook(() =>
+      useReservationFormControls({
+        checkIsDateReservable: () => true,
+        getTimeSlots: () => ['11:00'],
+      }),
+    )
+
+    const adultCounter = result.current.guestCounters.find(
+      ({ key }) => key === 'adult',
+    )
+
+    act(() => {
+      adultCounter?.onDecrease()
+      adultCounter?.onIncrease()
+      result.current.fields.guestName.onValueChange('  김하시  ')
+      result.current.fields.requestNote.onValueChange('창가 자리 부탁드립니다')
+    })
+
+    expect(
+      result.current.guestCounters.find(({ key }) => key === 'adult')?.value,
+    ).toBe(1)
+    expect(result.current.validity.totalGuestCount).toBe(1)
+    expect(result.current.validity.isGuestNameValid).toBe(true)
+    expect(result.current.fields.guestName.value).toBe('  김하시  ')
+    expect(result.current.fields.requestNote.value).toBe(
+      '창가 자리 부탁드립니다',
+    )
+  })
+
+  it('exposes selected reservation values for page-specific draft creation', () => {
+    const { result } = renderHook(() =>
+      useReservationFormControls({
+        checkIsDateReservable: () => true,
+        getTimeSlots: () => ['11:00'],
+      }),
+    )
+
+    act(() => {
+      result.current.guestCounters[0]?.onIncrease()
+      result.current.calendar.onDateSelect(new Date(2026, 5, 2))
+    })
+
+    act(() => {
+      result.current.timeSelector.onTimeSelect('11:00')
+    })
+
+    expect(result.current.values).toMatchObject({
+      guestCounts: { adult: 1, teen: 0, child: 0 },
+      selectedDate: new Date(2026, 5, 2),
+      selectedTime: '11:00',
+    })
+  })
+})

--- a/apps/client/src/features/reservation/hooks/useReservationFormControls.ts
+++ b/apps/client/src/features/reservation/hooks/useReservationFormControls.ts
@@ -1,0 +1,121 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import {
+  INITIAL_RESERVATION_GUEST_COUNTS,
+  RESERVATION_GUEST_COUNTERS,
+} from '@/features/reservation/constants/guest'
+import type {
+  ReservationGuestCounts,
+  ReservationGuestType,
+} from '@/features/reservation/constants/guest'
+import { checkIsTodayOrBefore, createMonthStart } from '@/shared/utils/date'
+
+interface UseReservationFormControlsParams {
+  checkIsDateReservable: (date: Date) => boolean
+  getTimeSlots: (selectedDate: Date | undefined) => readonly string[]
+}
+
+export const useReservationFormControls = ({
+  checkIsDateReservable,
+  getTimeSlots,
+}: UseReservationFormControlsParams) => {
+  const [guestName, setGuestName] = useState('')
+  const [guestCounts, setGuestCounts] = useState<ReservationGuestCounts>(
+    INITIAL_RESERVATION_GUEST_COUNTS,
+  )
+  const [requestNote, setRequestNote] = useState('')
+  const [visibleMonth, setVisibleMonth] = useState(() =>
+    createMonthStart(new Date()),
+  )
+  const [selectedDate, setSelectedDate] = useState<Date>()
+  const [selectedTime, setSelectedTime] = useState<string>()
+  const minMonth = createMonthStart(new Date())
+
+  const checkIsDateDisabled = useCallback(
+    (date: Date) => checkIsTodayOrBefore(date) || !checkIsDateReservable(date),
+    [checkIsDateReservable],
+  )
+
+  const isSelectedDateValid =
+    selectedDate !== undefined && !checkIsDateDisabled(selectedDate)
+  const totalGuestCount =
+    guestCounts.adult + guestCounts.teen + guestCounts.child
+  const isGuestNameValid = guestName.trim().length > 0
+  const timeSlots = useMemo(
+    () => getTimeSlots(selectedDate),
+    [getTimeSlots, selectedDate],
+  )
+
+  const handleGuestCountChange = (
+    guestType: ReservationGuestType,
+    amount: number,
+  ) => {
+    setGuestCounts((currentGuestCounts) => ({
+      ...currentGuestCounts,
+      [guestType]: Math.max(0, currentGuestCounts[guestType] + amount),
+    }))
+  }
+
+  const handleTimeSelect = (time: string) => {
+    if (!isSelectedDateValid) {
+      return
+    }
+
+    setSelectedTime(time)
+  }
+
+  const handleDateSelect = (nextDate: Date) => {
+    if (selectedDate?.getTime() !== nextDate.getTime()) {
+      setSelectedTime(undefined)
+    }
+
+    setSelectedDate(nextDate)
+  }
+
+  return {
+    fields: {
+      guestName: {
+        value: guestName,
+        onValueChange: setGuestName,
+      },
+      requestNote: {
+        value: requestNote,
+        onValueChange: setRequestNote,
+      },
+    },
+    guestCounters: RESERVATION_GUEST_COUNTERS.map(({ key, label }) => ({
+      key,
+      label,
+      value: guestCounts[key],
+      onDecrease: () => handleGuestCountChange(key, -1),
+      onIncrease: () => handleGuestCountChange(key, 1),
+    })),
+    validity: {
+      totalGuestCount,
+      isGuestNameValid,
+      isSelectedDateValid,
+      hasSelectedTime: selectedTime !== undefined,
+    },
+    values: {
+      guestCounts,
+      selectedDate,
+      selectedTime,
+    },
+    calendar: {
+      isDateDisabled: checkIsDateDisabled,
+      minMonth,
+      visibleMonth,
+      selectedDate,
+      onDateSelect: handleDateSelect,
+      onMonthChange: (nextMonth: Date) => {
+        setVisibleMonth(createMonthStart(nextMonth))
+      },
+    },
+    timeSelector: {
+      timeSlots,
+      selectedTime,
+      disabled: !isSelectedDateValid,
+      onTimeSelect: handleTimeSelect,
+    },
+  }
+}

--- a/apps/client/src/pages/anywhereReservation/hooks/useAnywhereReservationForm.ts
+++ b/apps/client/src/pages/anywhereReservation/hooks/useAnywhereReservationForm.ts
@@ -1,19 +1,9 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
-import {
-  INITIAL_RESERVATION_GUEST_COUNTS,
-  RESERVATION_GUEST_COUNTERS,
-} from '@/features/reservation/constants/guest'
-import type {
-  ReservationGuestCounts,
-  ReservationGuestType,
-} from '@/features/reservation/constants/guest'
+import type { ReservationGuestCounts } from '@/features/reservation/constants/guest'
+import { useReservationFormControls } from '@/features/reservation/hooks/useReservationFormControls'
 import { createReservationTimeSlots } from '@/features/reservation/utils/createReservationTimeSlots'
-import {
-  checkIsTodayOrBefore,
-  createMonthStart,
-  formatDateToLocalDateString,
-} from '@/shared/utils/date'
+import { formatDateToLocalDateString } from '@/shared/utils/date'
 
 export interface AnywhereReservationDraft {
   source: 'anywhere'
@@ -43,63 +33,38 @@ const ANYWHERE_RESERVATION_TIME_SLOTS = createReservationTimeSlots(
 export const useAnywhereReservationForm = () => {
   const [restaurantName, setRestaurantName] = useState('')
   const [restaurantAddress, setRestaurantAddress] = useState('')
-  const [guestName, setGuestName] = useState('')
-  const [guestCounts, setGuestCounts] = useState<ReservationGuestCounts>(
-    INITIAL_RESERVATION_GUEST_COUNTS,
-  )
-  const [visibleMonth, setVisibleMonth] = useState(() =>
-    createMonthStart(new Date()),
-  )
-  const [selectedDate, setSelectedDate] = useState<Date>()
-  const [selectedTime, setSelectedTime] = useState<string>()
-  const [requestNote, setRequestNote] = useState('')
-  const minMonth = createMonthStart(new Date())
-
-  const totalGuestCount =
-    guestCounts.adult + guestCounts.teen + guestCounts.child
+  const checkIsDateReservable = useCallback(() => true, [])
+  const getTimeSlots = useCallback(() => ANYWHERE_RESERVATION_TIME_SLOTS, [])
+  const formControls = useReservationFormControls({
+    checkIsDateReservable,
+    getTimeSlots,
+  })
+  const {
+    fields: formFields,
+    guestCounters,
+    calendar,
+    timeSelector,
+    validity,
+    values,
+  } = formControls
   const isRestaurantNameValid = restaurantName.trim().length > 0
   const isRestaurantAddressValid = restaurantAddress.trim().length > 0
-  const isGuestNameValid = guestName.trim().length > 0
-  const isSelectedDateValid =
-    selectedDate !== undefined && !checkIsTodayOrBefore(selectedDate)
   const canSubmit =
     isRestaurantNameValid &&
     isRestaurantAddressValid &&
-    isGuestNameValid &&
-    totalGuestCount > 0 &&
-    isSelectedDateValid &&
-    selectedTime !== undefined
-
-  const handleGuestCountChange = (
-    guestType: ReservationGuestType,
-    amount: number,
-  ) => {
-    setGuestCounts((currentGuestCounts) => ({
-      ...currentGuestCounts,
-      [guestType]: Math.max(0, currentGuestCounts[guestType] + amount),
-    }))
-  }
-
-  const handleTimeSelect = (time: string) => {
-    if (!isSelectedDateValid) {
-      return
-    }
-
-    setSelectedTime(time)
-  }
-
-  const handleDateSelect = (nextDate: Date) => {
-    if (selectedDate?.getTime() !== nextDate.getTime()) {
-      setSelectedTime(undefined)
-    }
-
-    setSelectedDate(nextDate)
-  }
+    validity.isGuestNameValid &&
+    validity.totalGuestCount > 0 &&
+    validity.isSelectedDateValid &&
+    validity.hasSelectedTime
 
   const createAnywhereReservationDraft = ():
     | AnywhereReservationDraft
     | undefined => {
-    if (!canSubmit || selectedDate === undefined || !selectedTime) {
+    if (
+      !canSubmit ||
+      values.selectedDate === undefined ||
+      !values.selectedTime
+    ) {
       return undefined
     }
 
@@ -109,11 +74,11 @@ export const useAnywhereReservationForm = () => {
       restaurantName: restaurantName.trim(),
       restaurantAddress: restaurantAddress.trim(),
       restaurantImageUrl: null,
-      guestName: guestName.trim(),
-      guests: guestCounts,
-      date: formatDateToLocalDateString(selectedDate),
-      time: selectedTime,
-      requestNote,
+      guestName: formFields.guestName.value.trim(),
+      guests: values.guestCounts,
+      date: formatDateToLocalDateString(values.selectedDate),
+      time: values.selectedTime,
+      requestNote: formFields.requestNote.value,
     }
   }
 
@@ -127,38 +92,11 @@ export const useAnywhereReservationForm = () => {
         value: restaurantAddress,
         onValueChange: setRestaurantAddress,
       },
-      guestName: {
-        value: guestName,
-        onValueChange: setGuestName,
-      },
-      requestNote: {
-        value: requestNote,
-        onValueChange: setRequestNote,
-      },
+      ...formFields,
     },
-    guestCounters: RESERVATION_GUEST_COUNTERS.map(({ key, label }) => ({
-      key,
-      label,
-      value: guestCounts[key],
-      onDecrease: () => handleGuestCountChange(key, -1),
-      onIncrease: () => handleGuestCountChange(key, 1),
-    })),
-    calendar: {
-      isDateDisabled: checkIsTodayOrBefore,
-      minMonth,
-      visibleMonth,
-      selectedDate,
-      onDateSelect: handleDateSelect,
-      onMonthChange: (nextMonth: Date) => {
-        setVisibleMonth(createMonthStart(nextMonth))
-      },
-    },
-    timeSelector: {
-      timeSlots: ANYWHERE_RESERVATION_TIME_SLOTS,
-      selectedTime,
-      disabled: !isSelectedDateValid,
-      onTimeSelect: handleTimeSelect,
-    },
+    guestCounters,
+    calendar,
+    timeSelector,
     submit: {
       canSubmit,
       createAnywhereReservationDraft,

--- a/apps/client/src/pages/restaurantReservationNew/hooks/useRestaurantReservationForm.ts
+++ b/apps/client/src/pages/restaurantReservationNew/hooks/useRestaurantReservationForm.ts
@@ -1,20 +1,10 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback } from 'react'
 
-import {
-  INITIAL_RESERVATION_GUEST_COUNTS,
-  RESERVATION_GUEST_COUNTERS,
-} from '@/features/reservation/constants/guest'
-import type {
-  ReservationGuestCounts,
-  ReservationGuestType,
-} from '@/features/reservation/constants/guest'
+import type { ReservationGuestCounts } from '@/features/reservation/constants/guest'
+import { useReservationFormControls } from '@/features/reservation/hooks/useReservationFormControls'
 import { createReservationTimeSlots } from '@/features/reservation/utils/createReservationTimeSlots'
-import {
-  checkIsTodayOrBefore,
-  createMonthStart,
-  formatDateToLocalDateString,
-} from '@/shared/utils/date'
 import type { ReservationRestaurant } from '@/pages/restaurantReservationNew/hooks/useReservationRestaurant'
+import { formatDateToLocalDateString } from '@/shared/utils/date'
 
 interface UseRestaurantReservationFormParams {
   restaurant: ReservationRestaurant
@@ -68,100 +58,59 @@ const checkIsReservableBusinessHours = (
 export const useRestaurantReservationForm = ({
   restaurant,
 }: UseRestaurantReservationFormParams) => {
-  const [guestName, setGuestName] = useState('')
-  const [guestCounts, setGuestCounts] = useState<ReservationGuestCounts>(
-    INITIAL_RESERVATION_GUEST_COUNTS,
-  )
-  const [visibleMonth, setVisibleMonth] = useState(() =>
-    createMonthStart(new Date()),
-  )
-  const [selectedDate, setSelectedDate] = useState<Date>()
-  const [selectedTime, setSelectedTime] = useState<string>()
-  const [requestNote, setRequestNote] = useState('')
-  const minMonth = createMonthStart(new Date())
-
-  const checkIsDateDisabled = useCallback(
-    (date: Date) => {
-      const businessHours = getBusinessHoursForDate(
-        date,
-        restaurant.businessHours,
-      )
-
-      return (
-        checkIsTodayOrBefore(date) ||
-        !checkIsReservableBusinessHours(businessHours)
-      )
-    },
+  const checkIsDateReservable = useCallback(
+    (date: Date) =>
+      checkIsReservableBusinessHours(
+        getBusinessHoursForDate(date, restaurant.businessHours),
+      ),
     [restaurant.businessHours],
   )
 
-  const timeSlots = useMemo(() => {
-    const businessHours = selectedDate
-      ? getBusinessHoursForDate(selectedDate, restaurant.businessHours)
-      : restaurant.businessHours.find(checkIsReservableBusinessHours)
+  const getTimeSlots = useCallback(
+    (selectedDate: Date | undefined) => {
+      const businessHours = selectedDate
+        ? getBusinessHoursForDate(selectedDate, restaurant.businessHours)
+        : restaurant.businessHours.find(checkIsReservableBusinessHours)
 
-    if (
-      !checkIsReservableBusinessHours(businessHours) ||
-      !businessHours?.open ||
-      !businessHours.close
-    ) {
-      return []
-    }
+      if (
+        !checkIsReservableBusinessHours(businessHours) ||
+        !businessHours?.open ||
+        !businessHours.close
+      ) {
+        return []
+      }
 
-    return createReservationTimeSlots(
-      {
-        open: businessHours.open,
-        close: businessHours.close,
-        breakStart: businessHours.breakStart,
-        breakEnd: businessHours.breakEnd,
-      },
-      restaurant.reservationIntervalMinutes,
-    )
-  }, [
-    restaurant.businessHours,
-    restaurant.reservationIntervalMinutes,
-    selectedDate,
-  ])
+      return createReservationTimeSlots(
+        {
+          open: businessHours.open,
+          close: businessHours.close,
+          breakStart: businessHours.breakStart,
+          breakEnd: businessHours.breakEnd,
+        },
+        restaurant.reservationIntervalMinutes,
+      )
+    },
+    [restaurant.businessHours, restaurant.reservationIntervalMinutes],
+  )
 
-  const totalGuestCount =
-    guestCounts.adult + guestCounts.teen + guestCounts.child
-  const isGuestNameValid = guestName.trim().length > 0
-  const isSelectedDateValid =
-    selectedDate !== undefined && !checkIsDateDisabled(selectedDate)
+  const formControls = useReservationFormControls({
+    checkIsDateReservable,
+    getTimeSlots,
+  })
+  const { fields, guestCounters, calendar, timeSelector, validity, values } =
+    formControls
   const canSubmit =
-    isGuestNameValid &&
-    totalGuestCount > 0 &&
-    isSelectedDateValid &&
-    selectedTime !== undefined
-
-  const handleGuestCountChange = (
-    guestType: ReservationGuestType,
-    amount: number,
-  ) => {
-    setGuestCounts((currentGuestCounts) => ({
-      ...currentGuestCounts,
-      [guestType]: Math.max(0, currentGuestCounts[guestType] + amount),
-    }))
-  }
-
-  const handleTimeSelect = (time: string) => {
-    if (!isSelectedDateValid) {
-      return
-    }
-
-    setSelectedTime(time)
-  }
-
-  const handleDateSelect = (nextDate: Date) => {
-    if (selectedDate?.getTime() !== nextDate.getTime()) {
-      setSelectedTime(undefined)
-    }
-
-    setSelectedDate(nextDate)
-  }
+    validity.isGuestNameValid &&
+    validity.totalGuestCount > 0 &&
+    validity.isSelectedDateValid &&
+    validity.hasSelectedTime
 
   const createReservationDraft = (): ReservationDraft | undefined => {
-    if (!canSubmit || selectedDate === undefined || !selectedTime) {
+    if (
+      !canSubmit ||
+      values.selectedDate === undefined ||
+      !values.selectedTime
+    ) {
       return undefined
     }
 
@@ -171,48 +120,19 @@ export const useRestaurantReservationForm = ({
       restaurantAddress: restaurant.address,
       restaurantImageUrl: restaurant.imageUrl,
       reservationFee: restaurant.reservationFee,
-      guestName: guestName.trim(),
-      guests: guestCounts,
-      date: formatDateToLocalDateString(selectedDate),
-      time: selectedTime,
-      requestNote,
+      guestName: fields.guestName.value.trim(),
+      guests: values.guestCounts,
+      date: formatDateToLocalDateString(values.selectedDate),
+      time: values.selectedTime,
+      requestNote: fields.requestNote.value,
     }
   }
 
   return {
-    fields: {
-      guestName: {
-        value: guestName,
-        onValueChange: setGuestName,
-      },
-      requestNote: {
-        value: requestNote,
-        onValueChange: setRequestNote,
-      },
-    },
-    guestCounters: RESERVATION_GUEST_COUNTERS.map(({ key, label }) => ({
-      key,
-      label,
-      value: guestCounts[key],
-      onDecrease: () => handleGuestCountChange(key, -1),
-      onIncrease: () => handleGuestCountChange(key, 1),
-    })),
-    calendar: {
-      isDateDisabled: checkIsDateDisabled,
-      minMonth,
-      visibleMonth,
-      selectedDate,
-      onDateSelect: handleDateSelect,
-      onMonthChange: (nextMonth: Date) => {
-        setVisibleMonth(createMonthStart(nextMonth))
-      },
-    },
-    timeSelector: {
-      timeSlots,
-      selectedTime,
-      disabled: !isSelectedDateValid,
-      onTimeSelect: handleTimeSelect,
-    },
+    fields,
+    guestCounters,
+    calendar,
+    timeSelector,
     submit: {
       canSubmit,
       createReservationDraft,


### PR DESCRIPTION
## 📌 요약

식당 예약과 어디든 예약 화면에 중복되어 있던 예약자명·요청사항·인원·날짜·시간 선택 상태를 `useReservationFormControls`로 추출했습니다. 화면별 예약 정책과 reservation draft 계약은 유지했습니다.

Jira: HASHI-150

## 📚 작업 내용

- 인원 증감, 날짜·시간 선택, 날짜 변경 시 시간 초기화, 기본 validity를 feature hook으로 공통화했습니다.
- 날짜 선택 전 시간 선택 방지와 draft 생성용 values를 공통 hook에 추가했습니다.
- 식당 예약 hook에는 영업시간·휴무·break time·식당 draft 생성 책임을 남겼습니다.
- 어디든 예약 hook에는 고정 30분 슬롯·식당명/주소 validation·anywhere draft 생성 책임을 남겼습니다.
- 공통 hook 상태 전이 테스트와 책임 경계 spec을 추가했습니다.

## 🔎 상세 설명

### 구조

```text
useReservationFormControls
  └─ 예약자명·요청사항·인원·날짜·시간 state와 UI controller

useRestaurantReservationForm
  └─ 식당 영업시간·휴무·break time 정책 + 식당 reservation draft

useAnywhereReservationForm
  └─ 고정 시간 슬롯·식당명/주소 validation + anywhere reservation draft
```

공통 hook은 식당인지 어디든 예약인지 알지 않습니다. 화면별 정책을 아래 두 함수로 주입받고, state/controller만 관리합니다.

```ts
useReservationFormControls({
  checkIsDateReservable, // 이 날짜가 화면 정책상 예약 가능한지
  getTimeSlots, // 선택 날짜에서 보여줄 시간 슬롯
})
```

### 공통 hook이 관리하는 값

- `fields`: 예약자명, 요청사항 input value와 변경 handler
- `guestCounters`: 어른·청소년·어린이 증감 controller와 0명 하한
- `calendar`: visible month, selected date, disabled date, 날짜 변경 handler
- `timeSelector`: 시간 슬롯, selected time, disabled 상태, 시간 선택 handler
- `validity`: 인원 합계, 예약자명, 날짜, 시간의 기본 유효성
- `values`: 각 page hook이 draft를 만들 때 사용하는 guest count, 선택 날짜, 선택 시간

### 상태 전이

1. 오늘·과거 날짜는 모든 화면에서 공통으로 비활성화합니다.
2. page 정책상 예약 불가인 날짜도 `checkIsDateReservable` 결과로 비활성화합니다.
3. 유효한 날짜를 선택하기 전에는 시간 클릭을 무시합니다. UI disabled뿐 아니라 handler에서도 막습니다.
4. 다른 날짜를 선택하면 이전 시간 선택을 초기화합니다. 날짜별 시간 슬롯이 다른 경우 잘못된 시간을 들고 다음 단계로 가는 것을 막기 위함입니다.
5. 같은 날짜를 다시 선택했을 때는 시간을 초기화하지 않습니다.

### 식당 예약 adapter

식당 예약은 `checkIsDateReservable`에서 선택 요일의 영업시간을 찾아 휴무 여부와 open/close 존재 여부를 확인합니다. `getTimeSlots`는 선택 요일의 영업시간과 break time, 예약 간격으로 슬롯을 생성합니다.

날짜를 아직 선택하지 않은 상태에서도 기존 화면처럼 첫 번째 예약 가능 영업시간의 슬롯을 보여줘야 하므로 `getTimeSlots(undefined)`를 지원했습니다. 다만 시간 선택은 유효한 날짜를 선택한 뒤에만 저장됩니다.

### 어디든 예약 adapter

어디든 예약은 오늘 이후 날짜라면 예약 가능하므로 `checkIsDateReservable`에서 항상 `true`를 반환합니다. 시간 슬롯은 기존과 동일하게 11:00~20:00, 30분 간격을 반환합니다.

식당명·주소는 공통 hook에 넣지 않고 page-local state와 validation으로 유지했습니다. 따라서 공통 validity에 식당명·주소 validity를 더해 최종 submit 가능 여부를 계산합니다.

### reservation draft 계약 유지

공통 hook은 draft를 만들지 않고 값만 반환합니다. draft 생성은 각 page hook에 남겼습니다.

- 식당 예약: `restaurantId`, `reservationFee`, 식당 이미지·주소 등 식당 메타데이터 유지
- 어디든 예약: `source: 'anywhere'`, `restaurantId: null`, `restaurantImageUrl: null` 유지

`ReservationRequestPage`가 두 draft shape으로 API 요청을 분기하므로, 이번 PR에서 이 계약을 통합하거나 바꾸지 않았습니다.

## 💭 고민한 부분

### 고민한 문제

두 화면의 상태 전이는 거의 같지만, 예약 가능 날짜·시간 슬롯·추가 입력값·draft metadata는 다릅니다. 중복을 없애겠다고 form 전체나 draft까지 합치면 식당 예약과 어디든 예약의 제품 정책이 공통 hook에 섞일 위험이 있었습니다.

### 고려한 선택지

1. 두 예약 form의 state·JSX·draft를 하나의 통합 form으로 구성한다.
2. 인원·날짜·시간 state/controller만 공통화하고, page hook은 정책과 draft 생성을 유지한다.
3. 현재 중복을 그대로 유지한다.

### 최종 선택과 이유

2번을 선택했습니다. 이번 목표는 동작 변경 없이 중복된 상태 전이를 한곳에서 관리하는 것이었고, 기존 page hook의 반환 shape와 reservation request로 전달하는 draft contract를 유지하는 편이 회귀 범위를 가장 작게 만들었습니다.

### 남은 고민

현재 공통 hook은 두 화면에서만 사용합니다. 이후 다른 예약 입력 화면이 추가될 때도 같은 state transition을 공유하는지 먼저 확인한 뒤 확장 여부를 판단하면 됩니다. 예약 취소 flow, formatter, reservation detail type 정리는 이 PR 범위에 포함하지 않았습니다.

## ✅ 검증

- [x] 공통 hook: 날짜 선택 전 시간 선택 무시, 날짜 변경 시 시간 초기화, 인원 0명 하한, values 노출 테스트
- [x] 식당 예약 페이지: 영업일·휴무·break time, 날짜별 시간 슬롯, draft navigation 회귀 테스트
- [x] 어디든 예약 페이지: 고정 30분 슬롯, 식당명·주소 validation, draft navigation 회귀 테스트
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — client 122 files / 601 tests, HDS UI 19 files / 179 tests 통과
- [x] `pnpm build`
- [x] `git diff --check`
- [x] 독립 pre-commit review — security / logic issue 없음