### PR TITLE
Refactor(client): HASHI-159 RestaurantListPage 네이밍 수정

### DIFF
--- a/apps/client/src/features/restaurantList/components/RestaurantListTemplate.tsx
+++ b/apps/client/src/features/restaurantList/components/RestaurantListTemplate.tsx
@@ -1,20 +1,18 @@
 import { BackIcon } from '@hashi/hds-icons'
 import { Button, Header, IconButton } from '@hashi/hds-ui'
 
-import {
-  CATEGORY_OPTIONS,
-  RestaurantCard,
-  RestaurantFilterBar,
-  useRestaurantListPage,
-} from '@/features/restaurantList'
+import { RestaurantCard } from '@/features/restaurantList/components/RestaurantCard'
+import { RestaurantFilterBar } from '@/features/restaurantList/components/RestaurantFilterBar'
+import { CATEGORY_OPTIONS } from '@/features/restaurantList/constants'
+import { useRestaurantListContent } from '@/features/restaurantList/hooks/useRestaurantListContent'
 import type {
   FilterOption,
   RestaurantListCurationType,
-} from '@/features/restaurantList'
+} from '@/features/restaurantList/types'
 import { FilterBottomSheet } from '@/shared/components/filterBottomSheet'
 import { ListEmptyState } from '@/shared/components/listEmptyState'
 
-type RestaurantListPageProps = {
+type RestaurantListTemplateProps = {
   title: string
   restaurantType: RestaurantListCurationType
   sortOptions: FilterOption[]
@@ -46,11 +44,11 @@ const renderSkeletonItems = (count: number) => {
   ))
 }
 
