### PR TITLE
Refactor(client): HASHI-161 프로필 생성 페이지 훅 책임 분리

### DIFF
--- a/apps/client/src/pages/profileNew/ProfileNewPage.spec.md
+++ b/apps/client/src/pages/profileNew/ProfileNewPage.spec.md
@@ -292,7 +292,7 @@ ProfileNewPage
   - `checkIsValidBirthDate`
   - `checkIsValidEmail`
   - `getAllowedProfileNewRedirectPath`
-  - `mapProfileNewOnboardingError`
+  - `applyProfileNewOnboardingError`
 - page-local constants:
   - `PROFILE_NEW_FORM_ID`
   - `SUPPORTED_PROFILE_IMAGE_MIME_TYPES`

--- a/apps/client/src/pages/profileNew/ProfileNewPage.spec.md
+++ b/apps/client/src/pages/profileNew/ProfileNewPage.spec.md
@@ -284,11 +284,15 @@ ProfileNewPage
 - page-local hook:
   - `useProfileNewPage`
   - `useProfileNewForm`
+  - `useProfileNewMutation`
+  - `useUploadedProfileImageKey`
 - page-local utils:
   - `formatBirthDateInput`
   - `formatPhoneNumberInput`
   - `checkIsValidBirthDate`
   - `checkIsValidEmail`
+  - `getAllowedProfileNewRedirectPath`
+  - `mapProfileNewOnboardingError`
 - page-local constants:
   - `PROFILE_NEW_FORM_ID`
   - `SUPPORTED_PROFILE_IMAGE_MIME_TYPES`
@@ -378,10 +382,13 @@ ProfileNewPage
 ## Implementation Notes
 
 - `ProfileNewPage`는 화면 섹션 조합만 담당한다.
-- `useProfileNewPage`는 navigation, search param, TanStack Query mutation 기반 form submit 연결을 담당한다.
+- `useProfileNewPage`는 navigation, search param, form submit event, ErrorBoundary로 전달할 unhandled error 상태를 조합한다.
 - form state, formatting, validation, submit draft 생성은 `useProfileNewForm`에서 소유한다.
 - `useProfileNewForm`은 form 값, formatting, validation, 서버 field error를 소유하고, submitting 상태는 mutation `isPending`을 주입받아 CTA 상태 계산에 사용한다.
-- `useProfileNewPage`는 `useMutation`의 `mutateAsync`, `isPending`, `onSuccess`, `onError`로 submit orchestration, 성공한 profile image key 재사용, error mapping, navigation을 소유한다.
+- `useProfileNewMutation`은 TanStack Query mutation, profile image key 확보, onboarding request body 생성, 성공 시 access token 저장과 redirect, auth failure redirect, handled/unhandled error 분기를 소유한다.
+- `useUploadedProfileImageKey`는 같은 `File` 객체로 재제출할 때 성공한 profile image `fileKey`를 재사용하는 정책을 소유한다.
+- `profileNewOnboardingError`는 onboarding API error code와 field error를 profile form의 field/form error로 반영하는 정책을 소유한다.
+- `profileNewRedirect`는 `redirectTo` query param을 허용된 내부 route로 제한하고, 허용된 path의 query string/hash를 보존하는 정책을 소유한다.
 - `requestOnboarding`과 `uploadProfileImage`는 React, route, UI state를 알지 않는다.
 - `signup_token`은 HttpOnly cookie이므로 프론트 코드에서 읽거나 저장하지 않는다.
 - 온보딩 API 요청에 Authorization header를 임의로 추가하지 않는다.

--- a/apps/client/src/pages/profileNew/hooks/useProfileNewMutation.ts
+++ b/apps/client/src/pages/profileNew/hooks/useProfileNewMutation.ts
@@ -9,7 +9,7 @@ import { requestOnboarding } from '@/pages/profileNew/api/requestOnboarding'
 import type { ProfileDraft } from '@/pages/profileNew/hooks/useProfileNewForm'
 import { createOnboardingRequestBody } from '@/pages/profileNew/utils/profileNewForm'
 import {
-  mapProfileNewOnboardingError,
+  applyProfileNewOnboardingError,
   type ProfileNewOnboardingErrorHandlers,
 } from '@/pages/profileNew/utils/profileNewOnboardingError'
 import { checkHasHttpStatus } from '@/shared/api/apiError'
