### PR TITLE
Refactor(root): HASHI-145 공정 분배 기반 PR 리뷰어 자동 할당 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @TEAM-HASHI/hashi-client

--- a/.github/reviewer-assignment.json
+++ b/.github/reviewer-assignment.json
@@ -1,0 +1,31 @@
+{
+  "lookbackDays": 30,
+  "requiredReviewerCount": 2,
+  "reviewers": [
+    {
+      "enabled": true,
+      "login": "jyeon03",
+      "weight": 1
+    },
+    {
+      "enabled": true,
+      "login": "chungyo",
+      "weight": 1
+    },
+    {
+      "enabled": true,
+      "login": "gyeongbibin",
+      "weight": 1
+    },
+    {
+      "enabled": true,
+      "login": "MinseoSONG",
+      "weight": 1
+    },
+    {
+      "enabled": true,
+      "login": "yurimidaH",
+      "weight": 1
+    }
+  ]
+}

--- a/.github/scripts/assign-reviewers.cjs
+++ b/.github/scripts/assign-reviewers.cjs
@@ -1,0 +1,330 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const DEFAULT_CONFIG_PATH = path.join(
+  process.cwd(),
+  '.github',
+  'reviewer-assignment.json',
+)
+
+const normalizeLogin = (login) => login.trim().toLowerCase()
+
+const readReviewerConfig = (configPath = DEFAULT_CONFIG_PATH) => {
+  return JSON.parse(fs.readFileSync(configPath, 'utf8'))
+}
+
+const validateReviewerConfig = (config) => {
+  if (!Number.isInteger(config.requiredReviewerCount)) {
+    throw new Error('requiredReviewerCount must be an integer.')
+  }
+
+  if (config.requiredReviewerCount !== 2) {
+    throw new Error('requiredReviewerCount must be 2.')
+  }
+
+  if (!Number.isInteger(config.lookbackDays) || config.lookbackDays <= 0) {
+    throw new Error('lookbackDays must be a positive integer.')
+  }
+
+  if (!Array.isArray(config.reviewers)) {
+    throw new Error('reviewers must be an array.')
+  }
+
+  const reviewerLogins = new Set()
+
+  for (const reviewer of config.reviewers) {
+    if (typeof reviewer.login !== 'string' || !reviewer.login.trim()) {
+      throw new Error('reviewer login must not be empty.')
+    }
+
+    const login = normalizeLogin(reviewer.login)
+
+    if (reviewerLogins.has(login)) {
+      throw new Error(`Duplicate reviewer login found: ${reviewer.login}`)
+    }
+
+    reviewerLogins.add(login)
+
+    if (
+      reviewer.weight !== undefined &&
+      (typeof reviewer.weight !== 'number' || reviewer.weight <= 0)
+    ) {
+      throw new Error(
+        `Reviewer weight must be a positive number: ${reviewer.login}`,
+      )
+    }
+  }
+
+  const enabledReviewers = config.reviewers.filter(
+    (reviewer) => reviewer.enabled !== false,
+  )
+
+  if (enabledReviewers.length < config.requiredReviewerCount + 1) {
+    throw new Error(
+      'At least 3 enabled reviewers are required to assign 2 reviewers while excluding the PR author.',
+    )
+  }
+}
+
+const createTieBreaker = (pullNumber, login) => {
+  const source = `${pullNumber}:${normalizeLogin(login)}`
+  let hash = 0
+
+  for (const character of source) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0
+  }
+
+  return hash
+}
+
+const createInitialReviewStats = (reviewers) => {
+  return new Map(
+    reviewers.map((reviewer) => [
+      normalizeLogin(reviewer.login),
+      {
+        assignments: 0,
+        reviews: 0,
+      },
+    ]),
+  )
+}
+
+const addAssignment = (reviewStats, login) => {
+  const stats = reviewStats.get(normalizeLogin(login))
+
+  if (stats) {
+    stats.assignments += 1
+  }
+}
+
+const addReview = (reviewStats, login) => {
+  const stats = reviewStats.get(normalizeLogin(login))
+
+  if (stats) {
+    stats.reviews += 1
+  }
+}
+
+const getAssignmentPressureScore = (reviewer, reviewStats) => {
+  const stats = reviewStats.get(normalizeLogin(reviewer.login)) ?? {
+    assignments: 0,
+    reviews: 0,
+  }
+  const weight =
+    typeof reviewer.weight === 'number' && reviewer.weight > 0
+      ? reviewer.weight
+      : 1
+
+  return (stats.assignments + stats.reviews) / weight
+}
+
+const selectReviewers = ({ author, config, pullNumber, reviewStats }) => {
+  validateReviewerConfig(config)
+
+  const authorLogin = normalizeLogin(author)
+  const candidates = config.reviewers.filter(
+    (reviewer) =>
+      reviewer.enabled !== false &&
+      normalizeLogin(reviewer.login) !== authorLogin,
+  )
+
+  if (candidates.length < config.requiredReviewerCount) {
+    throw new Error(
+      `At least ${config.requiredReviewerCount} eligible reviewers are required after excluding the PR author.`,
+    )
+  }
+
+  return candidates
+    .toSorted((left, right) => {
+      const scoreDifference =
+        getAssignmentPressureScore(left, reviewStats) -
+        getAssignmentPressureScore(right, reviewStats)
+
+      if (scoreDifference !== 0) {
+        return scoreDifference
+      }
+
+      return (
+        createTieBreaker(pullNumber, left.login) -
+        createTieBreaker(pullNumber, right.login)
+      )
+    })
+    .slice(0, config.requiredReviewerCount)
+    .map((reviewer) => reviewer.login)
+}
+
+const getConfiguredReviewerLogins = (config) => {
+  return new Set(
+    config.reviewers.map((reviewer) => normalizeLogin(reviewer.login)),
+  )
+}
+
+const getReviewersToRemove = ({
+  config,
+  currentRequestedReviewers,
+  selectedReviewers,
+}) => {
+  const configuredReviewerLogins = getConfiguredReviewerLogins(config)
+  const selectedReviewerLogins = new Set(selectedReviewers.map(normalizeLogin))
+
+  return currentRequestedReviewers
+    .filter((reviewer) =>
+      configuredReviewerLogins.has(normalizeLogin(reviewer.login)),
+    )
+    .filter(
+      (reviewer) => !selectedReviewerLogins.has(normalizeLogin(reviewer.login)),
+    )
+    .map((reviewer) => reviewer.login)
+}
+
+const getReviewersToRequest = ({
+  currentRequestedReviewers,
+  selectedReviewers,
+}) => {
+  const currentRequestedReviewerLogins = new Set(
+    currentRequestedReviewers.map((reviewer) => normalizeLogin(reviewer.login)),
+  )
+
+  return selectedReviewers.filter(
+    (reviewer) => !currentRequestedReviewerLogins.has(normalizeLogin(reviewer)),
+  )
+}
+
+const getLookbackIsoDate = (lookbackDays, now = new Date()) => {
+  const startDate = new Date(now)
+
+  startDate.setUTCDate(startDate.getUTCDate() - lookbackDays)
+
+  return startDate.toISOString()
+}
+
+const collectReviewStats = async ({
+  github,
+  owner,
+  repo,
+  config,
+  currentPullNumber,
+  now,
+}) => {
+  const reviewStats = createInitialReviewStats(config.reviewers)
+  const since = getLookbackIsoDate(config.lookbackDays, now)
+  const pullRequests = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: 'all',
+    sort: 'created',
+    direction: 'desc',
+    per_page: 100,
+  })
+
+  const recentPullRequests = pullRequests.filter((pullRequest) => {
+    return (
+      pullRequest.number !== currentPullNumber &&
+      new Date(pullRequest.created_at).toISOString() >= since
+    )
+  })
+
+  for (const pullRequest of recentPullRequests) {
+    for (const reviewer of pullRequest.requested_reviewers ?? []) {
+      addAssignment(reviewStats, reviewer.login)
+    }
+
+    const reviews = await github.paginate(github.rest.pulls.listReviews, {
+      owner,
+      repo,
+      pull_number: pullRequest.number,
+      per_page: 100,
+    })
+    const reviewedLogins = new Set()
+
+    const recentReviews = reviews.filter((review) => {
+      return (
+        review.submitted_at &&
+        new Date(review.submitted_at).toISOString() >= since
+      )
+    })
+
+    for (const review of recentReviews) {
+      const login = review.user?.login
+
+      if (login && !reviewedLogins.has(normalizeLogin(login))) {
+        addReview(reviewStats, login)
+        reviewedLogins.add(normalizeLogin(login))
+      }
+    }
+  }
+
+  return reviewStats
+}
+
+const assignReviewers = async ({ core, context, github }) => {
+  const pullRequest = context.payload.pull_request
+
+  if (!pullRequest) {
+    core.info('No pull request found in the event payload.')
+    return
+  }
+
+  const config = readReviewerConfig()
+  validateReviewerConfig(config)
+
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+  const reviewStats = await collectReviewStats({
+    github,
+    owner,
+    repo,
+    config,
+    currentPullNumber: pullRequest.number,
+  })
+  const reviewers = selectReviewers({
+    author: pullRequest.user.login,
+    config,
+    pullNumber: pullRequest.number,
+    reviewStats,
+  })
+  const reviewersToRemove = getReviewersToRemove({
+    config,
+    currentRequestedReviewers: pullRequest.requested_reviewers ?? [],
+    selectedReviewers: reviewers,
+  })
+  const reviewersToRequest = getReviewersToRequest({
+    currentRequestedReviewers: pullRequest.requested_reviewers ?? [],
+    selectedReviewers: reviewers,
+  })
+
+  if (reviewersToRemove.length > 0) {
+    await github.rest.pulls.removeRequestedReviewers({
+      owner,
+      repo,
+      pull_number: pullRequest.number,
+      reviewers: reviewersToRemove,
+    })
+  }
+
+  if (reviewersToRequest.length > 0) {
+    await github.rest.pulls.requestReviewers({
+      owner,
+      repo,
+      pull_number: pullRequest.number,
+      reviewers: reviewersToRequest,
+    })
+  }
+
+  core.info(`Requested reviewers: ${reviewers.join(', ')}`)
+}
+
+module.exports = {
+  addAssignment,
+  addReview,
+  assignReviewers,
+  collectReviewStats,
+  createInitialReviewStats,
+  getLookbackIsoDate,
+  getReviewersToRequest,
+  getReviewersToRemove,
+  getAssignmentPressureScore,
+  readReviewerConfig,
+  selectReviewers,
+  validateReviewerConfig,
+}

