### PR TITLE
Refactor(client): HASHI-157 식당 상세 공통 액션 로직 분리

### DIFF
--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.spec.md
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.spec.md
@@ -1,0 +1,138 @@
+# Hook Spec: `useRestaurantDetailActions`
+
+## Purpose
+
+`RestaurantDetailPage`와 `TodayRestaurantPage`가 공유하는 식당 상세 액션 흐름을 캡슐화한다.
+인증이 필요한 액션의 auth gate 상태, 카카오 로그인 시작, 예약 이동, 메뉴 상세 이동,
+현재 준비 중인 좋아요 액션의 coming soon 상태를 한 곳에서 관리한다.
+
+## Hook Type
+
+- [ ] app shared hook
+- [x] feature hook
+- [ ] page-local hook
+- [ ] data fetching hook
+- [x] form or interaction hook
+
+## Spec Location
+
+- spec path: `apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.spec.md`
+- implementation path: `apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.ts`
+
+## Usage
+
+- 사용 위치:
+  - `apps/client/src/pages/restaurantDetail/RestaurantDetailPage.tsx`
+  - `apps/client/src/pages/todayRestaurant/TodayRestaurantPage.tsx`
+- 이 hook을 사용하는 page가 직접 담당하지 않아도 되는 책임:
+  - 좋아요/예약 클릭 시 인증 필요 여부 판단
+  - auth gate bottom sheet open 상태 관리
+  - coming soon dialog open 상태 관리
+  - 카카오 OAuth 시작 시 현재 location 기반 redirect path 전달
+  - 식당 예약 생성 route 이동
+  - 메뉴 상세 route 이동과 menu detail source state 전달
+
+## Inputs
+
+### `restaurantId`
+
+- type: `string`
+- required: `true`
+- description: 예약 route와 메뉴 상세 route를 생성할 때 사용하는 식당 id.
+
+### `menuDetailSource`
+
+- type: `RestaurantMenuDetailSource`
+- required: `true`
+- description: 메뉴 상세 화면이 이전 상세 화면 종류를 복원할 수 있도록 route state에 전달하는 source 값.
+
+## Return Shape
+
+```ts
+const {
+  isAuthGateOpen,
+  isComingSoonOpen,
+  onAuthGateOpenChange,
+  onComingSoonOpenChange,
+  onPressKakao,
+  onPressLike,
+  onPressMenuItem,
+  onPressReservation,
+} = useRestaurantDetailActions({
+  menuDetailSource,
+  restaurantId,
+})
+```
+
+### `state`
+
+- `isAuthGateOpen`: 인증이 필요한 액션에서 로그인 유도 bottom sheet가 열려 있는지 나타낸다.
+- `isComingSoonOpen`: 현재 준비 중인 액션 안내 dialog가 열려 있는지 나타낸다.
+
+### `action`
+
+- `onAuthGateOpenChange`: auth gate bottom sheet open 상태를 외부 UI와 동기화한다.
+- `onComingSoonOpenChange`: coming soon dialog open 상태를 외부 UI와 동기화한다.
+- `onPressKakao`: 현재 location을 redirect path로 보존한 뒤 Kakao OAuth를 시작한다.
+- `onPressLike`: 인증 전에는 auth gate를 열고, 인증 후에는 coming soon dialog를 연다.
+- `onPressMenuItem`: 선택한 메뉴의 상세 route로 이동하고 source state를 전달한다.
+- `onPressReservation`: 인증 전에는 auth gate를 열고, 인증 후에는 식당 예약 생성 route로 이동한다.
+
+## Behavior
+
+1. hook 초기화 시 `useAuthStatus`, `useKakaoOAuthStart`, router navigate/location을 준비한다.
+2. 사용자가 좋아요를 누르면 인증 여부를 확인한다.
+3. 인증되지 않은 상태라면 auth gate bottom sheet를 연다.
+4. 인증된 상태라면 좋아요 기능이 아직 준비 중이므로 coming soon dialog를 연다.
+5. 사용자가 예약하기를 누르면 인증되지 않은 상태에서는 auth gate를 열고, 인증된 상태에서는 예약 생성 route로 이동한다.
+6. 사용자가 메뉴를 누르면 인증 여부와 무관하게 메뉴 상세 route로 이동하고 `menuDetailSource`를 route state로 전달한다.
+7. 사용자가 auth gate에서 카카오 로그인을 선택하면 현재 location 기반 path를 OAuth redirect 대상으로 전달한다.
+
+## Side Effects
+
+- API 호출: 없음
+- cache update/invalidation: 없음
+- localStorage/sessionStorage: 직접 접근하지 않음
+- navigation:
+  - `getRestaurantReservationNewPath(restaurantId)`로 이동
+  - `getRestaurantMenuDetailPath(restaurantId, menuId)`로 이동
+  - Kakao OAuth 시작 시 현재 route path를 redirect 값으로 전달
+- alert/toast: 없음
+- logging/tracking: 없음
+
+## Error Handling
+
+- 이 hook은 API 요청을 직접 수행하지 않으므로 request error를 처리하지 않는다.
+- OAuth 시작 중 발생하는 세부 에러 처리는 `useKakaoOAuthStart`의 책임이다.
+- route 생성에 필요한 `restaurantId`, `menuId`, `menuDetailSource` 값은 호출부가 유효한 값을 전달한다.
+
+## Dependencies
+
+- auth status: `useAuthStatus`
+- OAuth start: `useKakaoOAuthStart`
+- router: `useNavigate`, `useLocation`
+- route helpers:
+  - `getPathFromLocation`
+  - `getRestaurantMenuDetailPath`
+  - `getRestaurantReservationNewPath`
+
+## Non-Goals
+
+- 식당 상세 데이터 조회, 메뉴/리뷰 무한스크롤, 탭 상태 관리는 `useRestaurantDetailContent`가 소유한다.
+- 리뷰 작성 가능 여부와 리뷰 작성 route 이동은 `useRestaurantReviewWriteNavigation`이 소유한다.
+- 오늘의 식당 다시 추천받기 mutation과 상세 상태 reset은 `TodayRestaurantPage`가 소유한다.
+- 실제 좋아요 API mutation, optimistic update, cache invalidation, toast 처리는 현재 책임이 아니다.
+  좋아요 액션이 서버 상태 변경을 포함하게 되면 `useRestaurantLikeAction` 또는
+  `useRestaurantFavoriteAction` 같은 별도 hook 분리를 검토한다.
+- UI markup과 style은 `RestaurantDetailTemplate`, `AuthGateBottomSheet`, `ComingSoonDialog`가 소유한다.
+
+## Verification
+
+- [ ] 비인증 사용자가 좋아요를 누르면 auth gate가 열린다.
+- [ ] 인증 사용자가 좋아요를 누르면 coming soon dialog가 열린다.
+- [ ] 비인증 사용자가 예약하기를 누르면 auth gate가 열린다.
+- [ ] 인증 사용자가 예약하기를 누르면 예약 생성 route로 이동한다.
+- [ ] 메뉴를 누르면 메뉴 상세 route로 이동하고 source state를 전달한다.
+- [ ] auth gate에서 카카오 로그인을 누르면 현재 location 기반 redirect path로 OAuth를 시작한다.
+- [ ] `pnpm typecheck`
+- [ ] `pnpm lint`

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.ts
@@ -3,11 +3,11 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useKakaoOAuthStart } from '@/features/auth/hooks/useKakaoOAuthStart'
 import { getPathFromLocation } from '@/features/auth/utils/authRedirect'
