### PR TITLE
Refactor(client): HASHI-155 식당 상세 시간 의존 로직 개선

### DIFF
--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RestaurantStoreInformation } from '@/features/restaurantDetail/api/getRestaurantStoreInformation'
+import type { RestaurantSummary } from '@/features/restaurantDetail/api/getRestaurantSummary'
+import { createRestaurantDetailViewModel } from '@/features/restaurantDetail/utils/createRestaurantDetailViewModel'
+
+const restaurantSummary: RestaurantSummary = {
+  restaurantId: 10,
+  name: '하시 식당',
+  localName: 'Hashi Restaurant',
+  address: '도쿄도 시부야구',
+  imageUrls: ['https://example.com/restaurant.webp'],
+  reservationFee: 4000,
+  rating: 4.5,
+  reviewCount: 12,
+  summary: '테스트 식당입니다.',
+}
+
+const storeInformation: RestaurantStoreInformation = {
+  restaurantId: 10,
+  description: '매장 설명',
+  businessHours: [
+    {
+      dayOfWeek: 'MONDAY',
+      openTime: '11:00',
+      closeTime: '21:00',
+      breakStart: '15:00',
+      breakEnd: '17:00',
+      closed: false,
+    },
+    {
+      dayOfWeek: 'TUESDAY',
+      openTime: '12:00',
+      closeTime: '20:00',
+      closed: false,
+    },
+  ],
+  priceRange: {
+    currency: 'JPY',
+    minPrice: 1000,
+    maxPrice: 3000,
+  },
+}
+
+describe('createRestaurantDetailViewModel', () => {
+  it('uses the injected date for today business hours and last order time', () => {
+    const restaurant = createRestaurantDetailViewModel({
+      summary: restaurantSummary,
+      storeInformation,
+      menus: [],
+      reviews: [],
+      now: new Date('2026-08-17T09:00:00+09:00'),
+    })
+
+    expect(restaurant.businessHoursSummary).toBe('8/17 (월) 11:00 ~ 21:00')
+    expect(restaurant.lastOrderTime).toBe('21:00')
+  })
+
+  it('changes today business hours from the injected date instead of the real current date', () => {
+    const restaurant = createRestaurantDetailViewModel({
+      summary: restaurantSummary,
+      storeInformation,
+      menus: [],
+      reviews: [],
+      now: new Date('2026-08-18T09:00:00+09:00'),
+    })
+
+    expect(restaurant.businessHoursSummary).toBe('8/18 (화) 12:00 ~ 20:00')
+    expect(restaurant.lastOrderTime).toBe('20:00')
+  })
+
+  it('uses the injected date for closed day summary', () => {
+    const restaurant = createRestaurantDetailViewModel({
+      summary: restaurantSummary,
+      storeInformation: {
+        ...storeInformation,
+        businessHours: [
+          {
+            dayOfWeek: 'MONDAY',
+            closed: true,
+          },
+        ],
+      },
+      menus: [],
+      reviews: [],
+      now: new Date('2026-08-17T09:00:00+09:00'),
+    })
+
+    expect(restaurant.businessHoursSummary).toBe('8/17 (월) 휴무')
+    expect(restaurant.lastOrderTime).toBe('영업시간 정보 없음')
+  })
+})

--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts
@@ -49,7 +49,7 @@ describe('createRestaurantDetailViewModel', () => {
       storeInformation,
       menus: [],
       reviews: [],
-      now: new Date('2026-08-17T09:00:00+09:00'),
+      now: new Date(2026, 7, 17, 9, 0, 0),
     })
 
     expect(restaurant.businessHoursSummary).toBe('8/17 (월) 11:00 ~ 21:00')
@@ -62,7 +62,7 @@ describe('createRestaurantDetailViewModel', () => {
       storeInformation,
       menus: [],
       reviews: [],
-      now: new Date('2026-08-18T09:00:00+09:00'),
+      now: new Date(2026, 7, 18, 9, 0, 0),
     })
 
     expect(restaurant.businessHoursSummary).toBe('8/18 (화) 12:00 ~ 20:00')
@@ -77,13 +77,14 @@ describe('createRestaurantDetailViewModel', () => {
         businessHours: [
           {
             dayOfWeek: 'MONDAY',
+            closeTime: '21:00',
             closed: true,
           },
         ],
       },
       menus: [],
       reviews: [],
-      now: new Date('2026-08-17T09:00:00+09:00'),
+      now: new Date(2026, 7, 17, 9, 0, 0),
     })
 
     expect(restaurant.businessHoursSummary).toBe('8/17 (월) 휴무')

