### PR TITLE
Docs(client): HASHI-162 API 위치 기준 문서화

### DIFF
--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -151,6 +151,87 @@ apps/client/src/shared/hooks/
 `apps/client/src/shared/api`에는 low-level client, request, error 처리만 둡니다.
 Admin console endpoint boundary는 `apps/admin/src/shared/api`에 두고 client generated type을 import하지 않습니다.
 
+### Page-local vs Feature-local API
+
+API 위치는 endpoint path만 보고 결정하지 않습니다. 실제 소유 화면, 재사용 범위,
+query key/cache 책임, request/response adapter 성격을 함께 보고 결정합니다.
+
+#### 위치별 역할
+
+`pages/{page}/api`
+
+- 특정 page의 진입, 제출, 화면 전용 adapter에 묶인 API를 둡니다.
+- 다른 page에서 같은 서버 상태를 공유하지 않는 경우 page-local로 유지합니다.
+- 예시:
+  - `pages/profileNew/api/requestOnboarding.ts`
+  - `pages/home/api/getHotSnsRestaurants.ts`
+  - `pages/search/api/getSearchKeywordRecommendations.ts`
+
+`features/{feature}/api`
+
+- 여러 page에서 같은 public API, 같은 서버 상태, 같은 cache synchronization 기준을
+  공유하는 API를 둡니다.
+- 예시:
+  - `features/restaurantList/api/getRestaurants.ts`
+  - `features/magazine/api/getMagazineBanners.ts`
+  - `features/review/api/deleteReview.ts`
+
+`shared/api`
+
+- 도메인 endpoint가 아니라 앱 공통 API 인프라만 둡니다.
+- HTTP client, request wrapper, response envelope, error model, generated OpenAPI
+  type이 여기에 해당합니다.
+- 예시:
+  - `shared/api/request.ts`
+  - `shared/api/apiError.ts`
+  - `shared/api/generated/openapi.ts`
+
+page-local API는 나쁜 구조가 아닙니다. 한 화면에서만 쓰는 API를 미리 feature로
+올리면 feature가 page 전용 흐름을 알게 되어 경계가 흐려질 수 있습니다. 반대로
+같은 API와 query key를 여러 page가 각자 page-local로 만들면 cache key,
+invalidation, error 처리 기준이 갈라질 수 있습니다.
+
+### Placement Decision Checklist
+
+새 endpoint 함수, query, mutation을 추가하거나 기존 위치를 바꿀 때는 아래 순서로
+판단합니다.
+
+1. 이 API가 현재 한 page에서만 사용되는지 확인합니다.
+2. 다른 page가 같은 서버 상태와 같은 cache key를 공유하는지 확인합니다.
+3. request body나 response mapping이 특정 page draft/view model에 강하게 묶여 있는지 확인합니다.
+4. mutation 성공 후 invalidate해야 하는 query key가 feature 전반에 걸쳐 있는지 확인합니다.
+5. 재사용 근거가 명확하면 feature로 두고, 근거가 아직 없으면 page-local에서 시작합니다.
+6. shared에는 endpoint 함수를 두지 않고 low-level API 인프라만 둡니다.
+
+### Promotion Rule
+
+page-local API를 feature로 승격하는 기준은 다음과 같습니다.
+
+- 같은 endpoint 함수가 둘 이상의 page에서 필요해졌습니다.
+- 같은 query key factory를 여러 page가 공유해야 합니다.
+- mutation 성공 후 여러 page의 같은 도메인 cache를 일관되게 갱신해야 합니다.
+- page 전용 draft/view model 의존성을 제거해도 API 함수의 의미가 유지됩니다.
+- feature 내부 component, hook, query가 같은 API 타입을 공통 계약으로 사용합니다.
+
+승격 조건이 충족되지 않은 API는 당장 이동하지 않습니다. 대신 page spec이나 PR에
+"다른 page에서 재사용되면 feature로 승격" 조건을 남깁니다.
+
+현재 코드 기준 예시는 다음과 같습니다.
+
+- `pages/home/api/getHotSnsRestaurants.ts`는 `getRestaurants`를 홈 전용
+  `type=sns-hot`, `size=5` 조건으로 감싼 adapter이므로 page-local에 둡니다.
+- `pages/magazines/api/getMagazines.ts`는 매거진 목록 page 전용 cursor list이므로
+  같은 목록 계약을 다른 page가 사용하기 전까지 page-local에 둡니다.
+- `features/magazine/api/getMagazineBanners.ts`는 Home과 Magazines가 공유하므로
+  feature-local에 둡니다.
+- `features/restaurantList/api/getRestaurants.ts`는 Search, HashiPick,
+  PopularRestaurants, Home adapter에서 공유하므로 feature-local에 둡니다.
+- `pages/reservationRequest/api/createReservation.ts`는 `ReservationRequestDraft`에
+  강하게 의존하는 제출 adapter이므로 page-local에 둡니다.
+- 리뷰 관련 `myReviews`, `reviewDetail`, `reviewNew` API는 각 page 전용 흐름에서
+  시작하되, `reviewEdit` 등 다른 page와 같은 상세 조회, 이미지 업로드, cache
+  invalidation 기준을 공유하게 되면 `features/review` 승격을 검토합니다.
+
 ## Query Key Rules
 
 - query key factory는 같은 도메인 안에서 named export로 관리합니다.