--- a/.github/scripts/assign-reviewers.test.cjs
+++ b/.github/scripts/assign-reviewers.test.cjs
@@ -1,0 +1,230 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  addAssignment,
+  addReview,
+  collectReviewStats,
+  createInitialReviewStats,
+  getAssignmentPressureScore,
+  getLookbackIsoDate,
+  getReviewersToRequest,
+  getReviewersToRemove,
+  selectReviewers,
+  validateReviewerConfig,
+} = require('./assign-reviewers.cjs')
+
+const createConfig = () => ({
+  lookbackDays: 30,
+  requiredReviewerCount: 2,
+  reviewers: [
+    { enabled: true, login: 'jyeon03', weight: 1 },
+    { enabled: true, login: 'chungyo', weight: 1 },
+    { enabled: true, login: 'gyeongbibin', weight: 1 },
+    { enabled: true, login: 'MinseoSONG', weight: 1 },
+    { enabled: true, login: 'yurimidaH', weight: 1 },
+  ],
+})
+
+test('validateReviewerConfig requires exactly 2 reviewers', () => {
+  const config = createConfig()
+
+  assert.doesNotThrow(() => validateReviewerConfig(config))
+
+  assert.throws(
+    () => validateReviewerConfig({ ...config, requiredReviewerCount: 3 }),
+    /requiredReviewerCount must be 2/,
+  )
+})
+
+test('validateReviewerConfig rejects duplicate reviewer logins', () => {
+  const config = createConfig()
+
+  config.reviewers.push({ enabled: true, login: 'JYEON03', weight: 1 })
+
+  assert.throws(
+    () => validateReviewerConfig(config),
+    /Duplicate reviewer login found: JYEON03/,
+  )
+})
+
+test('validateReviewerConfig rejects empty reviewer logins', () => {
+  const config = createConfig()
+
+  config.reviewers[0].login = ''
+
+  assert.throws(
+    () => validateReviewerConfig(config),
+    /reviewer login must not be empty/,
+  )
+})
+
+test('validateReviewerConfig rejects invalid reviewer weights', () => {
+  const config = createConfig()
+
+  config.reviewers[0].weight = 0
+
+  assert.throws(
+    () => validateReviewerConfig(config),
+    /Reviewer weight must be a positive number: jyeon03/,
+  )
+})
+
+test('collectReviewStats counts only reviews submitted within the lookback window', async () => {
+  const config = createConfig()
+  const github = {
+    rest: {
+      pulls: {
+        list: 'pulls.list',
+        listReviews: 'pulls.listReviews',
+      },
+    },
+    paginate: async (method, params) => {
+      if (method === 'pulls.list') {
+        return [
+          {
+            created_at: '2026-07-20T00:00:00.000Z',
+            number: 10,
+            requested_reviewers: [{ login: 'chungyo' }],
+          },
+        ]
+      }
+
+      if (method === 'pulls.listReviews') {
+        assert.equal(params.pull_number, 10)
+
+        return [
+          {
+            submitted_at: '2026-08-01T00:00:00.000Z',
+            user: { login: 'gyeongbibin' },
+          },
+          {
+            submitted_at: '2026-06-01T00:00:00.000Z',
+            user: { login: 'MinseoSONG' },
+          },
+        ]
+      }
+
+      return []
+    },
+  }
+
+  const reviewStats = await collectReviewStats({
+    github,
+    owner: 'TEAM-HASHI',
+    repo: 'HASHI-CLIENT',
+    config,
+    currentPullNumber: 11,
+    now: new Date('2026-08-06T00:00:00.000Z'),
+  })
+
+  assert.deepEqual(reviewStats.get('chungyo'), {
+    assignments: 1,
+    reviews: 0,
+  })
+  assert.deepEqual(reviewStats.get('gyeongbibin'), {
+    assignments: 0,
+    reviews: 1,
+  })
+  assert.deepEqual(reviewStats.get('minseosong'), {
+    assignments: 0,
+    reviews: 0,
+  })
+})
+
+test('selectReviewers excludes the PR author and always returns 2 reviewers', () => {
+  const config = createConfig()
+  const reviewStats = createInitialReviewStats(config.reviewers)
+
+  const reviewers = selectReviewers({
+    author: 'jyeon03',
+    config,
+    pullNumber: 12,
+    reviewStats,
+  })
+
+  assert.equal(reviewers.length, 2)
+  assert.ok(!reviewers.includes('jyeon03'))
+})
+
+test('selectReviewers prefers reviewers with fewer recent reviews and assignments', () => {
+  const config = createConfig()
+  const reviewStats = createInitialReviewStats(config.reviewers)
+
+  addAssignment(reviewStats, 'chungyo')
+  addReview(reviewStats, 'gyeongbibin')
+  addReview(reviewStats, 'MinseoSONG')
+  addAssignment(reviewStats, 'MinseoSONG')
+
+  const reviewers = selectReviewers({
+    author: 'jyeon03',
+    config,
+    pullNumber: 21,
+    reviewStats,
+  })
+
+  assert.deepEqual(new Set(reviewers), new Set(['yurimidaH', 'chungyo']))
+})
+
+test('selectReviewers ignores disabled reviewers', () => {
+  const config = createConfig()
+  const reviewStats = createInitialReviewStats(config.reviewers)
+
+  config.reviewers = config.reviewers.map((reviewer) =>
+    reviewer.login === 'yurimidaH' ? { ...reviewer, enabled: false } : reviewer,
+  )
+
+  const reviewers = selectReviewers({
+    author: 'jyeon03',
+    config,
+    pullNumber: 24,
+    reviewStats,
+  })
+
+  assert.equal(reviewers.length, 2)
+  assert.ok(!reviewers.includes('yurimidaH'))
+})
+
+test('getReviewersToRemove removes configured reviewers that were not selected', () => {
+  const config = createConfig()
+
+  assert.deepEqual(
+    getReviewersToRemove({
+      config,
+      currentRequestedReviewers: [
+        { login: 'chungyo' },
+        { login: 'gyeongbibin' },
+        { login: 'external-reviewer' },
+      ],
+      selectedReviewers: ['jyeon03', 'gyeongbibin'],
+    }),
+    ['chungyo'],
+  )
+})
+
+test('getReviewersToRequest skips reviewers that are already requested', () => {
+  assert.deepEqual(
+    getReviewersToRequest({
+      currentRequestedReviewers: [{ login: 'chungyo' }],
+      selectedReviewers: ['chungyo', 'gyeongbibin'],
+    }),
+    ['gyeongbibin'],
+  )
+})
+
+test('getAssignmentPressureScore applies weight to reduce assignment pressure for busy reviewers', () => {
+  const config = createConfig()
+  const reviewStats = createInitialReviewStats(config.reviewers)
+  const reviewer = { enabled: true, login: 'chungyo', weight: 0.5 }
+
+  addReview(reviewStats, 'chungyo')
+
+  assert.equal(getAssignmentPressureScore(reviewer, reviewStats), 2)
+})
+
+test('getLookbackIsoDate subtracts lookback days in UTC', () => {
+  assert.equal(
+    getLookbackIsoDate(30, new Date('2026-08-06T00:00:00.000Z')),
+    '2026-07-07T00:00:00.000Z',
+  )
+})

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,27 @@
+name: Auto Assign Reviewers
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assign-reviewers:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Assign reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { assignReviewers } = require('./.github/scripts/assign-reviewers.cjs')
+
+            await assignReviewers({ core, context, github })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,7 @@ export default tseslint.config(
   {
     files: [
       '.agents/scripts/**/*.{js,mjs}',
+      '.github/scripts/**/*.{js,cjs,mjs}',
       'apps/admin/scripts/**/*.{js,mjs}',
       'apps/client/scripts/**/*.{js,mjs}',
       'scripts/**/*.{js,mjs}',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck:admin": "pnpm --filter @hashi/admin typecheck",
     "storybook": "pnpm --filter @hashi/hds-ui storybook",
     "test": "turbo test --filter=@hashi/client --filter=@hashi/hds-ui",
+    "test:assign-reviewers": "node --test .github/scripts/assign-reviewers.test.cjs",
     "test:lighthouse-comment": "node --test .github/scripts/lighthouse-comment.test.cjs",
     "test:lighthouse-preview-validation": "node --test .github/scripts/lighthouse-preview-validation.test.cjs",
     "test:lighthouse": "pnpm test:lighthouse-comment && pnpm test:lighthouse-preview-validation",


### PR DESCRIPTION
## 📌 요약

> 팀원 모두가 리뷰를 많이 경험할 수 있도록 리뷰어 2명을 자동으로 공정 분배하는 워크플로우를 구현했습니다.

Jira: [HASHI-145](https://siksa.atlassian.net/browse/HASHI-145)

## 📚 작업 내용

- 기존 CODEOWNERS 기반 리뷰어 자동 할당 방식을 제거했습니다.
- PR 생성, ready for review, reopen 시 리뷰어를 자동 할당하는 GitHub Actions workflow를 추가했습니다.
- PR 작성자를 제외하고 항상 2명의 리뷰어가 지정되도록 자동 할당 로직을 구현했습니다.
- 최근 30일 안에 작성된 review 수와 리뷰어로 요청된 횟수를 기준으로 리뷰어를 선택하도록 정리했습니다.

## 🔎 상세 설명
**기존 CODEOWNERS의 hashi-client을 할당하는 방식에서는 팀원별 리뷰 참여도를 기준으로 공정하게 리뷰어를 분배하기에는 한계가 있었습니다.**

`리뷰어 할당 기준`

- PR 작성자는 리뷰어 후보에서 제외합니다.
- 비활성화된 reviewer는 후보에서 제외합니다.
- 최근 30일 안에 작성한 review 수를 집계합니다.
- 최근 30일 안에 reviewer로 요청된 횟수를 함께 집계합니다.
- 집계된 부담도가 낮은 팀원을 우선 선택합니다.
- 최종적으로 2명의 reviewer만 지정되도록 처리합니다.
- 동점인 경우 PR 번호 기반 tie-breaker를 사용해 선택 결과가 안정적으로 나오도록 했습니다.

리뷰어 목록은 `.github/reviewer-assignment.json`에서 관리합니다.  
추가로 팀원 일정이나 리뷰 참여도에 따라 reviewer 활성화 여부나 weight 값을 조정할 수 있습니다.

## 💭 고민한 부분

- CODEOWNERS를 유지할지, GitHub Actions로 직접 reviewer를 계산할지 고민했습니다.
- 팀 전체를 reviewer로 지정하는 방식도 가능하지만 이 경우 실제 리뷰 참여가 특정 사람에게 몰릴 수 있어 공정 분배 목적과 맞지 않다고 판단했습니다.
- 리뷰어 자동 할당은 눈으로 바로 확인하기 어려운 자동화 로직이라, 테스트 코드를 함께 추가했습니다.

### 고민한 문제

- PR마다 reviewer를 무조건 2명씩 지정해야 했습니다.
- PR 작성자는 reviewer에서 제외되어야 했습니다.
- 리뷰를 많이 한 사람에게 계속 리뷰가 몰리지 않도록 해야 했습니다.
- 팀원 전체 지정 방식에서는 리뷰를 자주 하는 사람만 계속 리뷰하게 되는 문제가 있었습니다.

### 고려한 선택지

- `CODEOWNERS` 유지
- GitHub team 전체를 reviewer로 지정
- GitHub Actions에서 reviewer를 직접 계산해 요청

### 최종 선택과 이유
> GitHub Actions에서 reviewer를 직접 계산해 요청하는 방식을 선택했습니다.

- 최근 review 수, reviewer 요청 횟수, PR 작성자 제외, reviewer 수 제한 같은 정책을 코드로 명확하게 제어할 수 있습니다.  
- 또한 리뷰어 목록을 config 파일로 분리해두어, 이후 한 달 단위로 리뷰 참여도를 확인한 뒤 weight나 활성화 여부를 조정하기 쉽다고 판단했습니다.

### 남은 고민
- 한 달 정도 운영한 뒤 실제 리뷰어별 리뷰 수를 보고 weight 적용 기준을 조정하면 좋을 것 같습니다.