--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts
@@ -90,4 +90,26 @@ describe('createRestaurantDetailViewModel', () => {
     expect(restaurant.businessHoursSummary).toBe('8/17 (월) 휴무')
     expect(restaurant.lastOrderTime).toBe('영업시간 정보 없음')
   })
+
+  it('keeps business hours summary and last order unavailable when open time is missing', () => {
+    const restaurant = createRestaurantDetailViewModel({
+      summary: restaurantSummary,
+      storeInformation: {
+        ...storeInformation,
+        businessHours: [
+          {
+            dayOfWeek: 'MONDAY',
+            closeTime: '21:00',
+            closed: false,
+          },
+        ],
+      },
+      menus: [],
+      reviews: [],
+      now: new Date(2026, 7, 17, 9, 0, 0),
+    })
+
+    expect(restaurant.businessHoursSummary).toBe('8/17 (월) 휴무')
+    expect(restaurant.lastOrderTime).toBe('영업시간 정보 없음')
+  })
 })

--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
@@ -29,6 +29,10 @@ const API_DAY_BY_DATE_DAY = [
 ] as const
 
 type BusinessHoursViewModel = RestaurantDetail['businessHours'][number]
+type OpenBusinessHours = RestaurantStoreInformation['businessHours'][number] & {
+  closeTime: string
+  openTime: string
+}
 
 const formatNumber = (value: number) => value.toLocaleString('ko-KR')
 
@@ -68,6 +72,11 @@ const formatBusinessHours = (
     : null
 }
 