@@ -57,7 +57,7 @@ export const useProfileNewMutation = ({
       }
 
       if (
-        !mapProfileNewOnboardingError(error, {
+        !applyProfileNewOnboardingError(error, {
           setFieldError,
           setFormError,
         })

--- a/apps/client/src/pages/profileNew/hooks/useProfileNewMutation.ts
+++ b/apps/client/src/pages/profileNew/hooks/useProfileNewMutation.ts
@@ -1,0 +1,69 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { ROUTES } from '@/app/router/path'
+import {
+  clearAuthSession,
+  setAccessToken,
+} from '@/features/auth/session/authSession'
+import { requestOnboarding } from '@/pages/profileNew/api/requestOnboarding'
+import type { ProfileDraft } from '@/pages/profileNew/hooks/useProfileNewForm'
+import { createOnboardingRequestBody } from '@/pages/profileNew/utils/profileNewForm'
+import {
+  mapProfileNewOnboardingError,
+  type ProfileNewOnboardingErrorHandlers,
+} from '@/pages/profileNew/utils/profileNewOnboardingError'
+import { checkHasHttpStatus } from '@/shared/api/apiError'
+
+interface UseProfileNewMutationOptions {
+  getRedirectPath: () => string
+  getUploadedProfileImageKey: (file: File) => Promise<string>
+  navigateTo: (to: string, options?: { replace?: boolean }) => void
+  onUnhandledError: (error: unknown) => void
+  setFieldError: ProfileNewOnboardingErrorHandlers['setFieldError']
+  setFormError: ProfileNewOnboardingErrorHandlers['setFormError']
+}
+
+export const useProfileNewMutation = ({
+  getRedirectPath,
+  getUploadedProfileImageKey,
+  navigateTo,
+  onUnhandledError,
+  setFieldError,
+  setFormError,
+}: UseProfileNewMutationOptions) => {
+  return useMutation({
+    mutationFn: async (profileDraft: ProfileDraft) => {
+      const profileImageFile = profileDraft.profileImageFile
+      const profileImageKey = profileImageFile
+        ? await getUploadedProfileImageKey(profileImageFile)
+        : undefined
+
+      return requestOnboarding(
+        createOnboardingRequestBody(profileDraft, profileImageKey),
+      )
+    },
+    onSuccess: ({ accessToken }) => {
+      setAccessToken(accessToken)
+      navigateTo(getRedirectPath())
+    },
+    onError: (error) => {
+      if (
+        checkHasHttpStatus(error) &&
+        (error.status === 401 || error.status === 403)
+      ) {
+        clearAuthSession()
+        navigateTo(ROUTES.loginRequired, { replace: true })
+        return
+      }
+
+      if (
+        !mapProfileNewOnboardingError(error, {
+          setFieldError,
+          setFormError,
+        })
+      ) {
+        onUnhandledError(error)
+      }
+    },
+  })
+}

--- a/apps/client/src/pages/profileNew/hooks/useProfileNewPage.ts
+++ b/apps/client/src/pages/profileNew/hooks/useProfileNewPage.ts
@@ -1,187 +1,32 @@
-import { useMutation } from '@tanstack/react-query'
 import type { SyntheticEvent } from 'react'
-import { useRef, useState } from 'react'
-import { matchPath, useNavigate, useSearchParams } from 'react-router-dom'
+import { useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
-import { ROUTES } from '@/app/router/path'
-import {
-  clearAuthSession,
-  setAccessToken,
-} from '@/features/auth/session/authSession'
-import { requestOnboarding } from '@/pages/profileNew/api/requestOnboarding'
-import { uploadProfileImage } from '@/pages/profileNew/api/uploadProfileImage'
-import {
-  type ProfileDraft,
-  useProfileNewForm,
-} from '@/pages/profileNew/hooks/useProfileNewForm'
-import { createOnboardingRequestBody } from '@/pages/profileNew/utils/profileNewForm'
-import { checkHasHttpStatus, isApiError } from '@/shared/api/apiError'
-import { getErrorPresentation } from '@/shared/api/errorPresentation'
-import type { FieldError } from '@/shared/api/types'
+import { useProfileNewForm } from '@/pages/profileNew/hooks/useProfileNewForm'
+import { useProfileNewMutation } from '@/pages/profileNew/hooks/useProfileNewMutation'
+import { useUploadedProfileImageKey } from '@/pages/profileNew/hooks/useUploadedProfileImageKey'
+import { getAllowedProfileNewRedirectPath } from '@/pages/profileNew/utils/profileNewRedirect'
 
 export const PROFILE_NEW_FORM_ID = 'profile-new-form'
-
-const ALLOWED_REDIRECT_ROUTES = [
-  ROUTES.reviewNew,
-  ROUTES.restaurantReservationNew,
-  ROUTES.anywhereReservation,
-  ROUTES.reservationRequest,
-] as const
-
-const REDIRECT_URL_BASE = 'https://hashi.local'
-
-const ONBOARDING_ERROR_FIELD_MAP = {
-  nickname: 'nickname',
-  birthDate: 'birthDate',
-  phone: 'phoneNumber',
-  nameEng: 'englishName',
-  email: 'email',
-} as const
-
-const DUPLICATED_FIELD_ERROR_CODE_MAP = {
-  'USER-001': 'nickname',
-  'USER-002': 'email',
-  'USER-003': 'phoneNumber',
-} as const
-
-const getAllowedRedirectPath = (redirectTo: string | null) => {
-  if (!redirectTo?.startsWith('/') || redirectTo.startsWith('//')) {
-    return ROUTES.home
-  }
-
-  const redirectUrl = new URL(redirectTo, REDIRECT_URL_BASE)
-  const isAllowedRedirectPath = ALLOWED_REDIRECT_ROUTES.some((route) =>
-    matchPath({ path: route, end: true }, redirectUrl.pathname),
-  )
-
-  return isAllowedRedirectPath
-    ? `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`
-    : ROUTES.home
-}
-
-const getMappedFieldName = (field: string) => {
-  if (field in ONBOARDING_ERROR_FIELD_MAP) {
-    return ONBOARDING_ERROR_FIELD_MAP[
-      field as keyof typeof ONBOARDING_ERROR_FIELD_MAP
-    ]
-  }
-
-  return undefined
-}
-
-const getDuplicatedFieldName = (code: string) => {
-  if (code in DUPLICATED_FIELD_ERROR_CODE_MAP) {
-    return DUPLICATED_FIELD_ERROR_CODE_MAP[
-      code as keyof typeof DUPLICATED_FIELD_ERROR_CODE_MAP
-    ]
-  }
-
-  return undefined
-}
 
 export const useProfileNewPage = () => {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const [boundaryError, setBoundaryError] = useState<unknown>()
-  const uploadedProfileImageRef = useRef<
-    { file: File; fileKey: string } | undefined
-  >(undefined)
+  const { getUploadedProfileImageKey } = useUploadedProfileImageKey()
 
   const handleBackClick = () => {
     navigate(-1)
   }
 
-  const applyFieldErrors = (fieldErrors: FieldError[]) => {
-    let hasMappedFieldError = false
-
-    fieldErrors.forEach(({ field, reason }) => {
-      const mappedFieldName = getMappedFieldName(field)
-
-      if (!mappedFieldName) {
-        return
-      }
-
-      form.submit.setFieldError(mappedFieldName, reason)
-      hasMappedFieldError = true
-    })
-
-    return hasMappedFieldError
-  }
-
-  const handleLocalOnboardingError = (error: unknown) => {
-    if (!isApiError(error)) {
-      return false
-    }
-
-    const duplicatedFieldName = getDuplicatedFieldName(error.code)
-
-    if (duplicatedFieldName) {
-      form.submit.setFieldError(
-        duplicatedFieldName,
-        getErrorPresentation(error).message,
-      )
-      return true
-    }
-
-    if (error.code === 'COMMON-400') {
-      const hasMappedFieldError = applyFieldErrors(error.fieldErrors)
-
-      if (!hasMappedFieldError) {
-        form.submit.setFormError(getErrorPresentation(error).message)
-      }
-
-      return true
-    }
-
-    if (error.code === 'USER-004') {
-      form.submit.setFormError(getErrorPresentation(error).message)
-      return true
-    }
-
-    return false
-  }
-
-  const profileNewMutation = useMutation({
-    mutationFn: async (profileDraft: ProfileDraft) => {
-      const profileImageFile = profileDraft.profileImageFile
-      let profileImageKey: string | undefined
-
-      if (profileImageFile) {
-        const cachedProfileImage = uploadedProfileImageRef.current
-
-        if (cachedProfileImage?.file === profileImageFile) {
-          profileImageKey = cachedProfileImage.fileKey
-        } else {
-          profileImageKey = await uploadProfileImage(profileImageFile)
-          uploadedProfileImageRef.current = {
-            file: profileImageFile,
-            fileKey: profileImageKey,
-          }
-        }
-      }
-
-      return requestOnboarding(
-        createOnboardingRequestBody(profileDraft, profileImageKey),
-      )
-    },
-    onSuccess: ({ accessToken }) => {
-      setAccessToken(accessToken)
-      navigate(getAllowedRedirectPath(searchParams.get('redirectTo')))
-    },
-    onError: (error) => {
-      if (
-        checkHasHttpStatus(error) &&
-        (error.status === 401 || error.status === 403)
-      ) {
-        clearAuthSession()
-        navigate(ROUTES.loginRequired, { replace: true })
-        return
-      }
-
-      if (!handleLocalOnboardingError(error)) {
-        setBoundaryError(error)
-      }
-    },
+  const profileNewMutation = useProfileNewMutation({
+    getRedirectPath: () =>
+      getAllowedProfileNewRedirectPath(searchParams.get('redirectTo')),
+    getUploadedProfileImageKey,
+    navigateTo: navigate,
+    onUnhandledError: setBoundaryError,
+    setFieldError: (...args) => form.submit.setFieldError(...args),
+    setFormError: (message) => form.submit.setFormError(message),
   })
   const form = useProfileNewForm({
     isSubmitting: profileNewMutation.isPending,

--- a/apps/client/src/pages/profileNew/hooks/useUploadedProfileImageKey.ts
+++ b/apps/client/src/pages/profileNew/hooks/useUploadedProfileImageKey.ts
@@ -1,0 +1,27 @@
+import { useCallback, useRef } from 'react'
+
+import { uploadProfileImage } from '@/pages/profileNew/api/uploadProfileImage'
+
+export const useUploadedProfileImageKey = () => {
+  const uploadedProfileImageRef = useRef<
+    { file: File; fileKey: string } | undefined
+  >(undefined)
+
+  const getUploadedProfileImageKey = useCallback(async (file: File) => {
+    const cachedProfileImage = uploadedProfileImageRef.current
+
+    if (cachedProfileImage?.file === file) {
+      return cachedProfileImage.fileKey
+    }
+
+    const fileKey = await uploadProfileImage(file)
+    uploadedProfileImageRef.current = {
+      file,
+      fileKey,
+    }
+
+    return fileKey
+  }, [])
+
+  return { getUploadedProfileImageKey }
+}

--- a/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.test.ts
+++ b/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { mapProfileNewOnboardingError } from '@/pages/profileNew/utils/profileNewOnboardingError'
+import { applyProfileNewOnboardingError } from '@/pages/profileNew/utils/profileNewOnboardingError'
 import { ApiError } from '@/shared/api/apiError'
 import type { ErrorResponse } from '@/shared/api/types'
 
@@ -28,7 +28,7 @@ describe('profileNewOnboardingError utils', () => {
     const setFieldError = vi.fn()
     const setFormError = vi.fn()
 
-    const handled = mapProfileNewOnboardingError(
+    const handled = applyProfileNewOnboardingError(
       createErrorResponse('USER-001', 409, '중복된 닉네임입니다'),
       {
         setFieldError,
@@ -48,7 +48,7 @@ describe('profileNewOnboardingError utils', () => {
     const setFieldError = vi.fn()
     const setFormError = vi.fn()
 
-    const handled = mapProfileNewOnboardingError(
+    const handled = applyProfileNewOnboardingError(
       createErrorResponse('COMMON-400', 400, '잘못된 요청입니다', [
         {
           field: 'phone',
@@ -74,7 +74,7 @@ describe('profileNewOnboardingError utils', () => {
     const setFieldError = vi.fn()
     const setFormError = vi.fn()
 
-    const handled = mapProfileNewOnboardingError(
+    const handled = applyProfileNewOnboardingError(
       createErrorResponse('COMMON-400', 400, '잘못된 요청입니다', [
         {
           field: 'unknown',
@@ -97,7 +97,7 @@ describe('profileNewOnboardingError utils', () => {
     const setFieldError = vi.fn()
     const setFormError = vi.fn()
 
-    const handled = mapProfileNewOnboardingError(new Error('network'), {
+    const handled = applyProfileNewOnboardingError(new Error('network'), {
       setFieldError,
       setFormError,
     })

--- a/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.test.ts
+++ b/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { mapProfileNewOnboardingError } from '@/pages/profileNew/utils/profileNewOnboardingError'
+import { ApiError } from '@/shared/api/apiError'
+import type { ErrorResponse } from '@/shared/api/types'
+
+const createErrorResponse = (
+  code: string,
+  status: number,
+  message: string,
+  errors?: ErrorResponse['errors'],
+): ApiError =>
+  new ApiError(
+    {
+      success: false,
+      code,
+      message,
+      data: null,
+      timestamp: '2026-07-14T00:00:00.000Z',
+      path: '/api/v1/users/onboarding',
+      ...(errors ? { errors } : {}),
+    },
+    status,
+  )
+
+describe('profileNewOnboardingError utils', () => {
+  it('maps duplicated field errors to profile form fields', () => {
+    const setFieldError = vi.fn()
+    const setFormError = vi.fn()
+
+    const handled = mapProfileNewOnboardingError(
+      createErrorResponse('USER-001', 409, '중복된 닉네임입니다'),
+      {
+        setFieldError,
+        setFormError,
+      },
+    )
+
+    expect(handled).toBe(true)
+    expect(setFieldError).toHaveBeenCalledWith(
+      'nickname',
+      '중복된 닉네임입니다',
+    )
+    expect(setFormError).not.toHaveBeenCalled()
+  })
+
+  it('maps COMMON-400 field errors to profile form fields', () => {
+    const setFieldError = vi.fn()
+    const setFormError = vi.fn()
+
+    const handled = mapProfileNewOnboardingError(
+      createErrorResponse('COMMON-400', 400, '잘못된 요청입니다', [
+        {
+          field: 'phone',
+          rejectedValue: '010-1234-5678',
+          reason: '연락처는 하이픈 없이 숫자 10~11자리로 입력해주세요',
+        },
+      ]),
+      {
+        setFieldError,
+        setFormError,
+      },
+    )
+
+    expect(handled).toBe(true)
+    expect(setFieldError).toHaveBeenCalledWith(
+      'phoneNumber',
+      '연락처는 하이픈 없이 숫자 10~11자리로 입력해주세요',
+    )
+    expect(setFormError).not.toHaveBeenCalled()
+  })
+
+  it('uses form error when COMMON-400 has no mappable field error', () => {
+    const setFieldError = vi.fn()
+    const setFormError = vi.fn()
+
+    const handled = mapProfileNewOnboardingError(
+      createErrorResponse('COMMON-400', 400, '잘못된 요청입니다', [
+        {
+          field: 'unknown',
+          rejectedValue: '',
+          reason: '알 수 없는 오류입니다',
+        },
+      ]),
+      {
+        setFieldError,
+        setFormError,
+      },
+    )
+
+    expect(handled).toBe(true)
+    expect(setFieldError).not.toHaveBeenCalled()
+    expect(setFormError).toHaveBeenCalledWith('잘못된 요청입니다')
+  })
+
+  it('does not handle unexpected errors', () => {
+    const setFieldError = vi.fn()
+    const setFormError = vi.fn()
+
+    const handled = mapProfileNewOnboardingError(new Error('network'), {
+      setFieldError,
+      setFormError,
+    })
+
+    expect(handled).toBe(false)
+    expect(setFieldError).not.toHaveBeenCalled()
+    expect(setFormError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.ts
+++ b/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.ts
@@ -1,0 +1,108 @@
+import { isApiError } from '@/shared/api/apiError'
+import { getErrorPresentation } from '@/shared/api/errorPresentation'
+import type { FieldError } from '@/shared/api/types'
+
+export type ProfileNewFieldName =
+  | 'nickname'
+  | 'birthDate'
+  | 'phoneNumber'
+  | 'englishName'
+  | 'email'
+
+export interface ProfileNewOnboardingErrorHandlers {
+  setFieldError: (fieldName: ProfileNewFieldName, message: string) => void
+  setFormError: (message: string) => void
+}
+
+const ONBOARDING_ERROR_FIELD_MAP = {
+  nickname: 'nickname',
+  birthDate: 'birthDate',
+  phone: 'phoneNumber',
+  nameEng: 'englishName',
+  email: 'email',
+} as const
+
+const DUPLICATED_FIELD_ERROR_CODE_MAP = {
+  'USER-001': 'nickname',
+  'USER-002': 'email',
+  'USER-003': 'phoneNumber',
+} as const
+
+const getMappedFieldName = (field: string) => {
+  if (field in ONBOARDING_ERROR_FIELD_MAP) {
+    return ONBOARDING_ERROR_FIELD_MAP[
+      field as keyof typeof ONBOARDING_ERROR_FIELD_MAP
+    ]
+  }
+
+  return undefined
+}
+
+const getDuplicatedFieldName = (code: string) => {
+  if (code in DUPLICATED_FIELD_ERROR_CODE_MAP) {
+    return DUPLICATED_FIELD_ERROR_CODE_MAP[
+      code as keyof typeof DUPLICATED_FIELD_ERROR_CODE_MAP
+    ]
+  }
+
+  return undefined
+}
+
+const applyProfileNewFieldErrors = (
+  fieldErrors: FieldError[],
+  { setFieldError }: ProfileNewOnboardingErrorHandlers,
+) => {
+  let hasMappedFieldError = false
+
+  fieldErrors.forEach(({ field, reason }) => {
+    const mappedFieldName = getMappedFieldName(field)
+
+    if (!mappedFieldName) {
+      return
+    }
+
+    setFieldError(mappedFieldName, reason)
+    hasMappedFieldError = true
+  })
+
+  return hasMappedFieldError
+}
+
+export const mapProfileNewOnboardingError = (
+  error: unknown,
+  handlers: ProfileNewOnboardingErrorHandlers,
+) => {
+  if (!isApiError(error)) {
+    return false
+  }
+
+  const duplicatedFieldName = getDuplicatedFieldName(error.code)
+
+  if (duplicatedFieldName) {
+    handlers.setFieldError(
+      duplicatedFieldName,
+      getErrorPresentation(error).message,
+    )
+    return true
+  }
+
+  if (error.code === 'COMMON-400') {
+    const hasMappedFieldError = applyProfileNewFieldErrors(
+      error.fieldErrors,
+      handlers,
+    )
+
+    if (!hasMappedFieldError) {
+      handlers.setFormError(getErrorPresentation(error).message)
+    }
+
+    return true
+  }
+
+  if (error.code === 'USER-004') {
+    handlers.setFormError(getErrorPresentation(error).message)
+    return true
+  }
+
+  return false
+}

--- a/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.ts
+++ b/apps/client/src/pages/profileNew/utils/profileNewOnboardingError.ts
@@ -68,7 +68,7 @@ const applyProfileNewFieldErrors = (
   return hasMappedFieldError
 }
 
-export const mapProfileNewOnboardingError = (
+export const applyProfileNewOnboardingError = (
   error: unknown,
   handlers: ProfileNewOnboardingErrorHandlers,
 ) => {

--- a/apps/client/src/pages/profileNew/utils/profileNewRedirect.test.ts
+++ b/apps/client/src/pages/profileNew/utils/profileNewRedirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { ROUTES } from '@/app/router/path'
+import { getAllowedProfileNewRedirectPath } from '@/pages/profileNew/utils/profileNewRedirect'
+
+describe('profileNewRedirect utils', () => {
+  it('allows onboarding continuation routes with search and hash', () => {
+    expect(
+      getAllowedProfileNewRedirectPath(
+        '/restaurants/1/reviews/new?reservationId=1#review-form',
+      ),
+    ).toBe('/restaurants/1/reviews/new?reservationId=1#review-form')
+  })
+
+  it('falls back to home for unsupported, external, or protocol-relative redirect values', () => {
+    expect(getAllowedProfileNewRedirectPath(ROUTES.withdrawal)).toBe(
+      ROUTES.home,
+    )
+    expect(
+      getAllowedProfileNewRedirectPath('https://example.com/reviews/new'),
+    ).toBe(ROUTES.home)
+    expect(getAllowedProfileNewRedirectPath('//example.com/reviews/new')).toBe(
+      ROUTES.home,
+    )
+    expect(getAllowedProfileNewRedirectPath(null)).toBe(ROUTES.home)
+  })
+})

--- a/apps/client/src/pages/profileNew/utils/profileNewRedirect.ts
+++ b/apps/client/src/pages/profileNew/utils/profileNewRedirect.ts
@@ -1,0 +1,27 @@
+import { matchPath } from 'react-router-dom'
+
+import { ROUTES } from '@/app/router/path'
+
+const ALLOWED_PROFILE_NEW_REDIRECT_ROUTES = [
+  ROUTES.reviewNew,
+  ROUTES.restaurantReservationNew,
+  ROUTES.anywhereReservation,
+  ROUTES.reservationRequest,
+] as const
+
+const REDIRECT_URL_BASE = 'https://hashi.local'
+
+export const getAllowedProfileNewRedirectPath = (redirectTo: string | null) => {
+  if (!redirectTo?.startsWith('/') || redirectTo.startsWith('//')) {
+    return ROUTES.home
+  }
+
+  const redirectUrl = new URL(redirectTo, REDIRECT_URL_BASE)
+  const isAllowedRedirectPath = ALLOWED_PROFILE_NEW_REDIRECT_ROUTES.some(
+    (route) => matchPath({ path: route, end: true }, redirectUrl.pathname),
+  )
+
+  return isAllowedRedirectPath
+    ? `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`
+    : ROUTES.home
+}


### PR DESCRIPTION
## 📌 요약
> 프로필 생성 페이지의 중심 hook인 `useProfileNewPage`에 모여 있던 redirect 정책, 온보딩 mutation, 프로필 이미지 업로드 key 재사용, 서버 에러 매핑 로직을 역할별로 분리하는 리팩토링 작업을 진행했습니다!

Jira: HASHI-161

## 📚 작업 내용
- useProfileNewPage가 페이지 조합 역할에 집중하는 게 맞다고 판단하여 책임을 분리했습니다.
- 온보딩 완료 후 이동할 경로를 검증하는 redirect allowlist 로직을 별도 util로 분리했습니다.
- 온보딩 API 실패 응답을 form field error 또는 form-level error로 매핑하는 로직을 별도 util로 분리했습니다.
- 같은 프로필 이미지 파일로 재제출할 때 기존 업로드 `fileKey`를 재사용하는 로직을 별도 hook으로 분리했습니다.
- 온보딩 제출 mutation 흐름을 별도 hook으로 분리했습니다.
- redirect 정책과 서버 에러 매핑 정책에 대한 단위 테스트를 추가했습니다.

## 🔎 상세 설명
> 기존 useProfileNewPage는 프로필 생성 페이지의 form submit을 연결하는 hook이면서 동시에 여러 정책을 직접 알고 있었습니다.
- `redirectTo` query param이 허용된 경로인지 검증하는 라우팅 정책
- 외부 URL 또는 허용되지 않은 내부 경로를 차단하는 redirect 방어 로직
- 프로필 이미지가 선택된 경우 presigned upload를 먼저 수행하는 제출 흐름
- 같은 이미지 파일로 재제출할 때 이미 업로드된 `fileKey`를 재사용하는 캐시 로직
- 온보딩 API request body 생성
- 온보딩 API mutation 실행
- 온보딩 성공 시 access token 저장
- 온보딩 성공 후 redirect 처리
- 401/403 응답 시 인증 세션 정리 및 로그인 필요 페이지 이동
- `USER-001`, `USER-002`, `USER-003`, `COMMON-400`, `USER-004` 응답을 화면 에러로 매핑하는 로직
- 처리할 수 없는 에러를 ErrorBoundary로 전달하는 로직

### 기능 자체는 동작하지만 이후 수정이 필요한 상황에서 변경 범위가 커질 수 있고, 어떤 문제가 생겼을 때 어디를 봐야 하는지 헷갈릴 수 있어요!!!

- 예를 들어 redirect 허용 경로를 추가하려면 페이지 hook을 수정해야 하고, 서버 에러 코드가 바뀌어도 같은 페이지 hook을 수정해야 하며, 이미지 업로드 key 재사용 정책이 바뀌어도 같은 파일을 봐야 합니다. **서로 다른 이유로 변경되는 코드들이 하나의 hook에 모여 있어 유지보수성이 떨어질 수 있다고 판단했습니다.**
- 이번 리팩토링에서는 동작을 바꾸지 않고 책임 위치만 분리했습니닷!

### 1. useProfileNewPage 역할
- useProfileNewForm 생성
- useProfileNewMutation 연결
- 뒤로가기 핸들러 제공
- submit 이벤트에서 form draft 생성 후 mutation 실행
- ErrorBoundary로 전달할 boundaryError 상태 관리

### 2. useProfileNewMutation
- 온보딩 제출 mutation 담당
- 프로필 이미지가 있으면 업로드 key를 먼저 확보
- 온보딩 request body 생성
- `requestOnboarding` 호출
- 성공 시 access token 저장
- 성공 후 redirect 실행
- 401/403 응답 시 세션 정리 후 로그인 필요 페이지 이동
- 처리 가능한 서버 에러는 form error로 반영
- 처리할 수 없는 에러는 `onUnhandledError`로 전달

### 3. useUploadedProfileImageKey
- 프로필 이미지 업로드 key 재사용 담당
- 동일한 `File` 객체로 재제출하면 이전에 성공한 `fileKey`를 재사용
- 다른 파일이면 다시 업로드 후 새 `fileKey` 저장

### 4. profileNewRedirect
- 온보딩 완료 후 이동할 redirect path 검증 담당
- 허용된 내부 route만 통과
- 외부 URL과 protocol-relative URL 차단
- 허용된 path라면 query string과 hash를 보존
- 허용되지 않으면 `ROUTES.home` 반환

### 5. profileNewOnboardingError
- 온보딩 API 에러를 화면 form error로 매핑
- `USER-001`은 nickname field error
- `USER-002`는 email field error
- `USER-003`은 phoneNumber field error
- `COMMON-400`의 field error는 화면 field name으로 변환
- `USER-004`는 form-level error
- 처리 가능한 에러는 `true`, 처리할 수 없는 에러는 `false` 반환

### 6. 테스트
> 기존 `ProfileNewPage.test.tsx`가 전체 온보딩 플로우, 이미지 업로드, key 재사용, 성공/실패, redirect를 이미 통합 테스트로 검증하고 있기 때문에, `useProfileNewMutation`이나 `useUploadedProfileImageKey`에 대한 별도 테스트는 추가하지 않았습니다.  대신 redirect와 error mapping처럼 UI 없이도 정책 단위로 검증 가능한 부분만 단위 테스트를 추가했습니다.

- `profileNewRedirect.test.ts`
- `profileNewOnboardingError.test.ts`

## 💭 고민한 부분

### 고민한 문제
- useProfileNewPage가 너무 많은 책임을 가지고 있었지만 어디까지 분리하는 것이 적절한지 고민했습니다.
- 단순히 파일 수를 늘리는 리팩토링이 되지 않도록 실제로 변경 이유가 다른 로직만 분리하려고 했습니다.
- 기존 페이지 테스트가 이미 많은 케이스를 커버하고 있어서 새 테스트를 어디까지 추가해야 하는지도 고민이 되었어요.

### 고려한 선택지
- 선택지 1. useProfileNewPage 내부 구조만 정리하고 파일 분리는 하지 않기
- 선택지 2. redirect, error mapping 같은 순수 정책 로직만 util로 분리하기
- 선택지 3. redirect, error mapping, 이미지 업로드 key 재사용, onboarding mutation까지 역할별로 분리하기
- 선택지 4. useProfileNewForm의 이미지 입력 상태, touched field, validation 상태까지 함께 분리하기

### 최종 선택과 이유
> 최종적으로는 선택지 3을 선택했습니다.

- useProfileNewPage에서 문제가 되었던 책임은 단순히 코드 길이만의 문제가 아니라, 서로 다른 정책이 한 hook에 섞여 있다는 점이었습니다.
- 특히 아래 로직들은 변경 이유가 서로 달라요.
   - redirect allowlist는 라우팅/보안 정책
   - error mapping은 서버 API 계약과 화면 field name 사이의 매핑 정책
   - 이미지 업로드 key 재사용은 제출 최적화/업로드 캐시 정책
   - onboarding mutation은 비동기 제출 흐름과 성공/실패 처리 정책
   - page hook은 화면 상태와 이벤트를 조합하는 역할

-> 그래서 이 단위로 분리하는 것이 가장 자연스럽다고 생각했어요.

### 기타
> useProfileNewForm까지 이번 PR에서 함께 분리하지는 않았습니다.  
- useProfileNewForm도 내부에 이미지 입력, validation, server field error 관리가 포함되어 있지만, 현재는 프로필 생성 form 상태 관리라는 하나의 책임 안에 묶여 있다고 볼 수 있습니다. 여기까지 같이 분리하면 PR 범위가 커지고, 리뷰어가 온보딩 submit 구조와 form 내부 구조를 동시에 봐야 해서 리뷰 부담이 커질 수 있다고 판단했습니다. 이번 리팩토링 작업에서는 useProfileNewPage 책임 분리에 집중하고, useProfileNewForm은 필요 시 후속 리팩토링으로 진행하면 좋을 것 같아요!

### 남은 고민
- `useProfileNewForm`의 프로필 이미지 선택/preview/error 로직은 나중에 `useProfileImageInput` 같은 hook으로 분리할 수 있을 것 같습니다.
- 다만 touched field, server field error, validation 조합까지 지금 바로 분리하는 것은 오히려 form 흐름을 읽기 어렵게 만들 수 있어 보류했습니다.
- 추후 팀 차원에서 `react-hook-form`, `zod` 등 form 표준화 방향을 정한다면, 그때 `useProfileNewForm` 구조도 함께 재검토하는 것이 좋을 것 같습니다.
- 현재 `useProfileNewMutation`은 form error handler를 외부에서 주입받고 있는데, 이후 다른 온보딩 정책이 추가된다면 mutation hook의 인터페이스가 더 커지지 않도록 다시 점검할 필요가 있습니다.