### PR TITLE
Refactor(client): HASHI-154 Auth restore non-blocking route 정책 분리

### DIFF
--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -1,12 +1,7 @@
 import { RouterProvider } from 'react-router-dom'
 
-import { AuthSessionRestoreGate } from '@/app/providers/AuthSessionRestoreGate'
 import { router } from '@/app/router'
 
 export const App = () => {
-  return (
-    <AuthSessionRestoreGate>
-      <RouterProvider router={router} />
-    </AuthSessionRestoreGate>
-  )
+  return <RouterProvider router={router} />
 }

--- a/apps/client/src/app/layout/RootLayout.test.tsx
+++ b/apps/client/src/app/layout/RootLayout.test.tsx
@@ -6,30 +6,40 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RootLayout } from '@/app/layout/RootLayout'
 
-const { mockAsyncBoundary, mockToastRegion, mockTrackPageView } = vi.hoisted(
-  () => ({
-    mockAsyncBoundary: vi.fn(
-      ({
-        children,
-        resetKeys,
-      }: {
-        children: ReactNode
-        resetKeys?: unknown[]
-      }) => (
-        <div
-          data-testid="async-boundary"
-          data-reset-key={String(resetKeys?.[0] ?? '')}
-        >
-          {children}
-        </div>
-      ),
+const {
+  mockAsyncBoundary,
+  mockAuthSessionRestoreGate,
+  mockToastRegion,
+  mockTrackPageView,
+} = vi.hoisted(() => ({
+  mockAsyncBoundary: vi.fn(
+    ({
+      children,
+      resetKeys,
+    }: {
+      children: ReactNode
+      resetKeys?: unknown[]
+    }) => (
+      <div
+        data-testid="async-boundary"
+        data-reset-key={String(resetKeys?.[0] ?? '')}
+      >
+        {children}
+      </div>
     ),
-    mockToastRegion: vi.fn(({ className }: { className?: string }) => (
-      <div data-testid="toast-region" data-class-name={className} />
-    )),
-    mockTrackPageView: vi.fn(),
-  }),
-)
+  ),
+  mockAuthSessionRestoreGate: vi.fn(
+    ({ children, pathname }: { children: ReactNode; pathname?: string }) => (
+      <div data-pathname={pathname} data-testid="auth-session-restore-gate">
+        {children}
+      </div>
+    ),
+  ),
+  mockToastRegion: vi.fn(({ className }: { className?: string }) => (
+    <div data-testid="toast-region" data-class-name={className} />
+  )),
+  mockTrackPageView: vi.fn(),
+}))
 const { mockLocationStore, mockScrollTo } = vi.hoisted(() => ({
   mockLocationStore: {
     hash: '',
@@ -45,6 +55,10 @@ vi.mock('@hashi/hds-ui', () => ({
 
 vi.mock('@/app/providers/AsyncBoundary', () => ({
   default: mockAsyncBoundary,
+}))
+
+vi.mock('@/app/providers/AuthSessionRestoreGate', () => ({
+  AuthSessionRestoreGate: mockAuthSessionRestoreGate,
 }))
 
 vi.mock('@/shared/lib/analytics', () => ({
@@ -65,6 +79,7 @@ describe('RootLayout', () => {
     cleanup()
     vi.unstubAllGlobals()
     mockAsyncBoundary.mockClear()
+    mockAuthSessionRestoreGate.mockClear()
     mockToastRegion.mockClear()
     mockScrollTo.mockClear()
     mockTrackPageView.mockClear()
@@ -86,11 +101,30 @@ describe('RootLayout', () => {
     render(<RootLayout />)
 
     const boundary = screen.getByTestId('async-boundary')
+    const authGate = screen.getByTestId('auth-session-restore-gate')
     const outlet = screen.getByTestId('route-outlet')
     const toastRegion = screen.getByTestId('toast-region')
 
-    expect(boundary).toContainElement(outlet)
+    expect(boundary).toContainElement(authGate)
+    expect(authGate).toContainElement(outlet)
     expect(boundary).not.toContainElement(toastRegion)
+  })
+
+  it('passes the current pathname to AuthSessionRestoreGate', () => {
+    const { rerender } = render(<RootLayout />)
+
+    expect(screen.getByTestId('auth-session-restore-gate')).toHaveAttribute(
+      'data-pathname',
+      '/',
+    )
+
+    mockLocationStore.pathname = '/restaurants/restaurant-1'
+    rerender(<RootLayout />)
+
+    expect(screen.getByTestId('auth-session-restore-gate')).toHaveAttribute(
+      'data-pathname',
+      '/restaurants/restaurant-1',
+    )
   })
 
   it('scrolls to the top when the route pathname changes', () => {

--- a/apps/client/src/app/layout/RootLayout.tsx
+++ b/apps/client/src/app/layout/RootLayout.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 
 import AsyncBoundary from '@/app/providers/AsyncBoundary'
+import { AuthSessionRestoreGate } from '@/app/providers/AuthSessionRestoreGate'
 import { trackPageView } from '@/shared/lib/analytics'
 
 export const RootLayout = () => {
@@ -21,7 +22,9 @@ export const RootLayout = () => {
     <>
       <main className="app-mobile-frame min-h-dvh bg-white">
         <AsyncBoundary resetKeys={[pathname]}>
-          <Outlet />
+          <AuthSessionRestoreGate pathname={pathname}>
+            <Outlet />
+          </AuthSessionRestoreGate>
         </AsyncBoundary>
       </main>
       <ToastRegion className="z-toast fixed inset-x-0 top-0 mx-auto w-full max-w-[var(--app-mobile-max-width,100%)] px-5 pt-[calc(32px+var(--safe-area-top,0px))]" />

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
@@ -108,28 +108,34 @@ describe('AuthSessionRestoreGate', () => {
     expect(getAuthSessionStatus()).toBe('onboarding')
   })
 
-  it('renders public restaurant list routes while auth restore runs in the background', async () => {
-    mockedRequestTokenReissue.mockResolvedValue({
-      accessToken: 'restored-access-token',
-    })
-    window.history.pushState({}, '', ROUTES.hashiPickRestaurants)
+  it.each([
+    [ROUTES.hashiPickRestaurants, '하시픽 화면'],
+    [ROUTES.popularRestaurants, '인기 식당 화면'],
+  ])(
+    'renders %s while auth restore runs in the background',
+    async (pathname, screenText) => {
+      mockedRequestTokenReissue.mockResolvedValue({
+        accessToken: 'restored-access-token',
+      })
+      window.history.pushState({}, '', pathname)
 
-    render(
-      <AuthSessionRestoreGate>
-        <div>하시픽 화면</div>
-      </AuthSessionRestoreGate>,
-    )
+      render(
+        <AuthSessionRestoreGate>
+          <div>{screenText}</div>
+        </AuthSessionRestoreGate>,
+      )
 
-    expect(screen.getByText('하시픽 화면')).toBeInTheDocument()
-    expect(
-      screen.queryByText('로그인 상태를 확인하고 있어요'),
-    ).not.toBeInTheDocument()
+      expect(screen.getByText(screenText)).toBeInTheDocument()
+      expect(
+        screen.queryByText('로그인 상태를 확인하고 있어요'),
+      ).not.toBeInTheDocument()
 
-    await waitFor(() => {
-      expect(getAccessToken()).toBe('restored-access-token')
-    })
-    expect(mockedRequestTokenReissue).toHaveBeenCalledTimes(1)
-  })
+      await waitFor(() => {
+        expect(getAccessToken()).toBe('restored-access-token')
+      })
+      expect(mockedRequestTokenReissue).toHaveBeenCalledTimes(1)
+    },
+  )
 
   it('does not authenticate an admin session in the user client', async () => {
     mockedRequestTokenReissue.mockResolvedValue({

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
@@ -134,6 +134,38 @@ describe('AuthSessionRestoreGate', () => {
     },
   )
 
+  it('rechecks the current route while auth restore is still running', async () => {
+    let resolveReissue: (
+      value: Awaited<ReturnType<typeof requestTokenReissue>>,
+    ) => void = () => {}
+    mockedRequestTokenReissue.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReissue = resolve
+      }),
+    )
+
+    const { rerender } = render(
+      <AuthSessionRestoreGate pathname={ROUTES.hashiPickRestaurants}>
+        <div>route screen</div>
+      </AuthSessionRestoreGate>,
+    )
+
+    expect(screen.getByText('route screen')).toBeInTheDocument()
+
+    rerender(
+      <AuthSessionRestoreGate pathname={ROUTES.restaurantDetail}>
+        <div>route screen</div>
+      </AuthSessionRestoreGate>,
+    )
+
+    expect(screen.queryByText('route screen')).not.toBeInTheDocument()
+
+    resolveReissue({ accessToken: 'restored-access-token' })
+    await waitFor(() => {
+      expect(getAccessToken()).toBe('restored-access-token')
+    })
+  })
+
   it('does not authenticate an admin session in the user client', async () => {
     mockedRequestTokenReissue.mockResolvedValue({
       accessToken: 'admin-access-token',

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.test.tsx
@@ -126,9 +126,6 @@ describe('AuthSessionRestoreGate', () => {
       )
 
       expect(screen.getByText(screenText)).toBeInTheDocument()
-      expect(
-        screen.queryByText('로그인 상태를 확인하고 있어요'),
-      ).not.toBeInTheDocument()
 
       await waitFor(() => {
         expect(getAccessToken()).toBe('restored-access-token')

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
@@ -13,6 +13,7 @@ import { getApiAccessToken } from '@/shared/api/accessToken'
 
 interface AuthSessionRestoreGateProps {
   children: ReactNode
+  pathname?: string
 }
 
 let authSessionRestorePromise: Promise<void> | undefined
@@ -79,12 +80,16 @@ const restoreAuthSession = async () => {
 
 export const AuthSessionRestoreGate = ({
   children,
+  pathname,
 }: AuthSessionRestoreGateProps) => {
-  const [isRestoreCompleted, setIsRestoreCompleted] = useState(
-    () =>
-      Boolean(getAccessToken()) ||
-      getShouldRenderDuringAuthRestore(getCurrentPathname()),
+  const [isRestoreCompleted, setIsRestoreCompleted] = useState(() =>
+    Boolean(getAccessToken()),
   )
+  const currentPathname = pathname ?? getCurrentPathname()
+  const shouldRenderChildren =
+    isRestoreCompleted ||
+    Boolean(getAccessToken()) ||
+    getShouldRenderDuringAuthRestore(currentPathname)
 
   useEffect(() => {
     if (getAccessToken()) {
@@ -112,7 +117,7 @@ export const AuthSessionRestoreGate = ({
     }
   }, [])
 
-  if (!isRestoreCompleted) {
+  if (!shouldRenderChildren) {
     return null
   }
 

--- a/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
+++ b/apps/client/src/app/providers/AuthSessionRestoreGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 
-import { ROUTES } from '@/app/router/path'
+import { getShouldRenderDuringAuthRestore } from '@/app/providers/authSessionRestorePolicy'
 import { getAuthMe } from '@/features/auth/api/getAuthMe'
 import { requestTokenReissue } from '@/features/auth/api/reissueToken'
 import {
@@ -17,17 +17,12 @@ interface AuthSessionRestoreGateProps {
 
 let authSessionRestorePromise: Promise<void> | undefined
 
-const AUTH_RESTORE_NON_BLOCKING_PATHS = new Set<string>([
-  ROUTES.hashiPickRestaurants,
-  ROUTES.popularRestaurants,
-])
-
-const getShouldRenderDuringAuthRestore = () => {
+const getCurrentPathname = () => {
   if (typeof window === 'undefined') {
-    return false
+    return undefined
   }
 
-  return AUTH_RESTORE_NON_BLOCKING_PATHS.has(window.location.pathname)
+  return window.location.pathname
 }
 
 const restoreUserSession = async (accessToken: string) => {
@@ -86,7 +81,9 @@ export const AuthSessionRestoreGate = ({
   children,
 }: AuthSessionRestoreGateProps) => {
   const [isRestoreCompleted, setIsRestoreCompleted] = useState(
-    () => Boolean(getAccessToken()) || getShouldRenderDuringAuthRestore(),
+    () =>
+      Boolean(getAccessToken()) ||
+      getShouldRenderDuringAuthRestore(getCurrentPathname()),
   )
 
   useEffect(() => {

--- a/apps/client/src/app/providers/authSessionRestorePolicy.ts
+++ b/apps/client/src/app/providers/authSessionRestorePolicy.ts
@@ -1,0 +1,16 @@
+import { ROUTES } from '@/app/router/path'
+
+const AUTH_RESTORE_NON_BLOCKING_PATHS = new Set<string>([
+  ROUTES.hashiPickRestaurants,
+  ROUTES.popularRestaurants,
+])
+
+export const getShouldRenderDuringAuthRestore = (
+  pathname: string | undefined,
+) => {
+  if (!pathname) {
+    return false
+  }
+
+  return AUTH_RESTORE_NON_BLOCKING_PATHS.has(pathname)
+}

--- a/apps/client/src/app/providers/authSessionRestorePolicy.ts
+++ b/apps/client/src/app/providers/authSessionRestorePolicy.ts
@@ -1,5 +1,7 @@
 import { ROUTES } from '@/app/router/path'
 
+// 로그인 없이 접근 가능한 public route 전체가 아니라, auth restore 완료 전에도
+// 먼저 렌더링해도 잘못된 인증 상태 UI가 노출될 위험이 낮은 route만 포함한다.
 const AUTH_RESTORE_NON_BLOCKING_PATHS = new Set<string>([
   ROUTES.hashiPickRestaurants,
   ROUTES.popularRestaurants,

--- a/apps/client/src/app/router/lazy.test.tsx
+++ b/apps/client/src/app/router/lazy.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { act, cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -12,6 +13,10 @@ vi.mock('@/shared/hooks/useAuthStatus', () => ({
     isAuthenticated,
     status: isAuthenticated ? 'authenticated' : 'unauthenticated',
   }),
+}))
+
+vi.mock('@/app/providers/AuthSessionRestoreGate', () => ({
+  AuthSessionRestoreGate: ({ children }: { children: ReactNode }) => children,
 }))
 
 vi.mock('@/features/magazine/api/getMagazineBanners', () => ({


### PR DESCRIPTION
## 📌 요약

> Auth restore 중 먼저 렌더링해도 되는 non-blocking route 정책을 provider에서 분리했습니다.

Jira: HASHI-154

## 📚 작업 내용

- `AuthSessionRestoreGate` 내부에 있던 non-blocking route 목록을 `authSessionRestorePolicy.ts`로 분리했습니다.
- `AuthSessionRestoreGate`는 현재 pathname을 읽고, 렌더링 정책 판단은 별도 정책 함수에 위임하도록 정리했습니다.
- 하시픽/인기 식당 route가 auth restore 중에도 먼저 렌더링되는지 테스트를 보강했습니다.

## 🔎 상세 설명

기존 `AuthSessionRestoreGate`는 세션 복원 책임과 route별 렌더링 정책 책임을 함께 가지고 있었습니다.

이번 리팩토링에서는 non-blocking route 목록과 판단 로직을 `authSessionRestorePolicy.ts`로 분리해 provider가 세션 복원 흐름에 더 집중할 수 있도록 했습니다.

동작 자체는 변경하지 않았고, 기존에 public restaurant list 성격으로 먼저 렌더링하던 하시픽/인기 식당 route 정책을 그대로 유지했습니다.

검증:

- `pnpm --filter @hashi/client exec vitest run src/app/providers/AuthSessionRestoreGate.test.tsx`
- `pnpm typecheck:client`

## 💭 고민한 부분

### 고민한 문제

- provider 안에 auth restore 흐름과 route 정책이 함께 있어 새 non-blocking route를 추가할 때 기준을 놓치기 쉬운 구조였습니다.

### 고려한 선택지

- `app/providers` 하위에 auth restore 정책 파일을 분리하는 방식
- `features/auth/session` 하위에 auth 정책 파일을 분리하는 방식
- router meta 형태로 route별 auth restore 정책을 관리하는 방식

### 최종 선택과 이유

- 현재 변경 범위에서는 `app/providers/authSessionRestorePolicy.ts`로 분리하는 방식을 선택했습니다.
- non-blocking 여부는 auth token 자체보다 app route 렌더링 정책에 가까워 provider 근처에 두는 편이 현재 구조와 가장 잘 맞다고 판단했습니다.
- router meta 방식은 장기적으로 확장성은 있지만, 이번 티켓 범위에서는 구조 변경이 커질 수 있어 제외했습니다.

### 남은 고민

- non-blocking route가 더 많아지면 route meta 기반 정책 관리로 확장할지 다시 검토할 수 있습니다.