+const hasOpenBusinessHours = (
+  hours: RestaurantStoreInformation['businessHours'][number] | undefined,
+): hours is OpenBusinessHours =>
+  Boolean(hours && !hours.closed && hours.openTime && hours.closeTime)
+
 const formatBusinessHoursSummary = (
   businessHours: RestaurantStoreInformation['businessHours'],
   now: Date,
@@ -78,12 +87,7 @@ const formatBusinessHoursSummary = (
   )
   const dateLabel = formatDateLabel(now)
 
-  if (
-    !todayHours ||
-    todayHours.closed ||
-    !todayHours.openTime ||
-    !todayHours.closeTime
-  ) {
+  if (!hasOpenBusinessHours(todayHours)) {
     return `${dateLabel} 휴무`
   }
 
@@ -99,7 +103,7 @@ const formatLastOrderTime = (
     (hours) => normalizeDayOfWeek(hours.dayOfWeek) === todayApiDay,
   )
 
-  if (!todayHours || todayHours.closed || !todayHours.closeTime) {
+  if (!hasOpenBusinessHours(todayHours)) {
     return '영업시간 정보 없음'
   }
 

--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
@@ -99,6 +99,10 @@ const formatLastOrderTime = (
     (hours) => normalizeDayOfWeek(hours.dayOfWeek) === todayApiDay,
   )
 
+  if (todayHours?.closed) {
+    return '영업시간 정보 없음'
+  }
+
   return todayHours?.closeTime ?? '영업시간 정보 없음'
 }
 

--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
@@ -70,13 +70,13 @@ const formatBusinessHours = (
 
 const formatBusinessHoursSummary = (
   businessHours: RestaurantStoreInformation['businessHours'],
+  now: Date,
 ) => {
-  const today = new Date()
-  const todayApiDay = API_DAY_BY_DATE_DAY[today.getDay()]
+  const todayApiDay = API_DAY_BY_DATE_DAY[now.getDay()]
   const todayHours = businessHours.find(
     (hours) => normalizeDayOfWeek(hours.dayOfWeek) === todayApiDay,
   )
-  const dateLabel = formatDateLabel(today)
+  const dateLabel = formatDateLabel(now)
 
   if (
     !todayHours ||
@@ -92,8 +92,9 @@ const formatBusinessHoursSummary = (
 
 const formatLastOrderTime = (
   businessHours: RestaurantStoreInformation['businessHours'],
+  now: Date,
 ) => {
-  const todayApiDay = API_DAY_BY_DATE_DAY[new Date().getDay()]
+  const todayApiDay = API_DAY_BY_DATE_DAY[now.getDay()]
   const todayHours = businessHours.find(
     (hours) => normalizeDayOfWeek(hours.dayOfWeek) === todayApiDay,
   )
@@ -197,6 +198,7 @@ interface CreateRestaurantDetailViewModelParams {
   averageRating?: number
   reviewCount?: number
   ratingDistribution?: RatingDistributionResponse
+  now?: Date
 }
 
 export const createRestaurantDetailViewModel = ({
@@ -207,6 +209,7 @@ export const createRestaurantDetailViewModel = ({
   averageRating,
   reviewCount,
   ratingDistribution,
+  now = new Date(),
 }: CreateRestaurantDetailViewModelParams): RestaurantDetail => {
   const businessHours = storeInformation.businessHours.reduce<
     RestaurantDetail['businessHours']
@@ -232,10 +235,11 @@ export const createRestaurantDetailViewModel = ({
     address: summary.address,
     businessHoursSummary: formatBusinessHoursSummary(
       storeInformation.businessHours,
+      now,
     ),
     deposit: formatWon(summary.reservationFee),
     detailDescription: storeInformation.description ?? summary.summary ?? '',
-    lastOrderTime: formatLastOrderTime(storeInformation.businessHours),
+    lastOrderTime: formatLastOrderTime(storeInformation.businessHours, now),
     businessHours,
     priceRange: formatPriceRange(storeInformation.priceRange),
     heroImages: summary.imageUrls,

--- a/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
+++ b/apps/client/src/features/restaurantDetail/utils/createRestaurantDetailViewModel.ts
@@ -99,11 +99,11 @@ const formatLastOrderTime = (
     (hours) => normalizeDayOfWeek(hours.dayOfWeek) === todayApiDay,
   )
 
-  if (todayHours?.closed) {
+  if (!todayHours || todayHours.closed || !todayHours.closeTime) {
     return '영업시간 정보 없음'
   }
 
-  return todayHours?.closeTime ?? '영업시간 정보 없음'
+  return todayHours.closeTime
 }
 
 const formatPriceRange = (


### PR DESCRIPTION
## 📌 요약

> 식당 상세 view model의 현재 시간 의존 로직을 테스트 가능한 구조로 개선했습니다.

Jira: HASHI-155

## 📚 작업 내용

- `createRestaurantDetailViewModel`에 `now`를 선택적으로 주입할 수 있도록 변경했습니다.
- 영업시간 요약과 라스트오더 계산 로직이 직접 `new Date()`를 호출하지 않고 동일한 기준 날짜를 사용하도록 정리했습니다.
- 고정 날짜를 주입해 월요일/화요일/휴무일 결과를 검증하는 view model 테스트를 추가했습니다.

## 🔎 상세 설명

기존에는 식당 상세 view model 내부에서 현재 날짜를 직접 생성해 오늘 영업시간과 라스트오더를 계산했습니다.

이 구조는 실행 날짜에 따라 결과가 달라질 수 있어 테스트가 불안정해질 수 있었습니다. 이번 리팩토링에서는 `createRestaurantDetailViewModel`이 `now`를 선택적으로 받을 수 있게 하고, 실제 화면에서는 기존처럼 기본값 `new Date()`를 사용하도록 유지했습니다.

따라서 사용자에게 보이는 동작은 그대로 유지하면서, 테스트에서는 고정된 날짜를 주입해 날짜 의존 결과를 안정적으로 검증할 수 있습니다.

검증:

- `pnpm --filter @hashi/client exec vitest run src/features/restaurantDetail/utils/createRestaurantDetailViewModel.test.ts src/pages/restaurantDetail/RestaurantDetailPage.test.tsx src/pages/todayRestaurant/TodayRestaurantPage.test.tsx`
- `pnpm typecheck:client`

## 💭 고민한 부분

### 고민한 문제

- view model 내부에서 `new Date()`를 직접 호출하면 오늘 날짜에 따라 영업시간 요약과 라스트오더 결과가 달라져 테스트 안정성이 떨어질 수 있었습니다.

### 고려한 선택지

- `createRestaurantDetailViewModel`에 `now`를 선택적으로 주입하는 방식
- 날짜 helper를 별도 파일로 분리하는 방식
- 테스트에서 fake timer만 사용하는 방식

### 최종 선택과 이유

- 변경 범위가 가장 작고 기존 호출부에 영향을 주지 않는 `now` 선택 주입 방식을 선택했습니다.
- 날짜 helper 분리는 아직 재사용 범위가 식당 상세 view model에 한정되어 있어 과하다고 판단했습니다.
- fake timer만 사용하는 방식은 production 코드의 시간 의존성을 그대로 남기기 때문에 이번 리팩토링 목적과 맞지 않다고 판단했습니다.

### 남은 고민

- 식당 상세 외 다른 도메인에서도 현재 시간 의존 로직이 늘어나면 공통 date helper 또는 clock provider 도입을 검토할 수 있습니다.
