### PR TITLE
Fix(hds-ui): HASHI-170 Toast 구조 및 스펙 정리

### DIFF
--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -36,16 +36,10 @@ export {
   createToastQueue,
   DEFAULT_TOAST_TIMEOUT,
   showToast,
-  Toast,
   ToastRegion,
   toastQueue,
 } from './toast'
-export type {
-  ToastContent,
-  ToastOptions,
-  ToastProps,
-  ToastRegionProps,
-} from './toast'
+export type { ToastContent, ToastOptions, ToastRegionProps } from './toast'
 export { Dialog } from './dialog'
 export type {
   DialogBodyProps,

--- a/packages/hds-ui/src/components/toast/Toast.spec.md
+++ b/packages/hds-ui/src/components/toast/Toast.spec.md
@@ -23,12 +23,12 @@ import { showToast, ToastRegion } from '@hashi/hds-ui'
 const App = () => {
   return (
     <>
-      <ToastRegion className="z-toast fixed inset-x-0 top-0 mx-auto w-full max-w-[var(--app-mobile-max-width,100%)] px-5 pt-[calc(32px+var(--safe-area-top,0px))]" />
+      <ToastRegion className="z-toast fixed inset-x-0 top-0 mx-auto w-full max-w-(--app-mobile-max-width,100%) px-5 pt-[calc(32px+var(--safe-area-top,0px))]" />
       <button
         type="button"
         onClick={() => {
           showToast({
-            icon: <LinkIcon className="size-6" />,
+            icon: <LinkIcon className="size-6.5" />,
             children: '링크가 복사 되었어요.',
           })
         }}
@@ -42,7 +42,6 @@ const App = () => {
 
 Exported values:
 
-- `Toast`
 - `ToastRegion`
 - `toastQueue`
 - `createToastQueue`
@@ -53,7 +52,6 @@ Exported types:
 
 - `ToastContent`
 - `ToastOptions`
-- `ToastProps`
 - `ToastRegionProps`
 
 ## Structure
@@ -63,7 +61,7 @@ React Aria Toast는 queue 기반으로 동작합니다.
 ```text
 showToast({ icon, children })
   -> ToastRegion
-    -> Toast
+    -> internal Toast renderer
       -> icon slot
       -> message
 ```
@@ -103,11 +101,11 @@ showToast({ icon, children })
 - value: `1500`
 - description: `showToast`의 고정 자동 닫힘 시간입니다.
 
-### `className`
+### `ToastRegion.className`
 
 - type: `string`
 - required: `false`
-- description: `Toast` 또는 `ToastRegion` root element에 병합할 class입니다.
+- description: `ToastRegion` root element에 병합할 class입니다.
 
 ## Requirements
 
@@ -123,7 +121,7 @@ showToast({ icon, children })
 
 ```text
 ToastRegion
-  Toast
+  internal Toast renderer
     ToastContent
       icon slot
       message
@@ -138,10 +136,10 @@ Toast:
 - padding: horizontal `20px`
 - gap: `11px`
 - radius: `10px`
-- background: `primary-200`
+- background: `dim`
 - text color: `white`
 - typography: `typo-long-body-1`
-- icon slot: `24px * 24px`, `shrink-0`
+- icon slot: `26px * 26px`, `shrink-0`
 - message: `min-w-0 line-clamp-2`
 - enter keyframe: `opacity: 0`, `translateY(-4px)`, `scale(0.98)`에서 `opacity: 1`, `translateY(0)`, `scale(1)`로 표시합니다.
 - exit keyframe: `timeout`이 있는 toast는 제거되기 직전에 `opacity: 1`, `translateY(0)`, `scale(1)`에서 `opacity: 0`, `translateY(-4px)`, `scale(0.98)`로 사라집니다.

--- a/packages/hds-ui/src/components/toast/Toast.stories.tsx
+++ b/packages/hds-ui/src/components/toast/Toast.stories.tsx
@@ -13,9 +13,9 @@ const mobileFrameDecorator = (Story: () => ReactNode) => (
 type ToastPreviewProps = ToastContent
 
 const ToastPreview = ({ icon, children }: ToastPreviewProps) => (
-  <div className="bg-primary-200 flex h-15 w-full items-center gap-2.75 rounded-[10px] px-5 text-white">
+  <div className="bg-dim flex h-15 w-full items-center gap-2.75 rounded-[10px] px-5 text-white">
     {icon ? (
-      <span aria-hidden="true" className="flex size-6 shrink-0">
+      <span aria-hidden="true" className="flex size-6.5 shrink-0">
         {icon}
       </span>
     ) : null}
@@ -30,7 +30,7 @@ const meta = {
   decorators: [mobileFrameDecorator],
   args: {
     children: '링크가 복사 되었어요.',
-    icon: <LinkIcon className="size-6" />,
+    icon: <LinkIcon className="size-6.5" />,
   },
   argTypes: {
     children: {
@@ -69,7 +69,7 @@ export const LongText: Story = {
 export const Success: Story = {
   args: {
     children: '예약이 취소되었어요.',
-    icon: <CheckIcon className="text-success size-6" />,
+    icon: <CheckIcon className="text-success size-6.5" />,
   },
   render: (args) => <ToastPreview {...args} />,
 }
@@ -83,7 +83,7 @@ export const Error: Story = {
         잠시후 다시 시도해주세요.
       </>
     ),
-    icon: <NoteIcon className="size-6" />,
+    icon: <NoteIcon className="size-6.5" />,
   },
   render: (args) => <ToastPreview {...args} />,
 }

--- a/packages/hds-ui/src/components/toast/Toast.test.tsx
+++ b/packages/hds-ui/src/components/toast/Toast.test.tsx
@@ -54,6 +54,25 @@ describe('Toast', () => {
     ).toHaveClass('w-full', 'px-5')
   })
 
+  it('uses the dim background token and 26px icon slot', () => {
+    const queue = createToastQueue()
+    queue.add({
+      children: '예약이 취소되었어요.',
+      icon: <svg data-testid="toast-icon" />,
+    })
+
+    render(<ToastRegion queue={queue} />)
+
+    const toast = screen
+      .getByText('예약이 취소되었어요.')
+      .closest('[role="alert"]')?.parentElement
+
+    expect(toast).toHaveClass('bg-dim')
+    expect(screen.getByTestId('toast-icon').parentElement).toHaveClass(
+      'size-6.5',
+    )
+  })
+
   it('applies a soft enter keyframe animation', () => {
     const queue = createToastQueue()
     queue.add({ children: '링크가 복사 되었어요.' })

--- a/packages/hds-ui/src/components/toast/Toast.tsx
+++ b/packages/hds-ui/src/components/toast/Toast.tsx
@@ -15,18 +15,10 @@ export type ToastContent = {
   children: ReactNode
 }
 
-type AriaToastOptions = NonNullable<
-  Parameters<AriaToastQueue<ToastContent>['add']>[1]
->
+type ToastQueue = AriaToastQueue<ToastContent>
+type ToastQueueAddOptions = NonNullable<Parameters<ToastQueue['add']>[1]>
 
-export type ToastOptions = Omit<AriaToastOptions, 'timeout'>
-
-export type ToastProps = Omit<
-  AriaToastProps<ToastContent>,
-  'children' | 'className'
-> & {
-  className?: string
-}
+export type ToastOptions = Omit<ToastQueueAddOptions, 'timeout'>
 
 export type ToastRegionProps = Omit<
   AriaToastRegionProps<ToastContent>,
@@ -36,13 +28,21 @@ export type ToastRegionProps = Omit<
   queue?: AriaToastRegionProps<ToastContent>['queue']
 }
 
+type ToastProps = Omit<
+  AriaToastProps<ToastContent>,
+  'children' | 'className'
+> & {
+  className?: string
+}
+
+export const DEFAULT_TOAST_TIMEOUT = 1500
+
 export const createToastQueue = () =>
   new AriaToastQueue<ToastContent>({
     maxVisibleToasts: 1,
   })
 
 export const toastQueue = createToastQueue()
-export const DEFAULT_TOAST_TIMEOUT = 1500
 
 export const showToast = (content: ToastContent, options?: ToastOptions) => {
   return toastQueue.add(content, {
@@ -51,7 +51,7 @@ export const showToast = (content: ToastContent, options?: ToastOptions) => {
   })
 }
 
-export const Toast = ({ className, ...props }: ToastProps) => {
+const Toast = ({ className, ...props }: ToastProps) => {
   const { icon, children } = props.toast.content
 
   return (
@@ -59,7 +59,7 @@ export const Toast = ({ className, ...props }: ToastProps) => {
       {...props}
       className={cn(
         'pointer-events-none flex h-15 w-full items-center gap-2.75 px-5',
-        'bg-primary-200 rounded-[10px] text-white',
+        'bg-dim rounded-[10px] text-white',
         'transform-gpu',
         props.toast.timeout
           ? 'animate-toast-with-timeout'
@@ -69,7 +69,7 @@ export const Toast = ({ className, ...props }: ToastProps) => {
     >
       <AriaToastContent className="contents">
         {icon ? (
-          <span aria-hidden="true" className="flex size-6 shrink-0">
+          <span aria-hidden="true" className="flex size-6.5 shrink-0">
             {icon}
           </span>
         ) : null}

--- a/packages/hds-ui/src/components/toast/index.ts
+++ b/packages/hds-ui/src/components/toast/index.ts
@@ -2,13 +2,7 @@ export {
   createToastQueue,
   DEFAULT_TOAST_TIMEOUT,
   showToast,
-  Toast,
   ToastRegion,
   toastQueue,
 } from './Toast'
-export type {
-  ToastContent,
-  ToastOptions,
-  ToastProps,
-  ToastRegionProps,
-} from './Toast'
+export type { ToastContent, ToastOptions, ToastRegionProps } from './Toast'


### PR DESCRIPTION
## 📌 요약

> Toast 컴포넌트를 리디자인된 Figma 기준에 맞춰 수정하고 외부에 공개할 필요가 없는 내부 구현 export를 정리했습니다.

Jira: HASHI-170

## 📚 작업 내용

### Toast 디자인 스펙 반영

- Toast 배경을 `primary-200`에서 `dim` 토큰으로 변경
- icon slot 크기를 `24px`에서 `26px`로 변경
- Storybook의 Toast preview도 실제 컴포넌트와 동일한 기준으로 정리
- 기본, 성공, 에러 Story의 아이콘 크기를 동일하게 맞춤

### Toast public API 정리

- 외부에서 직접 사용하지 않는 `Toast` export 제거
- `Toast`와 함께 외부 노출이 필요 없어진 `ToastProps` export 제거
- `Toast`는 `ToastRegion` 내부에서만 사용하는 internal renderer로 정리
- `ToastOptions` 타입명을 읽기 쉽게 정리

### Spec 문서 정리

- 실제 구현과 맞지 않던 배경/아이콘 크기 기준 수정
- Exported values/types 목록을 현재 public API 기준으로 수정
- `Toast`가 public component처럼 보이지 않도록 `internal Toast renderer`로 표현 변경
- `className` 설명을 `ToastRegion.className` 기준으로 수정

## 🔎 상세 설명

> 기존 Toast 컴포넌트를 리디자인된 버전에 맞춰 수정했습니다! 이번 작업에서는 외부에서 사용하는 API와 내부 구현을 구분하는 작업도 진행했습니다!

- 배경색이 `primary-200`으로 되어 있었음
- 아이콘 슬롯이 24px 기준으로 되어 있었음
- Storybook preview와 실제 Toast 구현이 중복되어 있어 디자인 변경 시 불일치가 생길 수 있었음
- `Toast`는 실제 앱에서 직접 사용하지 않고 `ToastRegion` 내부에서만 렌더링되는데 public export로 열려 있었음

```tsx
<ToastRegion className="..." />

showToast({
  icon: <LinkIcon className="size-6.5" />,
  children: '링크가 복사 되었어요.',
})
```

-> `ToastRegion`을 전역에 배치하고 `showToast()`를 호출하는 기존 흐름은 유지됩니다.

## 💭 고민한 부분

### 1. Toast와 ToastRegion을 합칠지

> Toast는 실제 토스트 UI 한 개를 렌더링하고, ToastRegion은 React Aria queue를 보고 토스트가 표시될 영역을 관리합니다.

- React Aria Toast 구조 자체가 queue 기반이라 두 책임을 나누는 현재 구조가 자연스럽다고 판단했습니다.
- `Toast` / `ToastRegion` 구조는 유지했습니다.

### 2. Toast를 계속 export할지

> `Toast`를 직접 사용하지 않고 `ToastRegion`만 사용하고 있습니다.

- `Toast`는 queue에서 넘어온 toast item을 실제 UI로 그리는 내부 렌더러에 가까워서 public API로 열어둘 필요가 크지 않다고 판단했습니다.
- 외부 export에서는 제거하고, `ToastRegion` 내부에서만 사용하도록 정리했습니다.

## 📸 storybook 링크
https://6a39332c67b59aad1e4f42e8-bpyuyrvthf.chromatic.com/?path=/docs/components-toast--docs