### PR TITLE
Refactor(reservation): 예약 취소 성공 흐름 공통화

### DIFF
--- a/apps/client/src/features/reservation/hooks/useCancelReservationMutation.spec.md
+++ b/apps/client/src/features/reservation/hooks/useCancelReservationMutation.spec.md
@@ -1,0 +1,65 @@
+# Hook Spec: `useCancelReservationMutation`
+
+## Purpose
+
+예약 취소 API 호출 뒤 모든 예약 화면에 공통인 목록 cache 동기화와 성공 toast를 수행합니다. 화면별 detail cache, dialog, navigation은 page hook에 남깁니다.
+
+## Hook Type
+
+- [x] feature mutation hook
+- [x] server state synchronization hook
+
+## Inputs
+
+```ts
+useCancelReservationMutation({
+  onCanceled?: (result) => void | Promise<void>,
+})
+```
+
+| Input        | Required | Description                                                                                                                                                                                        |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onCanceled` | no       | 공통 목록 cache 동기화 전에 실행할 page-local best-effort 처리. 예약 상세의 detail cache 갱신처럼 feature가 알면 안 되는 query/UI 정책을 처리하며, 실패해도 서버 취소 성공 흐름을 중단하지 않는다. |
+
+## Owned Behavior
+
+1. `cancelReservation(reservationId)` mutation을 실행합니다.
+2. API 성공 시 `onCanceled`을 먼저 실행합니다. callback 실패는 Sentry에 보고하고 이후 성공 흐름을 계속합니다.
+3. UPCOMING / CANCELED 목록 cache를 `syncCanceledReservationCache`로 동기화합니다.
+4. 서버 성공 message를 toast로 한 번 노출합니다.
+5. API 실패 시 성공 callback, 목록 cache sync, 성공 toast를 실행하지 않습니다. 실패 toast는 QueryClient mutation 기본 `onError`가 담당합니다.
+
+## Non-Owned Behavior
+
+- 취소 dialog open/close state
+- 중복 confirm 방지 lock
+- 상세 query key와 detail cache 갱신 정책
+- 성공 뒤 tab 전환, scroll top, navigate
+- cancel API endpoint와 response contract
+- optimistic update
+
+## Ordering
+
+```text
+cancel API success
+  → onCanceled (page-local pre-processing)
+  → UPCOMING/CANCELED list cache synchronization
+  → success toast
+  → mutateAsync resolve
+  → page-local dialog close / tab switch / navigation
+```
+
+`syncCanceledReservationCache` 내부의 CANCELED 목록 prefetch가 실패해도 local cache 보정과 이후 success UI flow는 계속됩니다.
+`onCanceled`이 실패해도 서버 취소 결과를 실패로 바꾸지 않고 공통 cache 동기화와 성공 toast를 계속 실행합니다.
+
+## Verification
+
+- `useCancelReservationMutation.test.tsx`
+  - page-local callback → list cache sync → success toast 순서를 검증한다.
+  - page-local callback 실패 후에도 list cache sync, 성공 toast, mutation resolve가 유지되는지 검증한다.
+- `syncCanceledReservationCache.test.ts`
+  - UPCOMING 제거, CANCELED 추가, prefetch 실패 내성, 중복 삽입 방지를 검증한다.
+- `MyReservationsPage.test.tsx`
+  - 성공 toast가 한 번만 노출되고 CANCELED 탭으로 전환되는지 검증한다.
+- `ReservationDetailPage.test.tsx`
+  - detail cache 갱신, 성공 toast 한 번, CANCELED 목록 navigation을 검증한다.

--- a/apps/client/src/features/reservation/hooks/useCancelReservationMutation.test.tsx
+++ b/apps/client/src/features/reservation/hooks/useCancelReservationMutation.test.tsx
@@ -1,0 +1,179 @@
+import '@testing-library/jest-dom/vitest'
+
+import { showToast } from '@hashi/hds-ui'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { cancelReservation } from '@/features/reservation/api/cancelReservation'
+import { getMyReservations } from '@/features/reservation/api/getMyReservations'
+import type {
+  ReservationListResponse,
+  ReservationResponse,
+} from '@/features/reservation/api/getMyReservations'
+import { useCancelReservationMutation } from '@/features/reservation/hooks/useCancelReservationMutation'
+import { myReservationsQueryKeys } from '@/features/reservation/queries/myReservationsQueryKeys'
+
+vi.mock('@/features/reservation/api/cancelReservation', () => ({
+  cancelReservation: vi.fn(),
+}))
+
+vi.mock('@/features/reservation/api/getMyReservations', () => ({
+  getMyReservations: vi.fn(),
+}))
+
+vi.mock('@hashi/hds-ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hashi/hds-ui')>()
+
+  return {
+    ...actual,
+    showToast: vi.fn(),
+  }
+})
+
+const mockedCancelReservation = vi.mocked(cancelReservation)
+const mockedGetMyReservations = vi.mocked(getMyReservations)
+const mockedShowToast = vi.mocked(showToast)
+
+const canceledReservation = {
+  reservationId: 21,
+  restaurantId: 34,
+  restaurantName: '스시 하시',
+  reservedAt: '2026-07-20T18:30:00',
+  adultCount: 2,
+  reservationStatus: 'CANCELED',
+} as ReservationResponse
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+
+describe('useCancelReservationMutation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('runs page-local preparation before shared cache synchronization and success toast', async () => {
+    const queryClient = createQueryClient()
+    const events: string[] = []
+    const onCanceled = vi.fn(() => {
+      events.push('page')
+    })
+    const upcomingQueryKey = myReservationsQueryKeys.infiniteList('UPCOMING')
+
+    queryClient.setQueryData(upcomingQueryKey, {
+      pages: [
+        {
+          reservations: [
+            {
+              ...canceledReservation,
+              reservationStatus: 'CONFIRMED',
+            },
+          ],
+          hasNext: false,
+          totalCount: 1,
+        },
+      ],
+      pageParams: [null],
+    })
+    mockedCancelReservation.mockResolvedValue({
+      message: '예약 취소 요청이 완료되었습니다',
+      reservation: canceledReservation,
+    })
+    mockedGetMyReservations.mockImplementation(async () => {
+      events.push('sync')
+
+      return {
+        reservations: [],
+        hasNext: false,
+        totalCount: 0,
+      } satisfies ReservationListResponse
+    })
+    mockedShowToast.mockImplementation(() => {
+      events.push('toast')
+
+      return 'toast-id'
+    })
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(
+      () => useCancelReservationMutation({ onCanceled }),
+      { wrapper },
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync(21)
+    })
+
+    expect(events).toEqual(['page', 'sync', 'toast'])
+    expect(onCanceled).toHaveBeenCalledWith({
+      message: '예약 취소 요청이 완료되었습니다',
+      reservation: canceledReservation,
+    })
+    expect(queryClient.getQueryData(upcomingQueryKey)).toMatchObject({
+      pages: [{ reservations: [], totalCount: 0 }],
+    })
+    expect(mockedShowToast).toHaveBeenCalledWith({
+      children: '예약 취소 요청이 완료되었습니다',
+    })
+  })
+
+  it('keeps the shared success flow when page-local preparation fails', async () => {
+    const queryClient = createQueryClient()
+    const onCanceled = vi
+      .fn()
+      .mockRejectedValue(new Error('detail cache update failed'))
+    const cancelResult = {
+      message: '예약 취소 요청이 완료되었습니다',
+      reservation: canceledReservation,
+    }
+
+    mockedCancelReservation.mockResolvedValue(cancelResult)
+    mockedGetMyReservations.mockResolvedValue({
+      reservations: [],
+      hasNext: false,
+      totalCount: 0,
+    } satisfies ReservationListResponse)
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(
+      () => useCancelReservationMutation({ onCanceled }),
+      { wrapper },
+    )
+
+    await act(async () => {
+      await expect(result.current.mutateAsync(21)).resolves.toEqual(
+        cancelResult,
+      )
+    })
+
+    expect(
+      queryClient.getQueryData(
+        myReservationsQueryKeys.infiniteList('CANCELED'),
+      ),
+    ).toMatchObject({
+      pages: [
+        {
+          reservations: [
+            expect.objectContaining({
+              reservationId: 21,
+              reservationStatus: 'CANCELED',
+            }),
+          ],
+        },
+      ],
+    })
+    expect(mockedShowToast).toHaveBeenCalledWith({
+      children: '예약 취소 요청이 완료되었습니다',
+    })
+  })
+})

--- a/apps/client/src/features/reservation/hooks/useCancelReservationMutation.ts
+++ b/apps/client/src/features/reservation/hooks/useCancelReservationMutation.ts
@@ -1,9 +1,32 @@
-import { useMutation } from '@tanstack/react-query'
+import { showToast } from '@hashi/hds-ui'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { cancelReservation } from '@/features/reservation/api/cancelReservation'
+import { syncCanceledReservationCache } from '@/features/reservation/queries/syncCanceledReservationCache'
+import { captureError } from '@/shared/lib/sentry'
 
-export const useCancelReservationMutation = () => {
+type CancelReservationResult = Awaited<ReturnType<typeof cancelReservation>>
+
+interface UseCancelReservationMutationParams {
+  onCanceled?: (result: CancelReservationResult) => void | Promise<void>
+}
+
+export const useCancelReservationMutation = ({
+  onCanceled,
+}: UseCancelReservationMutationParams = {}) => {
+  const queryClient = useQueryClient()
+
   return useMutation({
     mutationFn: (reservationId: number) => cancelReservation(reservationId),
+    onSuccess: async (result) => {
+      try {
+        await onCanceled?.(result)
+      } catch (error) {
+        captureError(error)
+      }
+
+      await syncCanceledReservationCache(queryClient, result.reservation)
+      showToast({ children: result.message })
+    },
   })
 }

--- a/apps/client/src/features/reservation/queries/syncCanceledReservationCache.test.ts
+++ b/apps/client/src/features/reservation/queries/syncCanceledReservationCache.test.ts
@@ -1,0 +1,151 @@
+import { QueryClient, type InfiniteData } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getMyReservations } from '@/features/reservation/api/getMyReservations'
+import type {
+  ReservationListResponse,
+  ReservationResponse,
+} from '@/features/reservation/api/getMyReservations'
+import { myReservationsQueryKeys } from '@/features/reservation/queries/myReservationsQueryKeys'
+import { syncCanceledReservationCache } from '@/features/reservation/queries/syncCanceledReservationCache'
+
+vi.mock('@/features/reservation/api/getMyReservations', () => ({
+  getMyReservations: vi.fn(),
+}))
+
+const mockedGetMyReservations = vi.mocked(getMyReservations)
+
+const canceledReservation = {
+  reservationId: 21,
+  restaurantId: 34,
+  restaurantName: '스시 하시',
+  reservedAt: '2026-07-20T18:30:00',
+  adultCount: 2,
+  reservationStatus: 'CANCELED',
+} as ReservationResponse
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+describe('syncCanceledReservationCache', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('moves a canceled reservation from the upcoming cache to the canceled cache', async () => {
+    const queryClient = createQueryClient()
+    const upcomingQueryKey = myReservationsQueryKeys.infiniteList('UPCOMING')
+    const canceledQueryKey = myReservationsQueryKeys.infiniteList('CANCELED')
+
+    queryClient.setQueryData(upcomingQueryKey, {
+      pages: [
+        {
+          reservations: [
+            {
+              ...canceledReservation,
+              reservationStatus: 'CONFIRMED',
+            },
+          ],
+          hasNext: false,
+          totalCount: 1,
+        },
+      ],
+      pageParams: [null],
+    })
+    mockedGetMyReservations.mockResolvedValue({
+      reservations: [],
+      hasNext: false,
+      totalCount: 0,
+    } satisfies ReservationListResponse)
+
+    await syncCanceledReservationCache(queryClient, canceledReservation)
+
+    expect(queryClient.getQueryData(upcomingQueryKey)).toMatchObject({
+      pages: [{ reservations: [], totalCount: 0 }],
+    })
+    expect(queryClient.getQueryData(canceledQueryKey)).toMatchObject({
+      pages: [
+        {
+          reservations: [
+            expect.objectContaining({
+              reservationId: 21,
+              reservationStatus: 'CANCELED',
+            }),
+          ],
+          totalCount: 1,
+        },
+      ],
+    })
+  })
+
+  it('keeps local cache correction when fetching the canceled list fails', async () => {
+    const queryClient = createQueryClient()
+    const upcomingQueryKey = myReservationsQueryKeys.infiniteList('UPCOMING')
+    const canceledQueryKey = myReservationsQueryKeys.infiniteList('CANCELED')
+
+    queryClient.setQueryData(upcomingQueryKey, {
+      pages: [
+        {
+          reservations: [
+            {
+              ...canceledReservation,
+              reservationStatus: 'CONFIRMED',
+            },
+          ],
+          hasNext: false,
+          totalCount: 1,
+        },
+      ],
+      pageParams: [null],
+    })
+    mockedGetMyReservations.mockRejectedValue(new Error('canceled list failed'))
+
+    await expect(
+      syncCanceledReservationCache(queryClient, canceledReservation),
+    ).resolves.toBeUndefined()
+
+    expect(queryClient.getQueryData(upcomingQueryKey)).toMatchObject({
+      pages: [{ reservations: [], totalCount: 0 }],
+    })
+    expect(queryClient.getQueryData(canceledQueryKey)).toMatchObject({
+      pages: [
+        {
+          reservations: [expect.objectContaining({ reservationId: 21 })],
+          totalCount: 1,
+        },
+      ],
+    })
+  })
+
+  it('does not add the same reservation to the canceled cache twice', async () => {
+    const queryClient = createQueryClient()
+    const canceledQueryKey = myReservationsQueryKeys.infiniteList('CANCELED')
+    const canceledPage = {
+      reservations: [canceledReservation],
+      hasNext: false,
+      totalCount: 1,
+    } satisfies ReservationListResponse
+
+    queryClient.setQueryData(canceledQueryKey, {
+      pages: [canceledPage],
+      pageParams: [null],
+    })
+    mockedGetMyReservations.mockResolvedValue(canceledPage)
+
+    await syncCanceledReservationCache(queryClient, canceledReservation)
+
+    const queryData =
+      queryClient.getQueryData<InfiniteData<ReservationListResponse>>(
+        canceledQueryKey,
+      )
+
+    expect(queryData?.pages[0]?.reservations).toHaveLength(1)
+    expect(queryData?.pages[0]?.reservations).toEqual([
+      expect.objectContaining({ reservationId: 21 }),
+    ])
+  })
+})

--- a/apps/client/src/pages/myReservations/MyReservationsPage.spec.md
+++ b/apps/client/src/pages/myReservations/MyReservationsPage.spec.md
@@ -454,7 +454,7 @@ POST /api/v1/reservations/{reservationId}/cancel
 성공 시:
 
 - 현재 `방문 예정` 리스트에서 해당 예약을 제거하거나 refetch합니다.
-- `예약 취소` chip으로 이동하지는 않습니다.
+- `예약 취소` chip으로 이동해 취소된 예약 목록을 표시합니다.
 - 취소 성공 toast를 보여줍니다.
 - toast 문구는 예약 취소 API 성공 응답의 `message`를 사용합니다.
 

--- a/apps/client/src/pages/myReservations/MyReservationsPage.test.tsx
+++ b/apps/client/src/pages/myReservations/MyReservationsPage.test.tsx
@@ -564,6 +564,7 @@ describe('MyReservationsPage', () => {
 
     await waitFor(() => {
       expect(mockedCancelReservation).toHaveBeenCalledWith(21)
+      expect(mockShowToast).toHaveBeenCalledTimes(1)
       expect(mockShowToast).toHaveBeenCalledWith({
         children: '예약 취소 요청이 완료되었습니다',
       })

--- a/apps/client/src/pages/myReservations/hooks/useMyReservationsPage.ts
+++ b/apps/client/src/pages/myReservations/hooks/useMyReservationsPage.ts
@@ -1,13 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { showToast } from '@hashi/hds-ui'
-import { useQueryClient } from '@tanstack/react-query'
 import { generatePath, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
 import { getRestaurantReviewNewPath } from '@/app/router/routePaths'
 import {
   type MyReservationsApiStatus,
-  syncCanceledReservationCache,
   useCancelReservationMutation,
   useMyReservationsInfiniteQuery,
 } from '@/features/reservation'
@@ -50,7 +48,6 @@ const checkIsVisibleReservation = (
 
 export const useMyReservationsPage = () => {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const [searchParams, setSearchParams] = useSearchParams()
   const statusParam = searchParams.get('status')
   const selectedStatus = checkIsReservationStatusFilterValue(statusParam)
@@ -189,14 +186,8 @@ export const useMyReservationsPage = () => {
     isCancelRequestLockedRef.current = true
 
     try {
-      const canceledReservation =
-        await cancelReservationMutation.mutateAsync(reservationId)
+      await cancelReservationMutation.mutateAsync(reservationId)
 
-      showToast({ children: canceledReservation.message })
-      await syncCanceledReservationCache(
-        queryClient,
-        canceledReservation.reservation,
-      )
       setCancelReservationId(null)
       setSearchParams({ status: 'CANCELED' })
       window.scrollTo({ top: 0 })

--- a/apps/client/src/pages/reservationDetail/ReservationDetailPage.test.tsx
+++ b/apps/client/src/pages/reservationDetail/ReservationDetailPage.test.tsx
@@ -241,6 +241,7 @@ describe('ReservationDetailPage', () => {
 
     await waitFor(() => {
       expect(mockedCancelReservation).toHaveBeenCalledWith(12)
+      expect(mockShowToast).toHaveBeenCalledTimes(1)
       expect(mockShowToast).toHaveBeenCalledWith({
         children: '예약 취소 요청이 완료되었습니다',
       })

--- a/apps/client/src/pages/reservationDetail/hooks/useReservationDetailPage.ts
+++ b/apps/client/src/pages/reservationDetail/hooks/useReservationDetailPage.ts
@@ -1,13 +1,9 @@
 import { useRef, useState } from 'react'
-import { showToast } from '@hashi/hds-ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { ROUTES } from '@/app/router/path'
-import {
-  syncCanceledReservationCache,
-  useCancelReservationMutation,
-} from '@/features/reservation'
+import { useCancelReservationMutation } from '@/features/reservation'
 import { reservationNotices } from '@/pages/reservationDetail/constants/reservationNotice'
 import {
   reservationDetailQueryKey,
@@ -42,7 +38,21 @@ export const useReservationDetailPage = () => {
   const params = useParams<{ reservationId: string }>()
   const reservationId = parseReservationId(params.reservationId)
   const reservationDetailQuery = useReservationDetailQuery(reservationId)
-  const cancelReservationMutation = useCancelReservationMutation()
+  const cancelReservationMutation = useCancelReservationMutation({
+    onCanceled: ({ reservation }) => {
+      if (reservationId === null) {
+        return
+      }
+
+      const queryKey = reservationDetailQueryKey(reservationId)
+
+      queryClient.setQueryData(queryKey, reservation)
+      void queryClient.invalidateQueries({
+        queryKey,
+        refetchType: 'inactive',
+      })
+    },
+  })
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false)
   const isCancelRequestLockedRef = useRef(false)
   const reservationDetail = reservationDetailQuery.data
@@ -89,21 +99,8 @@ export const useReservationDetailPage = () => {
     isCancelRequestLockedRef.current = true
 
     try {
-      const canceledReservation =
-        await cancelReservationMutation.mutateAsync(reservationId)
-      const queryKey = reservationDetailQueryKey(reservationId)
+      await cancelReservationMutation.mutateAsync(reservationId)
 
-      queryClient.setQueryData(queryKey, canceledReservation.reservation)
-      void queryClient.invalidateQueries({
-        queryKey,
-        refetchType: 'inactive',
-      })
-      await syncCanceledReservationCache(
-        queryClient,
-        canceledReservation.reservation,
-      )
-
-      showToast({ children: canceledReservation.message })
       setIsCancelDialogOpen(false)
       navigate(`${ROUTES.myReservations}?status=CANCELED`)
     } catch {


### PR DESCRIPTION
## 📌 요약

마이예약과 예약상세 화면에서 각각 처리하던 예약 취소 성공 로직을 `useCancelReservationMutation`으로 모았습니다.

두 화면 모두 같은 취소 API를 사용하지만, 기존에는 성공 toast와 예약 목록 cache 갱신을 page hook에서 따로 처리하고 있었습니다. 화면이 추가되거나 한쪽 로직만 수정될 경우 cache 갱신 또는 toast가 빠질 수 있어, 모든 예약 화면에 공통인 처리만 mutation hook이 맡도록 정리했습니다.

상세 cache 갱신, dialog 닫기, 탭 변경, 화면 이동처럼 페이지마다 달라지는 동작은 기존과 같이 각 page hook에 남겼습니다.

Jira: HASHI-151

## 📚 작업 내용

- 예약 취소 API 호출 이후의 공통 성공 처리를 `useCancelReservationMutation`으로 이동
  - `UPCOMING`, `CANCELED` 예약 목록 cache 동기화
  - 서버 응답 `message`를 사용한 성공 toast 표시
- 예약상세의 detail cache 갱신은 `onCanceled` callback으로 분리
- page-local 후처리가 실패해도 이미 성공한 서버 취소 결과는 유지하도록 오류 경계 보완
- 마이예약과 예약상세 page hook에 중복되어 있던 cache 및 toast 처리 제거
- 취소 cache 동기화와 callback 실패 상황을 검증하는 테스트 추가
- 마이예약 취소 후 `CANCELED` 탭으로 이동하는 현재 동작을 spec에 반영

## 🔎 상세 설명

### 공통으로 처리할 부분

기존에는 마이예약과 예약상세에서 `mutateAsync` 호출 후 아래 작업을 각각 수행했습니다.

- 취소 API 응답 message로 성공 toast 표시
- 방문 예정 목록에서 취소한 예약 제거
- 예약 취소 목록에 취소한 예약 반영

같은 성공 정책이 두 page hook에 나뉘어 있어, 한 화면만 수정했을 때 다른 화면의 cache 상태가 달라질 가능성이 있었습니다.

이번 변경에서는 `useCancelReservationMutation`이 다음 순서를 책임집니다.

1. 예약 취소 API를 호출합니다.
2. 화면별로 필요한 `onCanceled` 후처리를 먼저 실행합니다.
3. `UPCOMING`, `CANCELED` 목록 cache를 동기화합니다.
4. 서버가 내려준 message로 성공 toast를 표시합니다.
5. 공통 처리가 끝나면 각 화면이 dialog, 탭, navigation을 정리합니다.

### 화면별 책임은 그대로 유지

공통 mutation hook이 화면 동작까지 알게 되면 예약 도메인 로직이 route와 UI 상태에 강하게 묶이게 됩니다. 그래서 아래 동작은 page hook에 남겼습니다.

- 마이예약
  - 취소 dialog 닫기
  - `CANCELED` 탭으로 변경
  - 스크롤 위치 초기화

- 예약상세
  - 예약상세 query cache 즉시 갱신
  - 상세 query invalidation
  - 취소 dialog 닫기
  - 취소된 예약 목록으로 이동

`useCancelReservationMutation`은 목록 cache와 toast만 공통으로 처리하고, 상세 query key나 route는 알지 못합니다.

### 후처리 실패가 서버 성공을 뒤집지 않도록 보완

예약상세는 `onCanceled`에서 detail cache를 갱신합니다. 이 callback에서 예외가 발생하면 취소 API는 이미 성공했는데도 mutation 전체가 실패로 처리될 수 있었습니다.

이 경우 사용자는 실패 toast를 보고 다시 취소를 시도할 수 있지만, 서버에서는 이미 예약이 취소된 상태라 화면과 서버 상태가 어긋날 수 있습니다.

이를 막기 위해 `onCanceled` 오류는 Sentry에 기록하되, 목록 cache 동기화와 성공 toast는 계속 실행하도록 분리했습니다. page-local 후처리 실패가 서버의 취소 성공 결과를 바꾸지는 않습니다.

### cache 동기화 검증 보강

기존 `syncCanceledReservationCache`의 동작을 다음 조건으로 검증했습니다.

- 취소한 예약이 `UPCOMING` cache에서 제거되는지
- 같은 예약이 `CANCELED` cache에 추가되는지
- `CANCELED` 목록 조회가 실패해도 로컬 cache 보정은 유지되는지
- 같은 예약이 cache에 중복으로 들어가지 않는지

## 💭 고민한 부분

### 고민한 문제

공통 처리를 mutation hook으로 옮기면 중복은 줄일 수 있지만, dialog와 navigation까지 함께 옮길 경우 feature hook이 특정 화면에 종속됩니다.

반대로 모든 처리를 page hook에 남기면 화면별 자유도는 높지만, 같은 취소 정책을 계속 중복해서 관리해야 합니다.

### 고려한 선택지

- 기존처럼 모든 성공 처리를 각 page hook에 유지
- cache, toast, dialog, navigation까지 mutation hook에서 처리
- 목록 cache와 toast만 공통화하고 화면별 처리는 callback과 page hook에 유지

### 최종 선택과 이유

세 번째 방식을 선택했습니다.

목록 cache와 성공 toast는 어떤 화면에서 예약을 취소하더라도 동일하게 적용되어야 합니다. 반면 detail cache, dialog, 탭, navigation은 화면마다 달라질 수 있습니다.

공통 정책과 화면 정책의 경계를 이 기준으로 나누면 중복을 줄이면서도 mutation hook이 특정 페이지에 의존하지 않습니다.

## ✅ 검증

- `pnpm format:check`
- `pnpm --filter @hashi/client lint`
- `pnpm --filter @hashi/client typecheck`
- `pnpm --filter @hashi/client test`
  - Test Files: 126 passed
  - Tests: 615 passed
- `pnpm --filter @hashi/client build`
- `verify-api-integration`
  - PASS
  - 추가 이슈 없음

## 👀 리뷰어에게

아래 두 부분을 중점적으로 확인 부탁드립니다.

- 목록 cache와 성공 toast를 mutation hook의 공통 책임으로 둔 경계가 적절한지
- `onCanceled → 목록 cache 동기화 → 성공 toast → 화면별 이동` 순서가 자연스러운지

UI 변경은 없어 스크린샷은 첨부하지 않았습니다.

## 남은 확인

- 실제 API 환경에서 취소 후 예약 목록과 상세 cache 상태 확인
- Preview 환경에서 마이예약·예약상세 취소 흐름 브라우저 QA
- 배포 및 운영 환경 동작 확인

## 참고

- `apps/client/src/features/reservation/hooks/useCancelReservationMutation.spec.md`
- `apps/client/src/pages/myReservations/MyReservationsPage.spec.md`