--- a/docs/workflows/api-integration.md
+++ b/docs/workflows/api-integration.md
@@ -90,6 +90,23 @@ apps/client/src/features/{feature}/
   types.ts
 ```
 
+위치 판단은 다음 기준을 따릅니다.
+
+- 특정 page의 화면 진입, 제출, page draft/view model에 묶인 API는 page-local로 둡니다.
+- 여러 page가 같은 endpoint, 같은 query key, 같은 cache synchronization 기준을 공유하면 feature로 둡니다.
+- `shared/api`에는 endpoint 함수를 두지 않고 request wrapper, error model, generated OpenAPI type 같은 공통 인프라만 둡니다.
+- 재사용 가능성이 있어 보인다는 이유만으로 feature로 미리 올리지 않습니다.
+- 실제로 두 번째 사용처가 생기거나 cache/invalidation 기준을 공유해야 할 때 feature로 승격합니다.
+- 애매한 경우에는 page-local에서 시작하고, page spec 또는 PR에 feature 승격 조건을 남깁니다.
+
+예시:
+
+- Home 전용 SNS 인기 식당 adapter는 `pages/home/api`에 둡니다.
+- 검색, 하시픽, 인기 식당이 공유하는 식당 목록 조회는 `features/restaurantList/api`에 둡니다.
+- Home과 Magazines가 공유하는 매거진 배너 조회는 `features/magazine/api`에 둡니다.
+- 프로필 생성 온보딩처럼 특정 route의 제출 흐름에 묶인 API는 `pages/profileNew/api`에 둡니다.
+- 리뷰 상세 조회나 리뷰 이미지 업로드는 다른 리뷰 page와 공유되기 전까지 page-local에서 시작하고, `reviewEdit` 등 재사용처가 생기면 `features/review` 승격을 검토합니다.
+
 `apps/client/src/shared/api`는 low-level HTTP client와 response/error 처리만 담당합니다.
 Admin console API boundary는 `apps/admin/src/shared/api`에서 같은 원칙을 따릅니다.
 


### PR DESCRIPTION
## 📌 요약
> 스프린트 개발에서 새 페이지/기능이 추가될 때 API 위치를 일관되게 판단할 수 있도록 `page-local`, `feature-local`, `shared/api` 기준을 문서화했습니다.

Jira: HASHI-162

## 📚 작업 내용

### 문서 수정

#### `docs/architecture/data-layer.md`

- API 위치 판단 기준 추가
- `page-local API`, `feature-local API`, `shared API` 역할 구분
- `page-local API`를 `feature API`로 승격하는 기준 추가
- 현재 코드 기준 예시 추가

#### `docs/workflows/api-integration.md`

- API 연동 시 참고할 placement 체크리스트 추가
- API 위치 판단 예시 추가

## 🔎 상세 설명

### 작업 배경
> 스프린트 개발이 시작되면서 1차 개발 범위에서 제외했던 페이지나 기능들이 추가될 예정이예요. 기능이 늘어나면 기존에는 특정 page 전용으로 시작했던 API가 다른 페이지에서도 재사용되거나, 같은 도메인의 query key와 cache synchronization 기준을 여러 화면에서 공유해야 하는 상황이 생길 것 같더라구요!

#### 그래서 이번 작업에서는 스프린트 시작 전에 page-local과 feature-local의 경계를 명확히 정리하고, 새 페이지/기능이 추가될 때 어떤 기준으로 API를 배치하거나 feature로 승격할지 판단할 수 있도록 문서 기준을 고도화했습니다.

**만약 기준이 명확하지 않으면 여러 문제가 생길 수 있어요!!**

- 비슷한 API 함수가 page마다 중복으로 생김
- 원래는 feature로 승격해야 하는 코드가 계속 page-local에 남음
- 같은 도메인의 query key/cache synchronization 기준이 화면마다 달라짐
- 아직 한 페이지에서만 쓰는 API를 너무 빨리 feature로 올려 feature가 page 전용 흐름까지 알게 됨

### 기존 상태

- 기존 코드에도 어느 정도 기준은 적용되어 있긴합니다.

| 구분 | 기존 방향 |
| --- | --- |
| 한 page 전용 API | `pages/*/api` |
| 여러 page가 공유하는 API | `features/*/api` |
| 공통 request/error/generated type | `shared/api` |

### 정리한 기준

- API 위치는 endpoint path만 보고 결정하지 않고, 실제 소유 화면, 재사용 범위, query key/cache 책임, request/response adapter 성격을 함께 보고 결정하도록 정리했습니다.

| 위치 | 기준 |
| --- | --- |
| `pages/{page}/api` | 특정 page의 진입, 제출, 화면 전용 adapter에 묶인 API |
| `features/{feature}/api` | 여러 page에서 같은 public API, 서버 상태, query key, cache synchronization 기준을 공유하는 API |
| `shared/api` | request wrapper, error model, generated OpenAPI type 같은 공통 인프라 |

- 재사용 가능성이 있어 보인다는 이유만으로 feature로 미리 올리지 않음
- 실제로 두 번째 사용처가 생기거나 cache/invalidation 기준을 공유해야 할 때 feature로 승격
- 애매한 경우에는 page-local에서 시작
- page spec 또는 PR에 feature 승격 조건을 남김
- shared/api에는 도메인 endpoint 함수를 두지 않음

### 현재 코드 기준 예시

| 파일 | 판단 |
| --- | --- |
| `pages/home/api/getHotSnsRestaurants.ts` | 홈 전용 SNS 인기 식당 adapter이므로 page-local 유지 |
| `pages/magazines/api/getMagazines.ts` | 매거진 목록 page 전용 cursor list이므로 page-local 유지 |
| `features/magazine/api/getMagazineBanners.ts` | Home과 Magazines에서 공유하므로 feature-local 유지 |
| `features/restaurantList/api/getRestaurants.ts` | Search, HashiPick, PopularRestaurants, Home adapter에서 공유하므로 feature-local 유지 |
| `pages/reservationRequest/api/createReservation.ts` | `ReservationRequestDraft`에 강하게 의존하는 제출 adapter이므로 page-local 유지 |
| 리뷰 관련 `myReviews`, `reviewDetail`, `reviewNew` API | 현재는 page 전용 흐름에서 시작하되, `reviewEdit` 등 재사용처가 생기면 `features/review` 승격 검토 |

## 💭 고민한 부분

### 고민한 문제

- 스프린트가 시작되면 기존에 제외했던 페이지와 기능들이 추가되면서 page-local로 시작했던 API가 feature로 승격되는 경우가 늘어날 수 있습니다.
- 이때 API 위치 기준이 명확하지 않으면, 같은 성격의 API도 작업자에 따라 `pages/*/api`에 들어가거나 `features/*/api`에 들어갈 수 있을 것 같더라구요.
- 비슷한 API 함수가 page마다 중복으로 생기거나 같은 도메인의 query key/cache synchronization 기준이 화면마다 달라질 수 있습니다.
- 반대로 모든 API를 도메인 이름 기준으로 features에 올리면, 실제로는 특정 page에서만 쓰는 API까지 feature에 섞이게 됩니다. 그렇게 되면 feature가 page 전용 draft, view model, 제출 흐름을 알게 되어 경계가 흐려질 수 있습니다.

### 고려한 선택지

| 선택지 | 내용 | 판단 |
| --- | --- | --- |
| 1 | 현재 page-local API를 feature로 일괄 이동 | 기능 변화 없이 import diff가 커지고 충돌 가능성이 커질 수 있어 제외 |
| 2 | 애매한 API만 일부 이동 | 기준이 먼저 정리되지 않으면 이동 판단도 다시 흔들릴 수 있어 보류 |
| 3 | 코드 이동 없이 문서 기준만 먼저 정리 | 현재 작업 목적에 가장 적합하다고 판단 |

### 최종 선택과 이유

> 최종적으로는 **코드 이동 없이 문서 기준만 먼저 정리하는 방식**을 선택했습니다.

- 현재 코드가 당장 크게 잘못 배치된 상태는 아니고, 이미 대체로 아래 방향을 따르고 있었습니다.

   - 한 page 전용 API는 page-local
   - 여러 page가 공유하는 API는 feature-local
  - 공통 request/error/generated type은 shared

- 파일을 무리하게 이동하면 기능 변화 없이 import diff만 커지고, 다른 작업 브랜치와 충돌 가능성도 커질 수 있다고 판단했습니다. 대신 문서에 기준과 예시를 명확히 남겨, 이후 API 추가/수정 시 팀원이 같은 기준으로 판단할 수 있도록 했습니다.

### 남은 고민
- 리뷰 관련 API는 `myReviews`, `reviewDetail`, `reviewNew`, 추후 `reviewEdit`까지 연결될 가능성이 있어 별도 이슈에서 위치 기준을 다시 정리하는 것이 좋을 것 같습니다.
- 예약 관련 API도 생성/상세/취소/목록이 늘어나면 query key와 cache invalidation 기준을 함께 점검할 필요가 있습니다.
- 이번 문서는 판단 기준을 정리한 것이므로, 이후 실제 코드 이동은 재사용 근거가 생긴 시점에 별도 PR로 진행하는 것이 좋을 것 같습니다.