### PR TITLE
Chore(root): HASHI-168 stacked PR force-with-lease 허용

### DIFF
--- a/.codex/hooks/pre_tool_use_bash_guard.py
+++ b/.codex/hooks/pre_tool_use_bash_guard.py
@@ -7,8 +7,10 @@ import json
 import os
 import re
 import shlex
+import subprocess
 import sys
 from dataclasses import dataclass
+from fnmatch import fnmatch
 
 
 BLOCKED_PACKAGE_MANAGERS = {"npm", "npx", "yarn", "bun", "bunx"}
@@ -23,6 +25,16 @@ GIT_OPTIONS_WITH_VALUE = {
     "--exec-path",
     "--config-env",
 }
+PROTECTED_BRANCHES = {"develop", "main", "master", "production"}
+STACKED_PR_BRANCH_PATTERNS = (
+    "chore/**",
+    "docs/**",
+    "feat/**",
+    "feature/**",
+    "fix/**",
+    "hotfix/**",
+    "refactor/**",
+)
 
 
 @dataclass(frozen=True)
@@ -176,7 +188,120 @@ def has_pnpm_workspace_scope(args: list[str]) -> bool:
 
 
 def is_force_push_token(token: str) -> bool:
-    return token in {"--force", "--force-with-lease", "-f"} or token.startswith("--force-with-lease=")
+    return token in {"--force", "--force-with-lease", "-f"} or token.startswith(
+        "--force-with-lease="
+    )
+
+
+def is_force_with_lease_token(token: str) -> bool:
+    return token == "--force-with-lease" or token.startswith("--force-with-lease=")
+
+
+def is_protected_branch(branch: str) -> bool:
+    normalized_branch = branch.removeprefix("refs/heads/")
+
+    return normalized_branch in PROTECTED_BRANCHES
+
+
+def is_stacked_pr_branch(branch: str) -> bool:
+    normalized_branch = branch.removeprefix("refs/heads/")
+
+    return any(
+        fnmatch(normalized_branch, pattern)
+        for pattern in STACKED_PR_BRANCH_PATTERNS
+    )
+
+
+def current_branch() -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return None
+
+    branch = result.stdout.strip()
+
+    return branch or None
+
+
+def push_refspecs(push_args: list[str]) -> list[str]:
+    positional_args = [
+        token
+        for token in push_args
+        if not token.startswith("-") and "=" not in token
+    ]
+
+    if len(positional_args) <= 1:
+        return []
+
+    return positional_args[1:]
+
+
+def target_branch_from_refspec(refspec: str) -> str:
+    refspec_without_force = refspec.removeprefix("+")
+
+    if ":" in refspec_without_force:
+        return refspec_without_force.rsplit(":", 1)[1]
+
+    return refspec_without_force
+
+
+def force_with_lease_option_target_branch(token: str) -> str | None:
+    if not token.startswith("--force-with-lease="):
+        return None
+
+    refname = token.split("=", 1)[1].split(":", 1)[0]
+
+    return refname or None
+
+
+def force_with_lease_target_branches(push_args: list[str]) -> list[str]:
+    option_targets = [
+        target
+        for token in push_args
+        if (target := force_with_lease_option_target_branch(token)) is not None
+    ]
+    refspecs = push_refspecs(push_args)
+
+    if not refspecs:
+        branch = current_branch()
+
+        return option_targets + ([branch] if branch else [])
+
+    return option_targets + [
+        target_branch_from_refspec(refspec) for refspec in refspecs
+    ]
+
+
+def check_force_push(push_args: list[str]) -> BlockDecision | None:
+    force_tokens = [token for token in push_args if is_force_push_token(token)]
+
+    if not force_tokens:
+        return None
+
+    if not all(is_force_with_lease_token(token) for token in force_tokens):
+        return BlockDecision(
+            "Destructive git command blocked: use --force-with-lease instead of --force or -f."
+        )
+
+    target_branches = force_with_lease_target_branches(push_args)
+
+    if any(is_protected_branch(branch) for branch in target_branches):
+        return BlockDecision(
+            "Destructive git command blocked: force-with-lease to a protected branch is not allowed."
+        )
+
+    if target_branches and all(is_stacked_pr_branch(branch) for branch in target_branches):
+        return None
+
+    return BlockDecision(
+        "Destructive git command blocked: force-with-lease is only allowed for stacked PR work branches."
+    )
 
 
 def check_git(args: list[str]) -> BlockDecision | None:
