### PR TITLE
Refactor(reservation): 예약 상세 타입 의존성 정리

### DIFF
--- a/apps/client/src/pages/reservationDetail/ReservationDetailPage.spec.md
+++ b/apps/client/src/pages/reservationDetail/ReservationDetailPage.spec.md
@@ -56,6 +56,7 @@
 - [ ] fixed Header와 fixed ActionBar는 z-index 토큰을 사용합니다.
 - [ ] 취소된 예약(`reservationStatus: CANCELED`)은 URL 직접 접근으로도 상세 화면을 표시하지 않고 `NotFoundPage`를 표시합니다.
 - [ ] 예약 취소 요청 중에는 취소 확인 버튼과 닫기 버튼을 비활성화해 중복 요청과 중간 닫기를 방지합니다.
+- [ ] `createReservationDetailViewModel`과 UI 컴포넌트가 공유하는 화면 데이터 타입은 page-local `types.ts`에서 관리하며, util은 `components/`를 import하지 않습니다.
 
 ## Data Dependencies
 
@@ -204,6 +205,10 @@ ReservationDetailPage
 - page-local util:
   - `createReservationDetailViewModel`
   - `reservationDetailPolicy`
+- page-local type:
+  - `ReservationProgressStatus`
+  - `ReservationProgressStep`
+  - `ReservationReceiptInfoItem`
 - page-local constants:
   - `reservationNotices`
 - icon:

--- a/apps/client/src/pages/reservationDetail/components/ReservationProgressSection.tsx
+++ b/apps/client/src/pages/reservationDetail/components/ReservationProgressSection.tsx
@@ -1,15 +1,9 @@
 import { ReservationRestaurantSummary } from '@/pages/reservationDetail/components/ReservationRestaurantSummary'
+import type {
+  ReservationProgressStatus,
+  ReservationProgressStep,
+} from '@/pages/reservationDetail/types'
 import { cn } from '@/shared/utils'