-import type { RestaurantMenuDetailSource } from '@/features/restaurantDetail/utils/restaurantDetailRoutes'
 import {
   getRestaurantMenuDetailPath,
   getRestaurantReservationNewPath,
-} from '@/features/restaurantDetail/utils/restaurantDetailRoutes'
+} from '@/app/router/routePaths'
+import type { RestaurantMenuDetailSource } from '@/features/restaurantDetail/utils/restaurantDetailRoutes'
 import { useAuthStatus } from '@/shared/hooks'
 
 interface UseRestaurantDetailActionsParams {

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailActions.ts
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { useKakaoOAuthStart } from '@/features/auth/hooks/useKakaoOAuthStart'
+import { getPathFromLocation } from '@/features/auth/utils/authRedirect'
+import type { RestaurantMenuDetailSource } from '@/features/restaurantDetail/utils/restaurantDetailRoutes'
+import {
+  getRestaurantMenuDetailPath,
+  getRestaurantReservationNewPath,
+} from '@/features/restaurantDetail/utils/restaurantDetailRoutes'
+import { useAuthStatus } from '@/shared/hooks'
+
+interface UseRestaurantDetailActionsParams {
+  menuDetailSource: RestaurantMenuDetailSource
+  restaurantId: string
+}
+
+export const useRestaurantDetailActions = ({
+  menuDetailSource,
+  restaurantId,
+}: UseRestaurantDetailActionsParams) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { isAuthenticated } = useAuthStatus()
+  const { startKakaoOAuth } = useKakaoOAuthStart()
+  const [isAuthGateOpen, setIsAuthGateOpen] = useState(false)
+  const [isComingSoonOpen, setIsComingSoonOpen] = useState(false)
+
+  const handlePressLike = () => {
+    if (!isAuthenticated) {
+      setIsAuthGateOpen(true)
+      return
+    }
+
+    setIsComingSoonOpen(true)
+  }
+
+  const handlePressReservation = () => {
+    if (!isAuthenticated) {
+      setIsAuthGateOpen(true)
+      return
+    }
+
+    navigate(getRestaurantReservationNewPath(restaurantId))
+  }
+
+  const handlePressMenuItem = (menuId: string) => {
+    navigate(getRestaurantMenuDetailPath(restaurantId, menuId), {
+      state: { source: menuDetailSource },
+    })
+  }
+
+  const handlePressKakao = () => {
+    startKakaoOAuth(getPathFromLocation(location))
+  }
+
+  return {
+    isAuthGateOpen,
+    isComingSoonOpen,
+    onAuthGateOpenChange: setIsAuthGateOpen,
+    onComingSoonOpenChange: setIsComingSoonOpen,
+    onPressKakao: handlePressKakao,
+    onPressLike: handlePressLike,
+    onPressMenuItem: handlePressMenuItem,
+    onPressReservation: handlePressReservation,
+  }
+}