@@ -195,8 +320,8 @@ def check_git(args: list[str]) -> BlockDecision | None:
     if subcommand == "clean" and has_git_clean_force_directory(sub_args):
         return BlockDecision("Destructive git command blocked: git clean with force and directory flags.")
 
-    if subcommand == "push" and any(is_force_push_token(token) for token in sub_args):
-        return BlockDecision("Destructive git command blocked: force push requires explicit human intent.")
+    if subcommand == "push":
+        return check_force_push(sub_args)
 
     return None
 

--- a/.codex/hooks/pre_tool_use_bash_guard_test.py
+++ b/.codex/hooks/pre_tool_use_bash_guard_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Tests for pre_tool_use_bash_guard."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import pre_tool_use_bash_guard as guard
+
+
+class BashGuardGitPushTest(unittest.TestCase):
+    def test_blocks_force_push(self) -> None:
+        decision = guard.check_git(["push", "--force", "origin", "feat/HASHI-1"])
+
+        self.assertIsNotNone(decision)
+        self.assertIn("--force-with-lease", decision.reason)
+
+    def test_blocks_short_force_push(self) -> None:
+        decision = guard.check_git(["push", "-f", "origin", "feat/HASHI-1"])
+
+        self.assertIsNotNone(decision)
+        self.assertIn("--force-with-lease", decision.reason)
+
+    def test_allows_force_with_lease_for_work_branch(self) -> None:
+        decision = guard.check_git(
+            ["push", "--force-with-lease", "origin", "refactor/HASHI-1-demo"]
+        )
+
+        self.assertIsNone(decision)
+
+    def test_blocks_force_with_lease_for_protected_branch(self) -> None:
+        decision = guard.check_git(["push", "--force-with-lease", "origin", "develop"])
+
+        self.assertIsNotNone(decision)
+        self.assertIn("protected branch", decision.reason)
+
+    def test_blocks_force_with_lease_option_for_protected_branch(self) -> None:
+        with patch.object(guard, "current_branch", return_value="refactor/HASHI-1-demo"):
+            decision = guard.check_git(["push", "--force-with-lease=develop"])
+
+        self.assertIsNotNone(decision)
+        self.assertIn("protected branch", decision.reason)
+
+    def test_allows_force_with_lease_without_refspec_on_work_branch(self) -> None:
+        with patch.object(guard, "current_branch", return_value="docs/HASHI-1-demo"):
+            decision = guard.check_git(["push", "--force-with-lease"])
+
+        self.assertIsNone(decision)
+
+    def test_blocks_force_with_lease_without_refspec_on_protected_branch(self) -> None:
+        with patch.object(guard, "current_branch", return_value="develop"):
+            decision = guard.check_git(["push", "--force-with-lease"])
+
+        self.assertIsNotNone(decision)
+        self.assertIn("protected branch", decision.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/agent/hooks.md
+++ b/docs/agent/hooks.md
@@ -42,7 +42,8 @@ Repo-local hook은 프로젝트 `.codex/` layer가 trusted 상태일 때 실행�
 - `git reset --hard`
 - `git checkout --`
 - `git clean`에 force와 directory flag가 함께 있는 명령
-- `git push --force`, `git push --force-with-lease`, `git push -f`
+- `git push --force`, `git push -f`
+- 보호 브랜치 또는 작업 브랜치 패턴이 아닌 브랜치로 향하는 `git push --force-with-lease`
 - `rm`에 recursive와 force flag가 함께 있는 명령
 - `npm`, `npx`, `yarn`, `bun`, `bunx`
 - `pnpm add`인데 `--filter`/`-F` 또는 `-w`/`--workspace-root`가 없는 명령
@@ -60,6 +61,10 @@ pnpm add -D -w package-name
 이 hook은 agent 실수 방지용 guardrail입니다.
 Codex `PreToolUse`가 모든 shell 실행 경로를 완전히 가로채는 보안 경계는 아닙니다.
 파괴적인 작업이나 예외적인 Git 작업은 사람이 의도를 명확히 확인한 뒤 별도 명령으로 수행합니다.
+
+Stacked PR rebase 흐름에서는 작업 브랜치에 한해 `git push --force-with-lease`를 허용합니다.
+허용되는 작업 브랜치 패턴은 `feat/**`, `feature/**`, `fix/**`, `hotfix/**`, `refactor/**`, `docs/**`, `chore/**`입니다.
+`develop`, `main`, `master`, `production` 같은 보호 브랜치로 향하는 force-with-lease push는 계속 차단합니다.
 
 API 연동 품질 검사는 hook이 아니라 `.agents/skills/verify-api-integration`에서 수행합니다.
 query key, Suspense query 선택, mutation cache synchronization, UI state 같은 판단은 코드 문맥이 필요하므로 lifecycle hook으로 차단하지 않습니다.


### PR DESCRIPTION
## 📌 요약

> 위험한 force push는 계속 막되, 작업 브랜치에 한해서만 `--force-with-lease`를 허용하도록 hook 정책과 문서를 수정했습니다.

Jira: HASHI-168

## 📚 작업 내용

### Codex Bash Guard 수정

- `git push --force` 차단 유지
- `git push -f` 차단 유지
- `git push --force-with-lease`는 작업 브랜치에 한해 허용
- `develop`, `main`, `master`, `production` 같은 보호 브랜치로 향하는 `--force-with-lease`는 계속 차단
- `--force-with-lease=develop`처럼 옵션에 보호 브랜치를 직접 지정하는 케이스도 차단
- 허용 가능한 작업 브랜치 패턴 추가

```text
feat/**
feature/**
fix/**
hotfix/**
refactor/**
docs/**
chore/**
```

### 테스트 추가
> `.codex/hooks/pre_tool_use_bash_guard_test.py`를 추가해 force push 정책을 검증했습니다.

**검증한 케이스**

- `git push --force`는 차단
- `git push -f`는 차단
- 작업 브랜치 대상 `git push --force-with-lease`는 허용
- 보호 브랜치 대상 `git push --force-with-lease`는 차단
- refspec 없이 현재 브랜치 기준으로 `--force-with-lease`를 사용하는 경우도 검증
- `--force-with-lease=develop` 형태의 보호 브랜치 지정도 차단

### 문서 수정
- `docs/agent/hooks.md`에 stacked PR 운영 시 force-with-lease 허용 기준을 문서화했습니다.


## 🔎 상세 설명

### 작업 배경
- 팀에서 stacked PR을 도입하면 하위 PR 위에 상위 PR을 쌓아 작업하게 됩니다. 이 구조에서는 하위 PR이 수정되거나 develop 최신 변경을 반영할 때, 상위 브랜치를 다시 rebase해야 하는 경우가 자주 생깁니다.
- 이때 이미 원격에 올라간 작업 브랜치의 커밋 해시가 바뀌기 때문에 일반 push로는 갱신할 수 없고, `git push --force-with-lease`가 필요합니다.
- 하지만 기존 Codex Bash Guard는 `--force-with-lease`까지 모두 차단하고 있어서, stacked PR을 정상적으로 운영하기 어려운 상태였습니다.

### 기존 문제
- 기존 정책은 force push 계열 명령을 모두 위험 명령으로 보고 차단했습니다.

```text
git push --force
git push -f
git push --force-with-lease
```

- 이 기준은 일반적인 실수 방지에는 안전하지만, stacked PR에서는 문제가 됩니다.

예를 들어

```text
하위 PR 수정
→ 상위 브랜치 rebase
→ 커밋 해시 변경
→ 원격 브랜치 갱신 필요
→ --force-with-lease 필요
→ 기존 hook에서 차단
```

## ⚖️ 고민한 부분

### `--force`와 `--force-with-lease`를 다르게 볼 것인가

- `--force`는 원격 브랜치가 다른 사람에 의해 변경됐는지 확인하지 않고 덮어쓸 수 있어 위험합니다.

- 반면 `--force-with-lease`는 내가 마지막으로 알고 있던 원격 상태와 현재 원격 상태가 같을 때만 push를 허용합니다. 다른 사람이 그 사이에 push한 변경을 무심코 덮어쓰는 위험을 줄일 수 있습니다.

- 그래서 두 명령을 분리했습니다.

```text
--force, -f
→ 계속 차단

--force-with-lease
→ 작업 브랜치에 한해 허용
```

### 보호 브랜치는 계속 막아야 하는가

- `develop`, `main`, `master`, `production` 같은 브랜치는 팀 기준 브랜치이기 때문에 force-with-lease도 허용하면 안 된다고 판단했습니다.

- 아래 케이스는 모두 차단되도록 했습니다.

```bash
git push --force-with-lease origin develop
git push --force-with-lease=develop
```

### 작업 브랜치 범위
- stacked PR에서 실제로 rebase/force-with-lease가 필요한 대상은 개인 작업 브랜치입니다.
- 그래서 현재 팀에서 사용하는 브랜치 네이밍 기준에 맞춰 아래 패턴만 허용했습니다.
- 이 범위 밖의 브랜치로 향하는 force-with-lease는 차단합니다.

```text
feat/**
feature/**
fix/**
hotfix/**
refactor/**
docs/**
chore/**
```

## 🧩 GitHub Ruleset 관련 정리

- 처음에는 stacked PR의 중간 PR들도 승인 2명이 있어야 merge 가능하게 만들기 위해 `feat/**`, `refactor/**`, `docs/**`, `chore/**` 같은 작업 브랜치 패턴에도 ruleset을 적용하는 방향을 검토했습니다.

- 하지만 실제로 확인해보니 작업 브랜치 ruleset에 `Changes must be made through a pull request` 계열 규칙이 걸리면, 개인 브랜치로 직접 push하는 것 자체가 막혔습니다.

**실제 에러**

```text
GH013: Repository rule violations found
Changes must be made through a pull request.
```

-> GitHub Ruleset은 해당 브랜치가 PR의 base 브랜치인지, 개인 작업용 head 브랜치인지 구분하지 않고 ref 패턴 기준으로 규칙을 적용합니다.

그래서 작업 브랜치 패턴에 강한 PR 필수 규칙을 걸면

```text
개인 브랜치 최초 push가 막힘
rebase 이후 force-with-lease push도 막힘
stacked PR 운영이 어려워짐
```

### develop ruleset

- `develop`은 계속 강하게 보호합니다.

```text
Require pull request before merging: ON
Required approvals: 2
Require conversation resolution before merging: ON
Block force pushes: ON
Status checks: 필요 시 ON
```

### 작업 브랜치 ruleset

- `feat/**`, `refactor/**`, `docs/**`, `chore/**` 같은 개인 작업 브랜치는 stacked PR 운영을 위해 직접 push와 `--force-with-lease`가 가능해야 합니다. 따라서 작업 브랜치에는 PR 필수/승인 필수 ruleset을 걸지 않거나, 브랜치 네이밍 같은 약한 규칙만 두는 방향이 맞다고 판단했습니다.

```text
Require pull request before merging: OFF
Required approvals: OFF
Block force pushes: OFF
```

**최종 방향**
```text
develop merge 품질은 GitHub ruleset으로 강제
stacked PR 중간 브랜치는 팀 리뷰 룰로 관리
작업 브랜치는 rebase와 force-with-lease 가능하게 유지
```

## 💭 남은 고민

- GitHub Ruleset만으로는 작업 브랜치에 대한 push/force-with-lease 허용과 stacked PR 중간 단계의 승인 2명 강제를 동시에 설정하는 건 안되더라구요...

- 그래서 develop 보호를 GitHub Ruleset으로 강제하고, stacked PR 중간 단계의 리뷰 기준은 팀 운영 규칙과 PR 리뷰 문화로 관리하는 방향이 현실적이라고 봤습니다.

- 추후 중간 PR 승인 누락이 반복적으로 발생하면 GitHub Actions나 별도 자동화를 검토해보면 될 것 같아요!!