-export const RestaurantListPage = ({
+export const RestaurantListTemplate = ({
   title,
   restaurantType,
   sortOptions,
-}: RestaurantListPageProps) => {
+}: RestaurantListTemplateProps) => {
   const {
     activeBottomSheet,
     categoryLabel,
@@ -75,7 +73,7 @@ export const RestaurantListPage = ({
     handleRetry,
     handleSelectCategory,
     handleSelectSort,
-  } = useRestaurantListPage({
+  } = useRestaurantListContent({
     restaurantType,
     sortOptions,
   })

--- a/apps/client/src/features/restaurantList/components/index.ts
+++ b/apps/client/src/features/restaurantList/components/index.ts
@@ -1,3 +1,4 @@
 export { RestaurantCard } from './RestaurantCard'
 export { RestaurantFilterBar } from './RestaurantFilterBar'
+export { RestaurantListTemplate } from './RestaurantListTemplate'
 export { RestaurantImageList } from './RestaurantImageList'

--- a/apps/client/src/features/restaurantList/hooks/index.ts
+++ b/apps/client/src/features/restaurantList/hooks/index.ts
@@ -1,1 +1,1 @@
-export { useRestaurantListPage } from './useRestaurantListPage'
+export { useRestaurantListContent } from './useRestaurantListContent'

--- a/apps/client/src/features/restaurantList/hooks/useRestaurantListContent.ts
+++ b/apps/client/src/features/restaurantList/hooks/useRestaurantListContent.ts
@@ -21,7 +21,7 @@ import { useInfiniteScrollTrigger } from '@/shared/hooks'
 
 type ActiveBottomSheet = 'sort' | 'category' | null
 
-type UseRestaurantListPageParams = {
+type UseRestaurantListContentParams = {
   restaurantType: RestaurantListCurationType
   sortOptions: FilterOption[]
 }
@@ -30,10 +30,10 @@ const getOptionByValue = (options: FilterOption[], value: string) => {
   return options.find((option) => option.value === value)
 }
 
-export const useRestaurantListPage = ({
+export const useRestaurantListContent = ({
   restaurantType,
   sortOptions,
-}: UseRestaurantListPageParams) => {
+}: UseRestaurantListContentParams) => {
   const navigate = useNavigate()
   const defaultSortOption = sortOptions[0]
   const [activeBottomSheet, setActiveBottomSheet] =

--- a/apps/client/src/features/restaurantList/index.ts
+++ b/apps/client/src/features/restaurantList/index.ts
@@ -5,9 +5,12 @@ export {
   POPULAR_RESTAURANTS_SORT_OPTIONS,
   RESTAURANT_LIST_PAGE_SIZE,
 } from './constants'
-export { RestaurantListPage } from './RestaurantListPage'
-export { useRestaurantListPage } from './hooks'
-export { RestaurantCard, RestaurantFilterBar } from './components'
+export { useRestaurantListContent } from './hooks'
+export {
+  RestaurantCard,
+  RestaurantFilterBar,
+  RestaurantListTemplate,
+} from './components'
 export type {
   FilterOption,
   Restaurant,

--- a/apps/client/src/pages/hashiPick/HashiPick.spec.md
+++ b/apps/client/src/pages/hashiPick/HashiPick.spec.md
@@ -75,8 +75,8 @@
 ### Current Implementation
 
 - 식당 목록 조회 endpoint 함수, query key factory, infinite query options는 `features/restaurantList`에 이미 구현되어 있습니다.
-- `HashiPickPage`는 `restaurantType="hashi-pick"`을 `RestaurantListPage`에 넘기고, 정적 restaurant fixture를 production render path에서 사용하지 않습니다.
-- `RestaurantListPage`와 `useRestaurantListPage`는 `restaurants` prop과 local slice가 아니라 TanStack Query server state와 `useInfiniteScrollTrigger`를 사용합니다.
+- `HashiPickPage`는 `restaurantType="hashi-pick"`을 `RestaurantListTemplate`에 넘기고, 정적 restaurant fixture를 production render path에서 사용하지 않습니다.
+- `RestaurantListTemplate`과 `useRestaurantListContent`는 `restaurants` prop과 local slice가 아니라 TanStack Query server state와 `useInfiniteScrollTrigger`를 사용합니다.
 - 이 API 연동은 기존 shared 식당 목록 API를 새로 만들지 않고, 하시 Pick route UI가 기존 query options를 소비하도록 연결합니다.
 - 검색 화면과 같은 `restaurantsInfiniteQueryOptions` 패턴을 사용하되, 검색어 `keyword` 대신 하시 Pick 목록 유형 `type`을 고정해서 보냅니다.
 - 서버 기반 무한스크롤은 검색/매거진 화면 관례처럼 `useInfiniteScrollTrigger`로 sentinel intersect 시 `fetchNextPage`를 호출합니다. 기존 local slicing mock 경로는 제거합니다.
@@ -195,14 +195,14 @@
   - selected sort/category -> API request params
   - `RestaurantSummaryResponse` -> `Restaurant`
 - owner:
-  - list state and handlers are owned by `useRestaurantListPage`
+  - list state and handlers are owned by `useRestaurantListContent`
   - API response normalization is owned by `features/restaurantList` mapper/hook
 
 ## UI Structure
 
 ```text
 HashiPickPage
-  RestaurantListPage
+  RestaurantListTemplate
     Header
     RestaurantFilterBar
     RestaurantCard list
@@ -222,18 +222,18 @@ HashiPickPage
 - app shared component:
   - `FilterBottomSheet`
 - feature component:
-  - `RestaurantListPage`
+  - `RestaurantListTemplate`
   - `RestaurantFilterBar`
   - `RestaurantCard`
   - `RestaurantImageList`
 - feature hook:
-  - `useRestaurantListPage`
+  - `useRestaurantListContent`
   - `useRestaurantsInfiniteQuery`
   - `restaurantsInfiniteQueryOptions`
 - feature query composition:
   - `createRestaurantListRequestParams`
   - `restaurantsInfiniteQueryOptions`
-  - `useRestaurantListPage`에서 `restaurantsInfiniteQueryOptions`를 감싸고 `throwOnError: false`를 명시합니다.
+  - `useRestaurantListContent`에서 `restaurantsInfiniteQueryOptions`를 감싸고 `throwOnError: false`를 명시합니다.
 - feature mapper:
   - `RestaurantSummaryResponse` -> `Restaurant`
 - feature mock:

--- a/apps/client/src/pages/hashiPick/HashiPickPage.tsx
+++ b/apps/client/src/pages/hashiPick/HashiPickPage.tsx
@@ -1,11 +1,11 @@
 import {
   HASHI_PICK_SORT_OPTIONS,
-  RestaurantListPage,
+  RestaurantListTemplate,
 } from '@/features/restaurantList'
 
 export const HashiPickPage = () => {
   return (
-    <RestaurantListPage
+    <RestaurantListTemplate
       restaurantType="hashi-pick"
       sortOptions={HASHI_PICK_SORT_OPTIONS}
       title="하시 Pick"

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurants.spec.md
@@ -75,8 +75,8 @@
 ### Current Implementation
 
 - 식당 목록 조회 endpoint 함수, query key factory, infinite query options는 `features/restaurantList`에 이미 구현되어 있습니다.
-- `PopularRestaurantsPage`는 `restaurantType="popular"`를 `RestaurantListPage`에 넘기고, 정적 restaurant fixture를 production render path에서 사용하지 않습니다.
-- `RestaurantListPage`와 `useRestaurantListPage`는 `restaurants` prop과 local slice가 아니라 TanStack Query server state와 `useInfiniteScrollTrigger`를 사용합니다.
+- `PopularRestaurantsPage`는 `restaurantType="popular"`를 `RestaurantListTemplate`에 넘기고, 정적 restaurant fixture를 production render path에서 사용하지 않습니다.
+- `RestaurantListTemplate`과 `useRestaurantListContent`는 `restaurants` prop과 local slice가 아니라 TanStack Query server state와 `useInfiniteScrollTrigger`를 사용합니다.
 - 이 API 연동은 기존 shared 식당 목록 API를 새로 만들지 않고, 인기 맛집 route UI가 기존 query options를 소비하도록 연결합니다.
 - 검색 화면과 같은 `restaurantsInfiniteQueryOptions` 패턴을 사용하되, 검색어 `keyword` 대신 인기 맛집 목록 유형 `type`을 고정해서 보냅니다.
 - 서버 기반 무한스크롤은 검색/매거진 화면 관례처럼 `useInfiniteScrollTrigger`로 sentinel intersect 시 `fetchNextPage`를 호출합니다. 기존 local slicing mock 경로는 제거합니다.
@@ -195,14 +195,14 @@
   - selected sort/category -> API request params
   - `RestaurantSummaryResponse` -> `Restaurant`
 - owner:
-  - list state and handlers are owned by `useRestaurantListPage`
+  - list state and handlers are owned by `useRestaurantListContent`
   - API response normalization is owned by `features/restaurantList` mapper/hook
 
 ## UI Structure
 
 ```text
 PopularRestaurantsPage
-  RestaurantListPage
+  RestaurantListTemplate
     Header
     RestaurantFilterBar
     RestaurantCard list
@@ -222,18 +222,18 @@ PopularRestaurantsPage
 - app shared component:
   - `FilterBottomSheet`
 - feature component:
-  - `RestaurantListPage`
+  - `RestaurantListTemplate`
   - `RestaurantFilterBar`
   - `RestaurantCard`
   - `RestaurantImageList`
 - feature hook:
-  - `useRestaurantListPage`
+  - `useRestaurantListContent`
   - `useRestaurantsInfiniteQuery`
   - `restaurantsInfiniteQueryOptions`
 - feature query composition:
   - `createRestaurantListRequestParams`
   - `restaurantsInfiniteQueryOptions`
-  - `useRestaurantListPage`에서 `restaurantsInfiniteQueryOptions`를 감싸고 `throwOnError: false`를 명시합니다.
+  - `useRestaurantListContent`에서 `restaurantsInfiniteQueryOptions`를 감싸고 `throwOnError: false`를 명시합니다.
 - feature mapper:
   - `RestaurantSummaryResponse` -> `Restaurant`
 - feature mock:

--- a/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.tsx
+++ b/apps/client/src/pages/popularRestaurants/PopularRestaurantsPage.tsx
@@ -1,11 +1,11 @@
 import {
   POPULAR_RESTAURANTS_SORT_OPTIONS,
-  RestaurantListPage,
+  RestaurantListTemplate,
 } from '@/features/restaurantList'
 
 export const PopularRestaurantsPage = () => {
   return (
-    <RestaurantListPage
+    <RestaurantListTemplate
       restaurantType="popular"
       sortOptions={POPULAR_RESTAURANTS_SORT_OPTIONS}
       title="인기 맛집"


### PR DESCRIPTION
## 📌 요약

> route 단위가 아닌 공통 식당 목록 컴포넌트의 `Page` 네이밍을 실제 책임에 맞게 정리했습니다.

Jira: HASHI-159

## 📚 작업 내용

- `RestaurantListPage`를 `RestaurantListTemplate`으로 변경
- 공통 템플릿을 `features/restaurantList/components`로 이동
- `useRestaurantListPage`를 `useRestaurantListContent`로 변경
- feature barrel export와 `HashiPickPage`, `PopularRestaurantsPage` 사용처 수정
- Hashi Pick과 인기 맛집 page spec의 컴포넌트·hook 책임 설명 갱신
- 이전 네이밍의 파일명, 심볼, import 및 문서 참조가 남아 있지 않은지 전체 검색

## 🔎 상세 설명

`RestaurantListPage`는 라우터에 직접 등록되는 page가 아니라 `HashiPickPage`와 `PopularRestaurantsPage`가 공통으로 사용하는 식당 목록 템플릿입니다.

프로젝트에서 `Page`는 `apps/client/src/pages` 아래의 route 단위 컴포넌트를 의미하므로, 실제 역할과 이름이 일치하도록 다음과 같이 변경했습니다.

```text
RestaurantListPage
→ RestaurantListTemplate

useRestaurantListPage
→ useRestaurantListContent
```
RestaurantListTemplate은 기존 RestaurantDetailTemplate 구조와 맞춰 feature의 components/ 아래에 배치했습니다.
useRestaurantListContent는 필터 상태, 식당 목록 query, 무한 스크롤, 재시도 및 공통 내비게이션 동작을 관리합니다. 공유 feature hook에는 Page 접미사를 사용하지 않는 기존 useRestaurantDetailContent 패턴을 따랐습니다.
라우트 경로, lazy loading, API 요청, query key, UI 렌더링 동작은 변경하지 않았습니다.


## 💭 고민한 부분
### 고민한 문제

- Page를 route 단위 컴포넌트에만 사용할지, 전체 화면 형태의 feature 컴포넌트에도 사용할지
- 공유 hook의 이름을 Template, Flow, Content 중 어떤 책임으로 표현할지

### 고려한 선택지

- RestaurantListScreen
- RestaurantListTemplate
- useRestaurantListTemplate
- useRestaurantListFlow
- useRestaurantListContent

### 최종 선택과 이유
`RestaurantListTemplate`
- 두 route page가 공통으로 사용하는 화면 구조라는 역할을 명확하게 표현합니다.
- 기존 RestaurantDetailTemplate과 동일한 feature template 패턴을 따릅니다.
- Page를 실제 route 단위 컴포넌트에만 사용할 수 있습니다.

`useRestaurantListContent`
- query와 필터·목록 상태를 제공하는 hook의 책임을 직접 표현합니다.
- features/restaurantDetail의 useRestaurantDetailContent 선례와 일치합니다.
- 컴포넌트 종류에 종속되는 Template이나 다단계 동작으로 오해할 수 있는 Flow보다 현재 역할에 적합합니다.

### 남은 고민

- 현재 템플릿은 query와 공통 내비게이션까지 포함하는 smart template입니다.
- 이번 PR은 동작이나 책임 분배를 변경하지 않고 네이밍과 파일 배치만 정리합니다. 추후 Template을 순수 presentational component로 제한하는 정책이 필요해지면 orchestration 분리를 별도 작업으로 검토할 수 있습니다.

## 👀 리뷰어에게
- Page를 route 단위 컴포넌트에만 사용하고, 공유 화면 구조에는 Template, 공유 feature hook에는 Content를 사용하는 방향이 적절한지 확인 부탁드립니다.

