### PR TITLE
Refactor(client): HASHI-156 RestaurantDetailPage 책임 분리

### DIFF
--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import type { RestaurantSummary } from '@/features/restaurantDetail/api/getRestaurantSummary'
-import { useRestaurantDetailInfiniteLists } from '@/features/restaurantDetail/hooks/useRestaurantDetailInfiniteLists'
+import { useRestaurantDetailListQueries } from '@/features/restaurantDetail/hooks/useRestaurantDetailListQueries'
 import { useRestaurantDetailReviewImageViewer } from '@/features/restaurantDetail/hooks/useRestaurantDetailReviewImageViewer'
 import { useRestaurantDetailReviewUnavailableModal } from '@/features/restaurantDetail/hooks/useRestaurantDetailReviewUnavailableModal'
 import { useRestaurantDetailTabs } from '@/features/restaurantDetail/hooks/useRestaurantDetailTabs'
@@ -32,7 +32,7 @@ export const useRestaurantDetailContent = ({
     ...restaurantStoreInformationQueryOptions(restaurantId),
     enabled,
   })
-  const infiniteLists = useRestaurantDetailInfiniteLists({
+  const infiniteLists = useRestaurantDetailListQueries({
     activeTab: detailTabs.activeTab,
     enabled,
     menuPageSize,

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
@@ -55,10 +55,13 @@ export const useRestaurantDetailContent = ({
       : null
 
   const handlePressReviewImage = (reviewId: string, imageIndex: number) => {
+    const selectedReview = restaurant?.reviews.find(
+      (review) => review.id === reviewId,
+    )
+
     reviewImageViewer.onOpenReviewImageViewer({
-      imageIndex,
-      restaurant,
-      reviewId,
+      imageUrls: selectedReview?.images ?? [],
+      initialIndex: imageIndex,
     })
   }
 

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
@@ -1,21 +1,13 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
-import { useCallback, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 
-import type { RestaurantMenuListData } from '@/features/restaurantDetail/api/getRestaurantMenus'
-import type { RestaurantReviewListData } from '@/features/restaurantDetail/api/getRestaurantReviews'
 import type { RestaurantSummary } from '@/features/restaurantDetail/api/getRestaurantSummary'
-import {
-  REVIEW_PAGE_SIZE,
-  type ReviewSortValue,
-} from '@/features/restaurantDetail/constants/restaurantReview'
-import {
-  restaurantMenusInfiniteQueryOptions,
-  restaurantReviewsInfiniteQueryOptions,
-  restaurantStoreInformationQueryOptions,
-} from '@/features/restaurantDetail/queries/restaurantDetailQueryOptions'
+import { useRestaurantDetailInfiniteLists } from '@/features/restaurantDetail/hooks/useRestaurantDetailInfiniteLists'
+import { useRestaurantDetailReviewImageViewer } from '@/features/restaurantDetail/hooks/useRestaurantDetailReviewImageViewer'
+import { useRestaurantDetailReviewUnavailableModal } from '@/features/restaurantDetail/hooks/useRestaurantDetailReviewUnavailableModal'
+import { useRestaurantDetailTabs } from '@/features/restaurantDetail/hooks/useRestaurantDetailTabs'
+import { restaurantStoreInformationQueryOptions } from '@/features/restaurantDetail/queries/restaurantDetailQueryOptions'
 import type { RestaurantDetailTab } from '@/features/restaurantDetail/types/restaurantDetail'
 import { createRestaurantDetailViewModel } from '@/features/restaurantDetail/utils/createRestaurantDetailViewModel'
-import { useInfiniteScrollTrigger } from '@/shared/hooks'
 
 interface UseRestaurantDetailContentParams {
   enabled?: boolean
@@ -32,145 +24,81 @@ export const useRestaurantDetailContent = ({
   restaurantId,
   summary,
 }: UseRestaurantDetailContentParams) => {
-  const [activeTab, setActiveTab] = useState<RestaurantDetailTab>(
-    initialTab ?? 'info',
-  )
-  const [selectedReviewSort, setSelectedReviewSort] =
-    useState<ReviewSortValue>('latest')
-  const [isReviewImageViewerOpen, setIsReviewImageViewerOpen] = useState(false)
-  const [reviewImageViewerImageUrls, setReviewImageViewerImageUrls] = useState<
-    string[]
-  >([])
-  const [reviewImageViewerInitialIndex, setReviewImageViewerInitialIndex] =
-    useState(0)
-  const [isReviewUnavailableModalOpen, setIsReviewUnavailableModalOpen] =
-    useState(false)
+  const detailTabs = useRestaurantDetailTabs({ initialTab })
+  const reviewImageViewer = useRestaurantDetailReviewImageViewer()
+  const reviewUnavailableModal = useRestaurantDetailReviewUnavailableModal()
 
   const storeInformationQuery = useQuery({
     ...restaurantStoreInformationQueryOptions(restaurantId),
     enabled,
   })
-  const menusQuery = useInfiniteQuery({
-    ...restaurantMenusInfiniteQueryOptions(restaurantId, menuPageSize),
+  const infiniteLists = useRestaurantDetailInfiniteLists({
+    activeTab: detailTabs.activeTab,
     enabled,
-  })
-  const reviewsQuery = useInfiniteQuery({
-    ...restaurantReviewsInfiniteQueryOptions({
-      restaurantId,
-      size: REVIEW_PAGE_SIZE,
-      sort: selectedReviewSort,
-    }),
-    enabled,
-  })
-
-  const canFetchNextMenuPage =
-    menusQuery.hasNextPage && !menusQuery.isFetchingNextPage
-  const canFetchNextReviewPage =
-    reviewsQuery.hasNextPage && !reviewsQuery.isFetchingNextPage
-  const { fetchNextPage: fetchNextMenuPage } = menusQuery
-  const { fetchNextPage: fetchNextReviewPage } = reviewsQuery
-
-  const handleIntersectMenu = useCallback(() => {
-    if (canFetchNextMenuPage) {
-      return fetchNextMenuPage()
-    }
-  }, [canFetchNextMenuPage, fetchNextMenuPage])
-
-  const handleIntersectReview = useCallback(() => {
-    if (canFetchNextReviewPage) {
-      return fetchNextReviewPage()
-    }
-  }, [canFetchNextReviewPage, fetchNextReviewPage])
-
-  const menuLoadMoreRef = useInfiniteScrollTrigger<HTMLDivElement>({
-    enabled: activeTab === 'menu' && canFetchNextMenuPage,
-    isLoading: menusQuery.isFetchingNextPage,
-    onIntersect: handleIntersectMenu,
-  })
-  const reviewLoadMoreRef = useInfiniteScrollTrigger<HTMLDivElement>({
-    enabled: activeTab === 'review' && canFetchNextReviewPage,
-    isLoading: reviewsQuery.isFetchingNextPage,
-    onIntersect: handleIntersectReview,
+    menuPageSize,
+    restaurantId,
+    selectedReviewSort: detailTabs.selectedReviewSort,
   })
 
   const storeInformation = storeInformationQuery.data
-  const menuPages = menusQuery.data?.pages ?? []
-  const reviewPages = reviewsQuery.data?.pages ?? []
-  const menus = menuPages.flatMap((page: RestaurantMenuListData) => page.menus)
-  const reviews = reviewPages.flatMap(
-    (page: RestaurantReviewListData) => page.reviews,
-  )
-  const firstReviewPage = reviewPages[0]
   const restaurant =
     summary && storeInformation
       ? createRestaurantDetailViewModel({
           summary,
           storeInformation,
-          menus,
-          reviews,
-          averageRating: firstReviewPage?.averageRating ?? 0,
-          reviewCount: firstReviewPage?.reviewCount ?? 0,
-          ratingDistribution: firstReviewPage?.ratingDistribution,
+          menus: infiniteLists.menus,
+          reviews: infiniteLists.reviews,
+          averageRating: infiniteLists.firstReviewPage?.averageRating ?? 0,
+          reviewCount: infiniteLists.firstReviewPage?.reviewCount ?? 0,
+          ratingDistribution: infiniteLists.firstReviewPage?.ratingDistribution,
         })
       : null
 
   const handlePressReviewImage = (reviewId: string, imageIndex: number) => {
-    const selectedReview = restaurant?.reviews.find(
-      (review) => review.id === reviewId,
-    )
-
-    setReviewImageViewerImageUrls(selectedReview?.images ?? [])
-    setReviewImageViewerInitialIndex(imageIndex)
-    setIsReviewImageViewerOpen(true)
-  }
-
-  const handleCloseReviewImageViewer = () => {
-    setIsReviewImageViewerOpen(false)
-  }
-
-  const handleOpenReviewUnavailableModal = () => {
-    setIsReviewUnavailableModalOpen(true)
-  }
-
-  const handleCloseReviewUnavailableModal = () => {
-    setIsReviewUnavailableModalOpen(false)
+    reviewImageViewer.onOpenReviewImageViewer({
+      imageIndex,
+      restaurant,
+      reviewId,
+    })
   }
 
   const resetDetailState = () => {
-    setActiveTab('info')
-    setSelectedReviewSort('latest')
-    setIsReviewImageViewerOpen(false)
-    setIsReviewUnavailableModalOpen(false)
-    setReviewImageViewerImageUrls([])
-    setReviewImageViewerInitialIndex(0)
+    detailTabs.resetTabs()
+    reviewImageViewer.resetReviewImageViewer()
+    reviewUnavailableModal.resetReviewUnavailableModal()
   }
 
   return {
-    activeTab,
+    activeTab: detailTabs.activeTab,
     error: storeInformationQuery.error,
-    hasMoreMenus: menusQuery.hasNextPage,
-    hasMoreReviews: reviewsQuery.hasNextPage,
+    hasMoreMenus: infiniteLists.hasMoreMenus,
+    hasMoreReviews: infiniteLists.hasMoreReviews,
     isLoading:
-      enabled && (!summary || !storeInformation || menusQuery.isPending),
-    isMenuListError: menusQuery.isError && menuPages.length === 0,
-    isReviewImageViewerOpen,
-    isReviewListError: reviewsQuery.isError && reviewPages.length === 0,
-    isReviewListLoading: reviewsQuery.isPending,
-    isReviewUnavailableModalOpen,
-    menuLoadMoreRef,
-    onCloseReviewImageViewer: handleCloseReviewImageViewer,
-    onCloseReviewUnavailableModal: handleCloseReviewUnavailableModal,
-    onOpenReviewUnavailableModal: handleOpenReviewUnavailableModal,
+      enabled &&
+      (!summary || !storeInformation || infiniteLists.isMenuListPending),
+    isMenuListError: infiniteLists.isMenuListError,
+    isReviewImageViewerOpen: reviewImageViewer.isReviewImageViewerOpen,
+    isReviewListError: infiniteLists.isReviewListError,
+    isReviewListLoading: infiniteLists.isReviewListLoading,
+    isReviewUnavailableModalOpen:
+      reviewUnavailableModal.isReviewUnavailableModalOpen,
+    menuLoadMoreRef: infiniteLists.menuLoadMoreRef,
+    onCloseReviewImageViewer: reviewImageViewer.onCloseReviewImageViewer,
+    onCloseReviewUnavailableModal:
+      reviewUnavailableModal.onCloseReviewUnavailableModal,
+    onOpenReviewUnavailableModal:
+      reviewUnavailableModal.onOpenReviewUnavailableModal,
     onPressReviewImage: handlePressReviewImage,
-    onRetryMenuList: () => void menusQuery.refetch(),
-    onRetryReviewList: () => void reviewsQuery.refetch(),
-    onSelectReviewSort: setSelectedReviewSort,
-    onTabChange: setActiveTab,
+    onRetryMenuList: infiniteLists.onRetryMenuList,
+    onRetryReviewList: infiniteLists.onRetryReviewList,
+    onSelectReviewSort: detailTabs.onSelectReviewSort,
+    onTabChange: detailTabs.onTabChange,
     resetDetailState,
     restaurant,
-    reviewImageViewerImageUrls,
-    reviewImageViewerInitialIndex,
-    reviewLoadMoreRef,
-    selectedReviewSort,
+    reviewImageViewerImageUrls: reviewImageViewer.reviewImageViewerImageUrls,
+    reviewImageViewerInitialIndex:
+      reviewImageViewer.reviewImageViewerInitialIndex,
+    reviewLoadMoreRef: infiniteLists.reviewLoadMoreRef,
+    selectedReviewSort: detailTabs.selectedReviewSort,
   }
 }

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailContent.ts
@@ -63,7 +63,7 @@ export const useRestaurantDetailContent = ({
   }
 
   const resetDetailState = () => {
-    detailTabs.resetTabs()
+    detailTabs.resetTabsToDefault()
     reviewImageViewer.resetReviewImageViewer()
     reviewUnavailableModal.resetReviewUnavailableModal()
   }

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailInfiniteLists.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailInfiniteLists.ts
@@ -1,0 +1,97 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
+
+import type { RestaurantMenuListData } from '@/features/restaurantDetail/api/getRestaurantMenus'
+import type { RestaurantReviewListData } from '@/features/restaurantDetail/api/getRestaurantReviews'
+import {
+  REVIEW_PAGE_SIZE,
+  type ReviewSortValue,
+} from '@/features/restaurantDetail/constants/restaurantReview'
+import {
+  restaurantMenusInfiniteQueryOptions,
+  restaurantReviewsInfiniteQueryOptions,
+} from '@/features/restaurantDetail/queries/restaurantDetailQueryOptions'
+import type { RestaurantDetailTab } from '@/features/restaurantDetail/types/restaurantDetail'
+import { useInfiniteScrollTrigger } from '@/shared/hooks'
+
+interface UseRestaurantDetailInfiniteListsParams {
+  activeTab: RestaurantDetailTab
+  enabled: boolean
+  menuPageSize: number
+  restaurantId: number
+  selectedReviewSort: ReviewSortValue
+}
+
+export const useRestaurantDetailInfiniteLists = ({
+  activeTab,
+  enabled,
+  menuPageSize,
+  restaurantId,
+  selectedReviewSort,
+}: UseRestaurantDetailInfiniteListsParams) => {
+  const menusQuery = useInfiniteQuery({
+    ...restaurantMenusInfiniteQueryOptions(restaurantId, menuPageSize),
+    enabled,
+  })
+  const reviewsQuery = useInfiniteQuery({
+    ...restaurantReviewsInfiniteQueryOptions({
+      restaurantId,
+      size: REVIEW_PAGE_SIZE,
+      sort: selectedReviewSort,
+    }),
+    enabled,
+  })
+
+  const canFetchNextMenuPage =
+    menusQuery.hasNextPage && !menusQuery.isFetchingNextPage
+  const canFetchNextReviewPage =
+    reviewsQuery.hasNextPage && !reviewsQuery.isFetchingNextPage
+  const { fetchNextPage: fetchNextMenuPage } = menusQuery
+  const { fetchNextPage: fetchNextReviewPage } = reviewsQuery
+
+  const handleIntersectMenu = useCallback(() => {
+    if (canFetchNextMenuPage) {
+      return fetchNextMenuPage()
+    }
+  }, [canFetchNextMenuPage, fetchNextMenuPage])
+
+  const handleIntersectReview = useCallback(() => {
+    if (canFetchNextReviewPage) {
+      return fetchNextReviewPage()
+    }
+  }, [canFetchNextReviewPage, fetchNextReviewPage])
+
+  const menuLoadMoreRef = useInfiniteScrollTrigger<HTMLDivElement>({
+    enabled: activeTab === 'menu' && canFetchNextMenuPage,
+    isLoading: menusQuery.isFetchingNextPage,
+    onIntersect: handleIntersectMenu,
+  })
+  const reviewLoadMoreRef = useInfiniteScrollTrigger<HTMLDivElement>({
+    enabled: activeTab === 'review' && canFetchNextReviewPage,
+    isLoading: reviewsQuery.isFetchingNextPage,
+    onIntersect: handleIntersectReview,
+  })
+
+  const menuPages = menusQuery.data?.pages ?? []
+  const reviewPages = reviewsQuery.data?.pages ?? []
+  const menus = menuPages.flatMap((page: RestaurantMenuListData) => page.menus)
+  const reviews = reviewPages.flatMap(
+    (page: RestaurantReviewListData) => page.reviews,
+  )
+
+  return {
+    firstReviewPage: reviewPages[0],
+    hasMoreMenus: menusQuery.hasNextPage,
+    hasMoreReviews: reviewsQuery.hasNextPage,
+    isMenuListError: menusQuery.isError && menuPages.length === 0,
+    isMenuListPending: menusQuery.isPending,
+    isReviewListError: reviewsQuery.isError && reviewPages.length === 0,
+    isReviewListLoading: reviewsQuery.isPending,
+    menuLoadMoreRef,
+    menus,
+    onRetryMenuList: () => void menusQuery.refetch(),
+    onRetryReviewList: () => void reviewsQuery.refetch(),
+    reviewLoadMoreRef,
+    reviews,
+  }
+}

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailListQueries.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailListQueries.ts
@@ -14,7 +14,7 @@ import {
 import type { RestaurantDetailTab } from '@/features/restaurantDetail/types/restaurantDetail'
 import { useInfiniteScrollTrigger } from '@/shared/hooks'
 
-interface UseRestaurantDetailInfiniteListsParams {
+interface UseRestaurantDetailListQueriesParams {
   activeTab: RestaurantDetailTab
   enabled: boolean
   menuPageSize: number
@@ -22,13 +22,13 @@ interface UseRestaurantDetailInfiniteListsParams {
   selectedReviewSort: ReviewSortValue
 }
 
-export const useRestaurantDetailInfiniteLists = ({
+export const useRestaurantDetailListQueries = ({
   activeTab,
   enabled,
   menuPageSize,
   restaurantId,
   selectedReviewSort,
-}: UseRestaurantDetailInfiniteListsParams) => {
+}: UseRestaurantDetailListQueriesParams) => {
   const menusQuery = useInfiniteQuery({
     ...restaurantMenusInfiniteQueryOptions(restaurantId, menuPageSize),
     enabled,

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailReviewImageViewer.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailReviewImageViewer.ts
@@ -1,11 +1,8 @@
 import { useState } from 'react'
 
-import type { RestaurantDetail } from '@/features/restaurantDetail/types/restaurantDetail'
-
 interface OpenReviewImageViewerParams {
-  imageIndex: number
-  restaurant: RestaurantDetail | null
-  reviewId: string
+  imageUrls: string[]
+  initialIndex: number
 }
 
 export const useRestaurantDetailReviewImageViewer = () => {
@@ -17,16 +14,11 @@ export const useRestaurantDetailReviewImageViewer = () => {
     useState(0)
 
   const openReviewImageViewer = ({
-    imageIndex,
-    restaurant,
-    reviewId,
+    imageUrls,
+    initialIndex,
   }: OpenReviewImageViewerParams) => {
-    const selectedReview = restaurant?.reviews.find(
-      (review) => review.id === reviewId,
-    )
-
-    setReviewImageViewerImageUrls(selectedReview?.images ?? [])
-    setReviewImageViewerInitialIndex(imageIndex)
+    setReviewImageViewerImageUrls(imageUrls)
+    setReviewImageViewerInitialIndex(initialIndex)
     setIsReviewImageViewerOpen(true)
   }
 

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailReviewImageViewer.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailReviewImageViewer.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+
+import type { RestaurantDetail } from '@/features/restaurantDetail/types/restaurantDetail'
+
+interface OpenReviewImageViewerParams {
+  imageIndex: number
+  restaurant: RestaurantDetail | null
+  reviewId: string
+}
+
+export const useRestaurantDetailReviewImageViewer = () => {
+  const [isReviewImageViewerOpen, setIsReviewImageViewerOpen] = useState(false)
+  const [reviewImageViewerImageUrls, setReviewImageViewerImageUrls] = useState<
+    string[]
+  >([])
+  const [reviewImageViewerInitialIndex, setReviewImageViewerInitialIndex] =
+    useState(0)
+
+  const openReviewImageViewer = ({
+    imageIndex,
+    restaurant,
+    reviewId,
+  }: OpenReviewImageViewerParams) => {
+    const selectedReview = restaurant?.reviews.find(
+      (review) => review.id === reviewId,
+    )
+
+    setReviewImageViewerImageUrls(selectedReview?.images ?? [])
+    setReviewImageViewerInitialIndex(imageIndex)
+    setIsReviewImageViewerOpen(true)
+  }
+
+  const closeReviewImageViewer = () => {
+    setIsReviewImageViewerOpen(false)
+  }
+
+  const resetReviewImageViewer = () => {
+    setIsReviewImageViewerOpen(false)
+    setReviewImageViewerImageUrls([])
+    setReviewImageViewerInitialIndex(0)
+  }
+
+  return {
+    isReviewImageViewerOpen,
+    onCloseReviewImageViewer: closeReviewImageViewer,
+    onOpenReviewImageViewer: openReviewImageViewer,
+    resetReviewImageViewer,
+    reviewImageViewerImageUrls,
+    reviewImageViewerInitialIndex,
+  }
+}

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailReviewUnavailableModal.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailReviewUnavailableModal.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+export const useRestaurantDetailReviewUnavailableModal = () => {
+  const [isReviewUnavailableModalOpen, setIsReviewUnavailableModalOpen] =
+    useState(false)
+
+  const openReviewUnavailableModal = () => {
+    setIsReviewUnavailableModalOpen(true)
+  }
+
+  const closeReviewUnavailableModal = () => {
+    setIsReviewUnavailableModalOpen(false)
+  }
+
+  const resetReviewUnavailableModal = () => {
+    setIsReviewUnavailableModalOpen(false)
+  }
+
+  return {
+    isReviewUnavailableModalOpen,
+    onCloseReviewUnavailableModal: closeReviewUnavailableModal,
+    onOpenReviewUnavailableModal: openReviewUnavailableModal,
+    resetReviewUnavailableModal,
+  }
+}

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailTabs.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailTabs.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+import type { ReviewSortValue } from '@/features/restaurantDetail/constants/restaurantReview'
+import type { RestaurantDetailTab } from '@/features/restaurantDetail/types/restaurantDetail'
+
+interface UseRestaurantDetailTabsParams {
+  initialTab?: RestaurantDetailTab
+}
+
+export const useRestaurantDetailTabs = ({
+  initialTab,
+}: UseRestaurantDetailTabsParams) => {
+  const [activeTab, setActiveTab] = useState<RestaurantDetailTab>(
+    initialTab ?? 'info',
+  )
+  const [selectedReviewSort, setSelectedReviewSort] =
+    useState<ReviewSortValue>('latest')
+
+  const resetTabs = () => {
+    setActiveTab('info')
+    setSelectedReviewSort('latest')
+  }
+
+  return {
+    activeTab,
+    onSelectReviewSort: setSelectedReviewSort,
+    onTabChange: setActiveTab,
+    resetTabs,
+    selectedReviewSort,
+  }
+}

--- a/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailTabs.ts
+++ b/apps/client/src/features/restaurantDetail/hooks/useRestaurantDetailTabs.ts
@@ -16,7 +16,7 @@ export const useRestaurantDetailTabs = ({
   const [selectedReviewSort, setSelectedReviewSort] =
     useState<ReviewSortValue>('latest')
 
-  const resetTabs = () => {
+  const resetTabsToDefault = () => {
     setActiveTab('info')
     setSelectedReviewSort('latest')
   }
@@ -25,7 +25,7 @@ export const useRestaurantDetailTabs = ({
     activeTab,
     onSelectReviewSort: setSelectedReviewSort,
     onTabChange: setActiveTab,
-    resetTabs,
+    resetTabsToDefault,
     selectedReviewSort,
   }
 }

--- a/apps/client/src/pages/restaurantDetail/RestaurantDetailPage.spec.md
+++ b/apps/client/src/pages/restaurantDetail/RestaurantDetailPage.spec.md
@@ -81,7 +81,7 @@
 
 - query: restaurant menus infinite
 - endpoint: `GET /api/v1/restaurants/{restaurantId}/menus`
-- enabled condition: route param `restaurantId` is valid number and menu tab has been requested
+- enabled condition: route param `restaurantId` is valid number
 - request params:
   - path: `restaurantId`
   - query: `cursor`, `size`
@@ -93,7 +93,7 @@
 - refetch condition: route param `restaurantId` 변경
 - pagination:
   - `getNextPageParam`: `hasNext`가 true이면 `nextCursor`
-  - next page trigger: 공통 `useInfiniteScrollTrigger` sentinel intersect
+  - next page trigger: 메뉴 탭이 active일 때 공통 `useInfiniteScrollTrigger` sentinel intersect
 
 - query: restaurant reviews infinite
 - requested endpoint: `GET /api/v1/restaurants/{restaurantId}/reviews`

--- a/apps/client/src/pages/todayRestaurant/TodayRestaurantPage.spec.md
+++ b/apps/client/src/pages/todayRestaurant/TodayRestaurantPage.spec.md
@@ -91,7 +91,7 @@
 
 - query: restaurant menus infinite
 - endpoint: `GET /api/v1/restaurants/{restaurantId}/menus`
-- enabled condition: today restaurant id exists and menu tab has been requested
+- enabled condition: today restaurant id exists
 - request params:
   - path: `restaurantId`
   - query: `cursor`, `size`
@@ -103,7 +103,7 @@
 - refetch condition: restaurantId 변경
 - pagination:
   - `getNextPageParam`: `hasNext`가 true이면 `nextCursor`
-  - next page trigger: 공통 `useInfiniteScrollTrigger` sentinel intersect
+  - next page trigger: 메뉴 탭이 active일 때 공통 `useInfiniteScrollTrigger` sentinel intersect
 
 - query: restaurant reviews infinite
 - requested endpoint: `GET /api/v1/restaurants/{restaurantId}/reviews`


### PR DESCRIPTION
## 📌 요약

> RestaurantDetailPage의 상세 콘텐츠 hook 책임을 query / tab / infinite scroll / review image viewer / modal state 단위로 분리했습니다.

Jira: HASHI-156

> Stacked PR입니다.  
> base: `refactor/HASHI-157-restaurant-detail-common-actions`  
> head: `refactor/HASHI-156-restaurant-detail-content-split`  
> 머지는 HASHI-157 PR이 먼저 머지된 뒤 HASHI-156 PR을 머지하는 순서로 진행합니다.

## 📚 작업 내용

- `useRestaurantDetailContent`가 직접 들고 있던 상세 콘텐츠 상태와 목록 조회 책임을 작은 hook으로 분리했습니다.
- 탭/리뷰 정렬 상태를 `useRestaurantDetailTabs`로 분리했습니다.
- 메뉴/리뷰 infinite query와 load more ref를 `useRestaurantDetailInfiniteLists`로 분리했습니다.
- 리뷰 이미지 뷰어 상태를 `useRestaurantDetailReviewImageViewer`로 분리했습니다.
- 리뷰 작성 불가 모달 상태를 `useRestaurantDetailReviewUnavailableModal`로 분리했습니다.
- 기존 `RestaurantDetailPage`, `TodayRestaurantPage`의 `useRestaurantDetailContent` 사용 방식은 유지했습니다.

## 🔎 상세 설명

기존 `useRestaurantDetailContent`는 상세 화면의 중심 hook 안에서 서버 상태 조회, 탭 상태, 리뷰 정렬, 무한 스크롤, 리뷰 이미지 뷰어, 리뷰 작성 불가 모달 상태를 함께 관리하고 있었습니다.

이번 PR에서는 외부 페이지 사용부를 크게 바꾸지 않고, `useRestaurantDetailContent`가 각 작은 hook을 조합해 최종 `restaurant` view model과 템플릿 props를 내려주는 역할에 집중하도록 정리했습니다.

## 💭 고민한 부분

### 고민한 문제

- 상세 콘텐츠 hook이 너무 많은 역할을 가져 변경 시 충돌 가능성과 읽기 부담이 커질 수 있었습니다.
- `RestaurantDetailPage`와 `TodayRestaurantPage`가 함께 사용하는 hook이라 public API를 크게 바꾸면 영향 범위가 커질 수 있었습니다.

### 고려한 선택지

- `useRestaurantDetailContent` 내부에 작은 helper만 두고 파일 수를 늘리지 않는 방식
- 책임별 hook 파일로 분리해서 각 상태/조회 로직의 소유를 명확히 하는 방식

### 최종 선택과 이유

- 책임별 hook 파일로 분리했습니다.
- Jira의 목적이 중심 hook의 책임 분리였고, query / tab / infinite scroll / review image viewer / modal state가 서로 다른 관심사라 파일 단위로 나누는 편이 리뷰와 유지보수에 더 명확하다고 판단했습니다.
- 페이지 사용부는 유지해서 리팩토링으로 인한 동작 변경 리스크를 줄였습니다.

### 남은 고민

- HASHI-157 브랜치가 업데이트될 경우, 이 PR 브랜치도 최신 157 기준으로 rebase해서 diff가 섞이지 않도록 관리하겠습니다.