--- a/apps/client/src/pages/restaurantDetail/RestaurantDetailPage.tsx
+++ b/apps/client/src/pages/restaurantDetail/RestaurantDetailPage.tsx
@@ -3,11 +3,7 @@ import { useMemo } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
-import {
-  getRestaurantDetailPath,
-  getRestaurantMenuDetailPath,
-  getRestaurantReservationNewPath,
-} from '@/app/router/routePaths'
+import { getRestaurantDetailPath } from '@/app/router/routePaths'
 import { AuthGateBottomSheet } from '@/features/auth/components/authGateBottomSheet'
 import { RestaurantDetailTemplate } from '@/features/restaurantDetail'
 import { useRestaurantDetailActions } from '@/features/restaurantDetail/hooks/useRestaurantDetailActions'

--- a/apps/client/src/pages/restaurantDetail/RestaurantDetailPage.tsx
+++ b/apps/client/src/pages/restaurantDetail/RestaurantDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
@@ -9,9 +9,8 @@ import {
   getRestaurantReservationNewPath,
 } from '@/app/router/routePaths'
 import { AuthGateBottomSheet } from '@/features/auth/components/authGateBottomSheet'
-import { useKakaoOAuthStart } from '@/features/auth/hooks/useKakaoOAuthStart'
-import { getPathFromLocation } from '@/features/auth/utils/authRedirect'
 import { RestaurantDetailTemplate } from '@/features/restaurantDetail'
+import { useRestaurantDetailActions } from '@/features/restaurantDetail/hooks/useRestaurantDetailActions'
 import { useRestaurantDetailContent } from '@/features/restaurantDetail/hooks/useRestaurantDetailContent'
 import { useRestaurantReviewWriteNavigation } from '@/features/restaurantDetail/hooks/useRestaurantReviewWriteNavigation'
 import { restaurantSummaryQueryOptions } from '@/features/restaurantDetail/queries/restaurantDetailQueryOptions'