-
-export type ReservationProgressStatus = 'completed' | 'current' | 'pending'
-
-export type ReservationProgressStep = {
-  id: string
-  title: string
-  description: string
-  requestedAt?: string
-  status: ReservationProgressStatus
-}
 
 export type ReservationProgressSectionProps = {
   requestedDate: string

--- a/apps/client/src/pages/reservationDetail/components/ReservationReceiptInfoCard.tsx
+++ b/apps/client/src/pages/reservationDetail/components/ReservationReceiptInfoCard.tsx
@@ -1,9 +1,4 @@
-import type { ReactNode } from 'react'
-
-export type ReservationReceiptInfoItem = {
-  label: string
-  value: ReactNode
-}
+import type { ReservationReceiptInfoItem } from '@/pages/reservationDetail/types'
 
 export type ReservationReceiptInfoCardProps = {
   title: string

--- a/apps/client/src/pages/reservationDetail/types.ts
+++ b/apps/client/src/pages/reservationDetail/types.ts
@@ -1,0 +1,14 @@
+export type ReservationProgressStatus = 'completed' | 'current' | 'pending'
+
+export interface ReservationProgressStep {
+  id: string
+  title: string
+  description: string
+  requestedAt?: string
+  status: ReservationProgressStatus
+}
+
+export interface ReservationReceiptInfoItem {
+  label: string
+  value: string
+}

--- a/apps/client/src/pages/reservationDetail/types.ts
+++ b/apps/client/src/pages/reservationDetail/types.ts
@@ -1,7 +1,9 @@
 export type ReservationProgressStatus = 'completed' | 'current' | 'pending'
 
+export type ReservationProgressStepId = 'received' | 'contacting' | 'confirmed'
+
 export interface ReservationProgressStep {
-  id: string
+  id: ReservationProgressStepId
   title: string
   description: string
   requestedAt?: string

--- a/apps/client/src/pages/reservationDetail/utils/createReservationDetailViewModel.ts
+++ b/apps/client/src/pages/reservationDetail/utils/createReservationDetailViewModel.ts
@@ -41,10 +41,7 @@ const formatAmount = (amount: number | undefined) => {
 
 const getStepStatuses = (
   reservationStatus: ReservationStatus | undefined,
-): Record<
-  'received' | 'contacting' | 'confirmed',
-  ReservationProgressStep['status']
-> => {
+): Record<ReservationProgressStep['id'], ReservationProgressStep['status']> => {
   if (reservationStatus === 'REQUESTED') {
     return {
       received: 'current',

--- a/apps/client/src/pages/reservationDetail/utils/createReservationDetailViewModel.ts
+++ b/apps/client/src/pages/reservationDetail/utils/createReservationDetailViewModel.ts
@@ -5,8 +5,10 @@ import {
   formatReservationMonthDay,
 } from '@/features/reservation/utils/formatReservation'
 import type { ReservationDetailResponse } from '@/pages/reservationDetail/api/getReservationDetail'
-import type { ReservationProgressStep } from '@/pages/reservationDetail/components/ReservationProgressSection'
-import type { ReservationReceiptInfoItem } from '@/pages/reservationDetail/components/ReservationReceiptInfoCard'
+import type {
+  ReservationProgressStep,
+  ReservationReceiptInfoItem,
+} from '@/pages/reservationDetail/types'
 
 type ReservationStatus = NonNullable<
   ReservationDetailResponse['reservationStatus']


### PR DESCRIPTION
## 📌 요약

예약 상세 view model이 UI 컴포넌트에서 선언한 타입을 직접 가져오던 역방향 의존성을 정리했습니다.

view model과 컴포넌트가 함께 사용하는 화면 데이터 타입을 page-local `types.ts`로 분리하고, 컴포넌트 자체의 Props 타입은 각 컴포넌트에 유지했습니다.

Jira: HASHI-169

## 📚 작업 내용

- 예약 상세 화면의 공통 데이터 타입을 `reservationDetail/types.ts`로 분리
- `createReservationDetailViewModel`의 `components/` 타입 import 제거
- `ReservationProgressSection`과 `ReservationReceiptInfoCard`가 page-local 타입을 사용하도록 변경
- 접수 정보 value 타입을 실제 view model 출력에 맞게 `string`으로 명확화
- `ReservationDetailPage.spec.md`에 타입 소유권과 의존성 경계 반영

## 🔎 상세 설명

기존 `createReservationDetailViewModel`은 다음 UI 컴포넌트에서 타입을 직접 import하고 있었습니다.

- `ReservationProgressSection`
- `ReservationReceiptInfoCard`

이 구조에서는 화면 데이터를 만드는 util이 렌더링을 담당하는 컴포넌트에 의존하게 됩니다. 컴포넌트의 타입 선언 위치나 구현이 변경되면 view model까지 영향을 받을 수 있어 의존 방향이 자연스럽지 않았습니다.

이번 변경에서는 두 영역이 함께 사용하는 데이터 타입을 `pages/reservationDetail/types.ts`로 이동했습니다.

- `ReservationProgressStatus`
- `ReservationProgressStep`
- `ReservationReceiptInfoItem`

그 결과 의존 방향은 다음과 같이 정리됩니다.

```text
createReservationDetailViewModel ─┐
                                      ├─> reservationDetail/types.ts
UI components ────────────────────┘
```

`ReservationProgressSectionProps`, `ReservationReceiptInfoCardProps`처럼 컴포넌트에서만 사용하는 Props 타입은 기존처럼 각 컴포넌트에 남겼습니다. 공통 데이터 계약만 `types.ts`로 이동해 타입 파일이 불필요한 Props 모음으로 커지지 않도록 범위를 제한했습니다.

## 💭 고민한 부분

### 고민한 문제

- 공유 데이터 타입을 UI 컴포넌트에 계속 둘지
- view model 전용 타입을 별도로 중복 선언할지
- 페이지 루트의 `types.ts`에서 하나의 계약으로 관리할지

### 고려한 선택지

- 기존 구조 유지
  - 변경은 적지만 view model이 UI 컴포넌트에 의존하는 문제가 남습니다.
- view model과 컴포넌트가 각각 타입 선언
  - 의존성은 끊기지만 동일한 데이터 구조가 중복됩니다.
- page-local `types.ts`로 공유 데이터 타입 분리
  - 양쪽이 중립적인 타입 계약을 바라볼 수 있습니다.

### 최종 선택과 이유

page-local `types.ts`로 공유 타입을 분리했습니다.

이 타입들은 예약 상세 페이지 안에서만 사용되기 때문에 `features`나 `shared`로 승격하지 않았습니다. 페이지 내부의 의존 방향만 바로잡으면서 변경 범위를 예약 상세에 한정할 수 있습니다.

또한 `ReservationReceiptInfoItem.value`는 기존 `ReactNode`에서 `string`으로 좁혔습니다. 실제 view model이 생성하는 값은 예약자, 인원, 주소, 방문 일정, 수수료 문자열뿐이며 React element를 전달하는 호출부는 없습니다. 이를 통해 화면 데이터 타입이 React 렌더링 타입에 의존하지 않도록 했습니다.

### 남은 고민

현재 예약 상세 한 곳의 타입 경계를 정리하는 작업이므로 전역 ESLint 규칙이나 별도 architecture test는 추가하지 않았습니다. 동일한 역방향 의존이 여러 페이지에서 반복될 경우 공통 정적 검사 도입을 검토할 수 있습니다.

## 🔗 Stacked PR 안내

이 PR은 [#158 예약 표시 formatter 공통화](https://github.com/TEAM-HASHI/HASHI-CLIENT/pull/158)를 부모로 하는 stacked PR입니다.

- 현재 base: `refactor/HASHI-167-reservation-formatters`
- 현재 head: `refactor/HASHI-169-reservation-detail-types`
- #158 변경을 기반으로 예약 상세 view model 타입을 정리합니다.
- #158이 먼저 병합된 뒤 이 브랜치를 최신 `develop`에 rebase하고 PR base를 `develop`으로 변경할 예정입니다.

## ✅ 검증

- [x] 예약 상세 util의 `components/` import 제거 확인
- [x] `pnpm format:check`
- [x] `pnpm --filter @hashi/client lint`
- [x] `pnpm --filter @hashi/client typecheck`
- [x] `pnpm --filter @hashi/client test`
  - 131개 테스트 파일, 640개 테스트 통과
- [x] `pnpm --filter @hashi/client build`
- [x] 독립 코드리뷰
  - Critical, Important, Minor 지적사항 없음

## 👀 리뷰어에게

공통 데이터 타입과 컴포넌트 전용 Props의 소유권이 적절하게 분리됐는지 확인 부탁드립니다.

`ReservationReceiptInfoItem.value`를 `ReactNode`가 아닌 `string`으로 제한한 부분이 현재 예약 상세 화면의 확장 방향과 맞는지도 함께 봐주시면 좋겠습니다.