### PR TITLE
Fix(analytics): GA 이벤트 전송 수정

### DIFF
--- a/apps/client/src/shared/lib/analytics.test.ts
+++ b/apps/client/src/shared/lib/analytics.test.ts
@@ -6,6 +6,15 @@ import {
   trackPageView,
 } from '@/shared/lib/analytics'
 
+const expectGtagCommand = (
+  command: IArguments | undefined,
+  expected: unknown[],
+) => {
+  expect(command).toBeDefined()
+  expect(Object.prototype.toString.call(command)).toBe('[object Arguments]')
+  expect(Array.from(command ?? [])).toEqual(expected)
+}
+
 describe('analytics', () => {
   beforeEach(() => {
     document.head.innerHTML = ''
@@ -38,9 +47,11 @@ describe('analytics', () => {
         'script[src="https://www.googletagmanager.com/gtag/js?id=G-TEST123"]',
       ),
     ).toBeInTheDocument()
-    expect(window.dataLayer).toEqual([
-      ['js', expect.any(Date)],
-      ['config', 'G-TEST123', { send_page_view: false }],
+    expectGtagCommand(window.dataLayer?.[0], ['js', expect.any(Date)])
+    expectGtagCommand(window.dataLayer?.[1], [
+      'config',
+      'G-TEST123',
+      { send_page_view: false },
     ])
   })
 
@@ -53,7 +64,7 @@ describe('analytics', () => {
     initAnalytics()
     trackPageView('/restaurants/1?tab=review')
 
-    expect(window.dataLayer?.at(-1)).toEqual([
+    expectGtagCommand(window.dataLayer?.at(-1), [
       'event',
       'page_view',
       {

--- a/apps/client/src/shared/lib/analytics.ts
+++ b/apps/client/src/shared/lib/analytics.ts
@@ -4,7 +4,7 @@ type GtagCommand = [string, ...unknown[]]
 
 declare global {
   interface Window {
-    dataLayer?: GtagCommand[]
+    dataLayer?: IArguments[]
     gtag?: (...args: GtagCommand) => void
   }
 }
@@ -23,9 +23,11 @@ export const initAnalytics = () => {
   window.dataLayer = window.dataLayer ?? []
   window.gtag =
     window.gtag ??
-    ((...args: GtagCommand) => {
-      window.dataLayer?.push(args)
-    })
+    function () {
+      // gtag.js requires queued commands to retain the Arguments object shape.
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer?.push(arguments)
+    }
 
   if (!document.getElementById(GA_SCRIPT_ID)) {
     const script = document.createElement('script')


### PR DESCRIPTION
## 📌 요약

Google Analytics 명령을 배열이 아닌 표준 `Arguments` 객체로 dataLayer에 전달하도록 수정했습니다.

Jira: HASHI-166

## 📚 작업 내용

- gtag 초기화 시 `arguments` 객체를 dataLayer에 전달
- 초기화·페이지뷰 명령의 전달 형식을 검증하는 회귀 테스트 추가

## 🔎 상세 설명

기존에는 rest parameter 배열을 dataLayer에 넣어 gtag.js가 명령을 처리하지 못했습니다. Google tag 표준 queue 형식인 `Arguments` 객체를 보존하도록 변경했습니다.

## 💭 고민한 부분

### 고민한 문제

- gtag.js 스크립트는 로드되지만 `collect` 요청이 발생하지 않았습니다.

### 고려한 선택지

- 배열 형태를 유지
- 표준 gtag queue 형식인 `Arguments` 객체 사용

### 최종 선택과 이유

- Google tag 표준 형식을 사용해 초기화와 이벤트 명령이 정상 해석되도록 했습니다.

### 남은 고민

- Preview 환경은 운영 측정 ID와 분리하거나 GA 변수를 제거해 운영 데이터 오염을 방지합니다.

## ✅ 검증

- [x] `pnpm --filter @hashi/client exec vitest run` (122 files, 601 tests)
- [x] `pnpm --filter @hashi/client typecheck`
- [x] `pnpm --filter @hashi/client lint`
- [x] `pnpm exec prettier --check apps/client/src/shared/lib/analytics.ts apps/client/src/shared/lib/analytics.test.ts`