@@ -45,10 +44,7 @@ const RestaurantDetailContent = ({
   const navigate = useNavigate()
   const location = useLocation()
   const { isAuthenticated } = useAuthStatus()
-  const { startKakaoOAuth } = useKakaoOAuthStart()
   const initialTab = getRestaurantDetailTabState(location.state).activeTab
-  const [isAuthGateOpen, setIsAuthGateOpen] = useState(false)
-  const [isComingSoonOpen, setIsComingSoonOpen] = useState(false)
 
   const summaryQuery = useQuery(restaurantSummaryQueryOptions(restaurantId))
   const detailContent = useRestaurantDetailContent({
@@ -57,9 +53,13 @@ const RestaurantDetailContent = ({
     restaurantId,
     summary: summaryQuery.data,
   })
+  const detailActions = useRestaurantDetailActions({
+    menuDetailSource: 'detail',
+    restaurantId: String(restaurantId),
+  })
   const reviewWriteNavigation = useRestaurantReviewWriteNavigation({
     isAuthenticated,
-    onAuthRequired: () => setIsAuthGateOpen(true),
+    onAuthRequired: () => detailActions.onAuthGateOpenChange(true),
     onReviewUnavailable: detailContent.onOpenReviewUnavailableModal,
     restaurantId,
   })
@@ -85,30 +85,6 @@ const RestaurantDetailContent = ({
     navigateBackOrReplace(navigate, ROUTES.home)
   }
 
-  const handlePressLike = () => {
-    if (!isAuthenticated) {
-      setIsAuthGateOpen(true)
-      return
-    }
-
-    setIsComingSoonOpen(true)
-  }
-
-  const handlePressReservation = () => {
-    if (!isAuthenticated) {
-      setIsAuthGateOpen(true)
-      return
-    }
-
-    navigate(getRestaurantReservationNewPath(restaurant.id))
-  }
-
-  const handlePressMenuItem = (menuId: string) => {
-    navigate(getRestaurantMenuDetailPath(restaurant.id, menuId), {
-      state: { source: 'detail' },
-    })
-  }
-
   return (
     <>
       <RestaurantDetailTemplate
@@ -128,9 +104,9 @@ const RestaurantDetailContent = ({
           detailContent.onCloseReviewUnavailableModal
         }
         onPressBack={handlePressBack}
-        onPressLike={handlePressLike}
-        onPressMenuItem={handlePressMenuItem}
-        onPressReservation={handlePressReservation}
+        onPressLike={detailActions.onPressLike}
+        onPressMenuItem={detailActions.onPressMenuItem}
+        onPressReservation={detailActions.onPressReservation}
         onPressReviewImage={detailContent.onPressReviewImage}
         onPressWriteReview={reviewWriteNavigation.onPressWriteReview}
         onRetryMenuList={detailContent.onRetryMenuList}
@@ -152,13 +128,13 @@ const RestaurantDetailContent = ({
         variant="detail"
       />
       <AuthGateBottomSheet
-        onKakaoPress={() => startKakaoOAuth(getPathFromLocation(location))}
-        onOpenChange={setIsAuthGateOpen}
-        open={isAuthGateOpen}
+        onKakaoPress={detailActions.onPressKakao}
+        onOpenChange={detailActions.onAuthGateOpenChange}
+        open={detailActions.isAuthGateOpen}
       />
       <ComingSoonDialog
-        onOpenChange={setIsComingSoonOpen}
-        open={isComingSoonOpen}
+        onOpenChange={detailActions.onComingSoonOpenChange}
+        open={detailActions.isComingSoonOpen}
       />
     </>
   )

--- a/apps/client/src/pages/todayRestaurant/TodayRestaurantPage.tsx
+++ b/apps/client/src/pages/todayRestaurant/TodayRestaurantPage.tsx
@@ -3,10 +3,6 @@ import { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
-import {
-  getRestaurantMenuDetailPath,
-  getRestaurantReservationNewPath,
-} from '@/app/router/routePaths'
 import { AuthGateBottomSheet } from '@/features/auth/components/authGateBottomSheet'
 import { RestaurantDetailTemplate } from '@/features/restaurantDetail'
 import { getRandomRestaurantRecommendation } from '@/features/restaurantDetail/api/getRandomRestaurantRecommendation'

--- a/apps/client/src/pages/todayRestaurant/TodayRestaurantPage.tsx
+++ b/apps/client/src/pages/todayRestaurant/TodayRestaurantPage.tsx
@@ -8,11 +8,10 @@ import {
   getRestaurantReservationNewPath,
 } from '@/app/router/routePaths'
 import { AuthGateBottomSheet } from '@/features/auth/components/authGateBottomSheet'
-import { useKakaoOAuthStart } from '@/features/auth/hooks/useKakaoOAuthStart'
-import { getPathFromLocation } from '@/features/auth/utils/authRedirect'
 import { RestaurantDetailTemplate } from '@/features/restaurantDetail'
 import { getRandomRestaurantRecommendation } from '@/features/restaurantDetail/api/getRandomRestaurantRecommendation'
 import type { RestaurantSummary } from '@/features/restaurantDetail/api/getRestaurantSummary'
+import { useRestaurantDetailActions } from '@/features/restaurantDetail/hooks/useRestaurantDetailActions'
 import { useRestaurantDetailContent } from '@/features/restaurantDetail/hooks/useRestaurantDetailContent'
 import { useRestaurantReviewWriteNavigation } from '@/features/restaurantDetail/hooks/useRestaurantReviewWriteNavigation'
 import { randomRestaurantRecommendationQueryOptions } from '@/features/restaurantDetail/queries/restaurantDetailQueryOptions'
@@ -32,12 +31,9 @@ export const TodayRestaurantPage = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const { isAuthenticated } = useAuthStatus()
-  const { startKakaoOAuth } = useKakaoOAuthStart()
   const initialTab = getRestaurantDetailTabState(location.state).activeTab
   const [recommendedSummary, setRecommendedSummary] =
     useState<RestaurantSummary | null>(null)
-  const [isAuthGateOpen, setIsAuthGateOpen] = useState(false)
-  const [isComingSoonOpen, setIsComingSoonOpen] = useState(false)
 
   const randomRecommendationQuery = useQuery(
     randomRestaurantRecommendationQueryOptions(),
@@ -52,9 +48,13 @@ export const TodayRestaurantPage = () => {
     restaurantId,
     summary,
   })
+  const detailActions = useRestaurantDetailActions({
+    menuDetailSource: 'today',
+    restaurantId: String(restaurantId),
+  })
   const reviewWriteNavigation = useRestaurantReviewWriteNavigation({
     isAuthenticated,
-    onAuthRequired: () => setIsAuthGateOpen(true),
+    onAuthRequired: () => detailActions.onAuthGateOpenChange(true),
     onReviewUnavailable: detailContent.onOpenReviewUnavailableModal,
     restaurantId,
   })
@@ -97,24 +97,6 @@ export const TodayRestaurantPage = () => {
     navigateBackOrReplace(navigate, ROUTES.home)
   }
 
-  const handlePressLike = () => {
-    if (!isAuthenticated) {
-      setIsAuthGateOpen(true)
-      return
-    }
-
-    setIsComingSoonOpen(true)
-  }
-
-  const handlePressReservation = () => {
-    if (!isAuthenticated) {
-      setIsAuthGateOpen(true)
-      return
-    }
-
-    navigate(getRestaurantReservationNewPath(restaurant.id))
-  }
-
   const handlePressRecommendAgain = () => {
     if (recommendAgainMutation.isPending) {
       return
@@ -122,12 +104,6 @@ export const TodayRestaurantPage = () => {
 
     recommendAgainMutation.mutate({
       excludeRestaurantId: restaurant.id ? Number(restaurant.id) : undefined,
-    })
-  }
-
-  const handlePressMenuItem = (menuId: string) => {
-    navigate(getRestaurantMenuDetailPath(restaurant.id, menuId), {
-      state: { source: 'today' },
     })
   }
 
@@ -150,10 +126,10 @@ export const TodayRestaurantPage = () => {
           detailContent.onCloseReviewUnavailableModal
         }
         onPressBack={handlePressBack}
-        onPressLike={handlePressLike}
-        onPressMenuItem={handlePressMenuItem}
+        onPressLike={detailActions.onPressLike}
+        onPressMenuItem={detailActions.onPressMenuItem}
         onPressRecommendAgain={handlePressRecommendAgain}
-        onPressReservation={handlePressReservation}
+        onPressReservation={detailActions.onPressReservation}
         onPressReviewImage={detailContent.onPressReviewImage}
         onPressWriteReview={reviewWriteNavigation.onPressWriteReview}
         onRetryMenuList={detailContent.onRetryMenuList}
@@ -172,13 +148,13 @@ export const TodayRestaurantPage = () => {
         variant="today"
       />
       <AuthGateBottomSheet
-        onKakaoPress={() => startKakaoOAuth(getPathFromLocation(location))}
-        onOpenChange={setIsAuthGateOpen}
-        open={isAuthGateOpen}
+        onKakaoPress={detailActions.onPressKakao}
+        onOpenChange={detailActions.onAuthGateOpenChange}
+        open={detailActions.isAuthGateOpen}
       />
       <ComingSoonDialog
-        onOpenChange={setIsComingSoonOpen}
-        open={isComingSoonOpen}
+        onOpenChange={detailActions.onComingSoonOpenChange}
+        open={detailActions.isComingSoonOpen}
       />
     </>
   )


### PR DESCRIPTION
## 📌 요약

> 식당 상세 화면과 오늘의 식당 화면에 중복되어 있던 공통 액션 로직을 hook으로 분리했습니다.

Jira: HASHI-157

## 📚 작업 내용

- `useRestaurantDetailActions` hook을 추가했습니다.
- `RestaurantDetailPage`, `TodayRestaurantPage`에 중복되어 있던 인증 바텀시트/찜/예약/메뉴 이동/카카오 로그인 시작 로직을 공통 hook으로 이동했습니다.
- 메뉴 상세 이동 시 필요한 source 값은 `detail`, `today`를 각 페이지에서 주입하도록 정리했습니다.

## 🔎 상세 설명

기존에는 `RestaurantDetailPage`와 `TodayRestaurantPage`가 같은 상세 템플릿을 사용하면서도 인증이 필요한 액션 처리와 메뉴 상세 이동 로직을 각각 가지고 있었습니다.

이번 리팩토링에서는 두 페이지에서 동일하게 사용하는 액션 흐름을 `useRestaurantDetailActions`로 분리했습니다. 페이지는 각자 필요한 `menuDetailSource`만 넘기고, hook이 인증 필요 여부에 따른 auth gate 표시, 예약 페이지 이동, 메뉴 상세 이동, 카카오 OAuth 시작, coming soon dialog 상태를 관리합니다.

뒤로가기와 오늘의 식당 다시 추천받기는 페이지별 책임으로 남겼습니다.

검증:

- `pnpm --filter @hashi/client exec vitest run src/pages/restaurantDetail/RestaurantDetailPage.test.tsx src/pages/todayRestaurant/TodayRestaurantPage.test.tsx`
- `pnpm typecheck:client`

## 💭 고민한 부분

### 고민한 문제

- 두 페이지의 인증 바텀시트, 찜, 예약, 메뉴 이동 로직이 거의 동일하게 중복되어 있어 이후 변경 시 한쪽만 수정될 가능성이 있었습니다.

### 고려한 선택지

- 페이지별 핸들러를 유지하고 중복만 감수하는 방식
- `RestaurantDetailTemplate`까지 액션 책임을 넘기는 방식
- 공통 액션 hook을 만들어 페이지에서 필요한 source만 주입하는 방식

### 최종 선택과 이유

- 공통 액션 hook을 분리하는 방식을 선택했습니다.
- 템플릿은 UI 조립 책임에 가깝고, 액션 흐름은 route/auth 상태와 연결되어 있어 hook으로 분리하는 편이 책임이 명확하다고 판단했습니다.
- `detail`/`today` 차이는 `menuDetailSource` 주입으로 처리해 두 페이지의 동작 차이를 유지했습니다.

### 남은 고민

- 찜 기능이 실제 API로 연결되면 현재 coming soon 처리 부분은 별도 mutation hook으로 교체할 수 있습니다.
