### PR TITLE
Fix(hds-ui): HASHI-177 Calendar UI 수정

### DIFF
--- a/packages/hds-ui/src/components/calendar/Calendar.spec.md
+++ b/packages/hds-ui/src/components/calendar/Calendar.spec.md
@@ -1,12 +1,12 @@
 # Component Spec: `Calendar`
 
-Jira: HASHI-42
+Jira: HASHI-177 (최초 구현: HASHI-42)
 
 ## Purpose
 
 `Calendar`는 월 단위 날짜 선택 UI를 그리는 HDS의 공통 interactive primitive입니다.
 
-HDS는 **월 헤더, 이전/다음 월 탐색 버튼, 요일 행, 날짜 grid, 선택/비활성 날짜의 시각 상태, 기본 접근성 계약, controlled selection callback**만 담당합니다. 실제 예약 가능 여부 계산, API 호출, query/mutation, 예약 정책, 영업일 규칙, 결제/예약 submit, analytics, 제품 copy는 App Shell / Page / Feature에서 처리합니다.
+HDS는 **월 헤더, 이전/다음 월 탐색 버튼, 날짜 grid, 선택/비활성 날짜의 시각 상태, 기본 접근성 계약, controlled selection callback**만 담당합니다. 실제 예약 가능 여부 계산, API 호출, query/mutation, 예약 정책, 영업일 규칙, 결제/예약 submit, analytics, 제품 copy는 App Shell / Page / Feature에서 처리합니다.
 
 ## Component Type
 
@@ -16,9 +16,10 @@ HDS는 **월 헤더, 이전/다음 월 탐색 버튼, 요일 행, 날짜 grid, �
 
 ## Figma Reference
 
-- 전달 이미지 기준 calendar month view
+- [Calendar 리디자인](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7869-36523&m=dev)
+- 기본 날짜: `7869:36535`, 선택 예시: `7869:36537`, 선택 날짜: `7869:36542`
 - month header: left `icon_back`, two-line year/month text, right `icon_next`
-- weekday row: `S M T W T F S`
+- weekday row: 최신 디자인에서는 표시하지 않음
 - date grid: 7 columns, month days only
 - selected date state: black rounded rectangle
 - unavailable date state: muted cool-gray text
@@ -92,14 +93,14 @@ HDS는 **월 헤더, 이전/다음 월 탐색 버튼, 요일 행, 날짜 grid, �
 - [x] 제품 도메인 데이터, route, API, logging, analytics에 의존하지 않습니다.
 - [x] `month` 기준으로 visible month를 렌더링합니다.
 - [x] visible month 외 날짜는 v1에서 렌더링하지 않고 empty grid cell로 정렬합니다.
-- [x] 요일은 일요일부터 토요일까지 7개 column으로 렌더링합니다.
-- [x] 날짜 column은 `repeat(7, minmax(0, 1fr))` 형태의 equal-column grid로 배치합니다.
+- [x] 요일 행은 표시하지 않으며 날짜는 일요일부터 토요일 순서의 7개 column으로 렌더링합니다.
+- [x] 날짜 column은 `36px` 셀 7개를 부모 너비 안에 균등 분산합니다. 최소 콘텐츠 너비는 `252px`입니다.
 - [x] 날짜 visual은 각 grid cell 중앙에 정렬합니다.
 - [x] month header는 `44px` 높이 안에서 연도와 월을 세로 2줄로 중앙 정렬합니다.
 - [x] 연도 label은 `typo-body-3`, `text-cool-gray-900` 기준을 따릅니다.
 - [x] 월 label은 `typo-sub-header-1`, `text-black` 기준을 따릅니다.
-- [x] 세로 row gap은 `10px` 기준으로 구현합니다.
-- [x] 날짜 텍스트 visual box는 `padding: 5px 12px` 기준을 따릅니다.
+- [x] 날짜 셀 높이는 `36px`, 세로 row gap은 `6px`로 고정해 선택 시 행이 움직이지 않게 합니다.
+- [x] 일반 날짜는 너비 `34px`, `padding: 5px 6px`이며 선택 날짜는 `36px × 36px`, `padding: 4px 7px`입니다.
 - [x] 선택 가능한 날짜는 `typo-body-4`, `text-black` 기준을 따릅니다.
 - [x] 선택 불가 날짜는 `typo-body-4`, `text-cool-gray-400` 기준을 따릅니다.
 - [x] 선택된 날짜는 `rounded-[5px]`, `bg-black`, `typo-sub-header-2`, `text-white` 기준을 따릅니다.
@@ -110,7 +111,6 @@ HDS는 **월 헤더, 이전/다음 월 탐색 버튼, 요일 행, 날짜 grid, �
 - [x] `onMonthChange`가 없으면 월 이동 버튼은 disabled 상태로 렌더링합니다.
 - [x] `minMonth`가 visible month와 같거나 이후면 이전 달 버튼은 disabled 상태로 렌더링합니다.
 - [x] 날짜 버튼에는 기본적으로 `YYYY년 M월 D일` 형태의 accessible name을 제공합니다.
-- [x] 요일 label에는 전체 요일 accessible name을 제공합니다.
 - [x] `className`은 root에 안전하게 병합합니다.
 
 ## UI Structure
@@ -122,8 +122,6 @@ Calendar
     Year label
     Month label
     Next month button
-  Weekday row
-    Weekday label x 7
   Date grid
     Empty cell x leading offset
     Date button x month day count
@@ -195,20 +193,6 @@ Calendar
 - default: Korean full date label, for example `'2026년 6월 1일'`
 - description: 날짜 button의 accessible name을 포맷합니다. visible text는 숫자만 유지하되 스크린리더에는 연/월/일 정보를 제공합니다.
 
-### `weekdayLabels`
-
-- type: `readonly [string, string, string, string, string, string, string]`
-- required: `false`
-- default: `['S', 'M', 'T', 'W', 'T', 'F', 'S']`
-- description: 요일 표시 텍스트입니다. 일요일부터 토요일 순서로 전달합니다.
-
-### `weekdayAriaLabels`
-
-- type: `readonly [string, string, string, string, string, string, string]`
-- required: `false`
-- default: `['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']`
-- description: 요일 label의 accessible name입니다. 시각 label은 `S M T W T F S`처럼 짧게 유지하되 스크린리더에는 전체 요일명을 제공합니다.
-
 ### `className`
 
 - type: `string`
@@ -238,24 +222,6 @@ export type CalendarProps = Omit<
   formatYearLabel?: (month: Date) => string
   formatMonthLabel?: (month: Date) => string
   getDateAriaLabel?: (date: Date) => string
-  weekdayLabels?: readonly [
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-  ]
-  weekdayAriaLabels?: readonly [
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-  ]
 }
 ```
 
@@ -277,7 +243,7 @@ export type CalendarProps = Omit<
 ## Behavior
 
 1. `month`의 year/month를 기준으로 첫 요일 offset과 월 일수를 계산합니다.
-2. 요일 row는 항상 7개 label을 렌더링합니다.
+2. 요일 row는 렌더링하지 않습니다.
 3. 날짜 grid는 7 columns를 유지하고 첫 날짜 전 empty cell을 렌더링합니다.
 4. 각 날짜는 native `button`으로 렌더링합니다.
 5. 활성 날짜를 클릭하면 해당 날짜의 `Date` 객체로 `onDateSelect`를 호출합니다.
@@ -304,31 +270,19 @@ export type CalendarProps = Omit<
   - white background는 호출부 surface에 맡기되 story에서는 white wrapper를 제공합니다.
 - header:
   - horizontal layout
-  - bottom spacing to weekday row: `22px`
+  - bottom spacing to date grid: `26px`
   - left/right icon button과 centered month label
   - month label: `typo-sub-header-1`, `text-black`
   - icon color: `text-cool-gray-900`
   - icon source: `BackIcon`, `NextIcon` from `@hashi/hds-icons`
-- weekday row:
-  - `grid`
-  - `grid-template-columns: repeat(7, minmax(0, 1fr))`
-  - bottom spacing to date grid: `22px`
-  - `bg-primary-100`
-  - `rounded-[5px]`
-  - weekday text: `typo-body-5`, `text-black`
-  - Sunday label text: `typo-sub-header-3`, `text-primary-400`
-  - Saturday label text: `typo-sub-header-3`, `text-point-300`
-  - label padding: `py-[5px] px-3`
 - date grid:
-  - `grid`
-  - `grid-template-columns: repeat(7, minmax(0, 1fr))`
-  - `row-gap: 10px`
-  - column spacing is produced by equal-width columns and centered date boxes, not fixed `column-gap: 18px`
-  - date cell: center alignment
-  - date button: `h-8`, `py-[5px] px-3`, `rounded-[5px]`
+  - `grid`, `grid-template-columns: repeat(7, auto)`, `justify-content: space-between`
+  - `row-gap: 6px`
+  - date cell: `size-9` (`36px × 36px`), center alignment
+  - date button: `w-8.5`, `py-1.25 px-1.5`, `rounded-[5px]`
   - available date: `typo-body-4`, `text-black`
   - disabled date: `typo-body-4`, `text-cool-gray-400`
-  - selected date: `size-8`, `typo-sub-header-2`, `bg-black`, `text-white`
+  - selected date: `size-9`, `py-1 px-1.75`, `typo-sub-header-2`, `bg-black`, `text-white`
 - focus-visible:
   - `focus-visible:outline-2`
   - `focus-visible:outline-offset-2`
@@ -338,9 +292,12 @@ export type CalendarProps = Omit<
 
 - `Black`은 Tailwind 기본 `text-black`/`bg-black` utility를 사용합니다.
 - `radius 5`는 현재 radius token이 없으므로 `rounded-[5px]`를 사용합니다.
-- `5px` vertical padding은 Tailwind 기본 spacing에 없으므로 `py-[5px]`를 사용합니다.
-- `12px` horizontal padding은 Tailwind `px-3`와 일치합니다.
-- date button은 선택 상태에서 row 높이가 흔들리지 않도록 기본 높이를 `h-8`로 고정합니다.
+- spacing/sizing은 Tailwind scale을 사용합니다: `py-1.25` = 5px, `px-1.5` = 6px, `size-9` = 36px.
+- Figma 기본 날짜는 너비 34px, 선택 날짜는 36px입니다. 모든 날짜의 배치 공간을 36px로 통일해 선택 상태 변경 시 행/열 이동을 막습니다.
+- Figma 기본/선택 예시의 날짜 영역 시작점은 2px 다릅니다. 선택 예시의 header–grid 간격 26px를 기준으로 사용하며, 날짜 행 간격은 42px로 통일합니다.
+- Figma의 346px는 비교용 너비이며 root에 고정하지 않습니다. 36px 셀 사이의 수평 간격은 부모 너비에 맞춰 분산합니다.
+- Figma 예시의 2026년 6월에 포함된 31일과 날짜 시작 위치는 복제하지 않습니다. 실제 연월의 일수와 시작 요일을 계산합니다.
+- `weekdayLabels`, `weekdayAriaLabels`는 요일 행 제거와 함께 public API에서 제거했습니다. 기존 앱 호출부 두 곳에서는 사용하지 않습니다.
 
 ## Accessibility
 
@@ -359,9 +316,6 @@ export type CalendarProps = Omit<
   - `role="grid"`/roving tabindex는 v1에서 도입하지 않습니다. 완전한 date picker keyboard contract가 필요해지면 `react-aria-components` 기반 Calendar로 확장합니다.
   - selected date에는 button 역할에 맞는 `aria-pressed="true"`를 제공합니다.
   - disabled date에는 native `disabled`를 사용합니다.
-- weekday row:
-  - visual label은 `S M T W T F S`를 유지합니다.
-  - 각 weekday label에는 `weekdayAriaLabels`로 전체 요일 accessible name을 제공합니다.
 - visible text:
   - date button의 visible text는 숫자만 렌더링합니다.
   - date button의 accessible name은 `getDateAriaLabel` 결과를 사용합니다.
@@ -393,8 +347,9 @@ export type CalendarProps = Omit<
 - [x] Month navigation callbacks
 - [x] Minimum month previous-navigation disabled state
 - [x] Custom month label formatter
-- [x] Custom weekday labels
-- [x] Narrow mobile wrapper around `393px`
+- [x] Figma 비교용 346px 콘텐츠 너비
+- [x] Narrow container: 320px viewport에서 좌우 여백 32px를 제외한 256px 콘텐츠 너비
+- [x] Six-week month: 2026년 8월
 - [x] Long root `aria-label` or labelled wrapper accessibility check
 
 v1에서 loading, error, invalid, range selection, time selection, popover positioning은 지원하지 않습니다.
@@ -420,10 +375,15 @@ v1에서 loading, error, invalid, range selection, time selection, popover posit
 
 ## Verification
 
-- [x] `corepack pnpm format:check`
-- [x] `corepack pnpm --filter @hashi/hds-ui lint`
-- [x] `corepack pnpm --filter @hashi/hds-ui typecheck`
-- [x] `corepack pnpm --filter @hashi/hds-ui build`
-- [x] `corepack pnpm --filter @hashi/hds-ui test`
-- [x] `corepack pnpm --filter @hashi/hds-ui build-storybook`
-- [x] 주요 UI 상태 Storybook story 구성 확인
+- [x] `pnpm format:check`
+- [x] `pnpm --filter @hashi/hds-ui lint`
+- [x] `pnpm --filter @hashi/hds-ui typecheck`
+- [x] `pnpm --filter @hashi/hds-ui build`
+- [x] `pnpm --filter @hashi/hds-ui test`
+- [x] `pnpm build-storybook`
+- [x] 기본/선택/비활성/월 이동/좁은 너비/6주 렌더링을 브라우저에서 확인
+- [x] 선택 전후 날짜 중심 좌표와 행 높이가 동일한지 확인
+- [x] `pnpm --filter @hashi/client typecheck` — 앱 호출부 호환성 확인
+- [x] Tab으로 비활성 날짜 건너뛰기, 포커스 표시, Enter로 날짜 선택 확인
+
+2026-09-07 검증: HDS 19개 파일/179개 테스트 통과. 브라우저에서 346px/256px 콘텐츠 너비, 320px viewport, 선택 전후 중심 좌표 유지, 월 이동 및 6주 렌더링을 확인했습니다. 예약 API 및 실제 예약 제출은 변경하지 않았으며 이번 검증 범위에 포함하지 않습니다.

--- a/packages/hds-ui/src/components/calendar/Calendar.stories.tsx
+++ b/packages/hds-ui/src/components/calendar/Calendar.stories.tsx
@@ -6,7 +6,7 @@ import { Calendar } from './Calendar'
 const JUNE_2026 = new Date(2026, 5, 1)
 
 const calendarDecorator = (Story: () => ReactNode) => (
-  <div className="w-[393px] max-w-full bg-white px-8 py-6">
+  <div className="w-102.5 max-w-full bg-white px-8 py-6">
     <Story />
   </div>
 )
@@ -15,6 +15,9 @@ const meta = {
   title: 'Components/Calendar',
   component: Calendar,
   tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
   args: {
     month: JUNE_2026,
   },
@@ -44,12 +47,6 @@ const meta = {
       control: false,
     },
     disabledDates: {
-      control: false,
-    },
-    weekdayLabels: {
-      control: false,
-    },
-    weekdayAriaLabels: {
       control: false,
     },
   },
@@ -121,7 +118,6 @@ export const CustomLabels: Story = {
   args: {
     formatYearLabel: (month) => `${month.getFullYear()}년`,
     formatMonthLabel: (month) => String(month.getMonth() + 1).padStart(2, '0'),
-    weekdayLabels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   },
 }
 
@@ -135,5 +131,24 @@ export const LabelledRegion: Story = {
   args: {
     'aria-label': '예약 가능한 날짜를 선택하는 달력',
     selectedDate: new Date(2026, 5, 7),
+  },
+}
+
+export const SixWeekMonth: Story = {
+  args: {
+    month: new Date(2026, 7, 1),
+    selectedDate: new Date(2026, 7, 31),
+  },
+}
+
+export const NarrowContainer: Story = {
+  render: (args) => (
+    <div className="w-64 max-w-full">
+      <Calendar {...args} />
+    </div>
+  ),
+  args: {
+    selectedDate: new Date(2026, 5, 7),
+    disabledDates: [new Date(2026, 5, 6)],
   },
 }

--- a/packages/hds-ui/src/components/calendar/Calendar.test.tsx
+++ b/packages/hds-ui/src/components/calendar/Calendar.test.tsx
@@ -7,27 +7,14 @@ afterEach(() => {
 })
 
 describe('Calendar', () => {
-  it('renders the visible month with weekday labels and month days', () => {
+  it('renders the visible month and its days without a weekday row', () => {
     render(<Calendar month={new Date(2026, 5, 1)} />)
 
     expect(screen.getByRole('heading', { name: '2026 6월' })).toBeTruthy()
     expect(screen.getByText('2026').className).toContain('typo-body-3')
     expect(screen.getByText('2026').className).toContain('text-cool-gray-900')
     expect(screen.getByText('6월').className).toContain('typo-sub-header-1')
-    expect(screen.getAllByText('S')).toHaveLength(2)
-    expect(screen.getAllByText('S')[0]?.className).toContain(
-      'typo-sub-header-3',
-    )
-    expect(screen.getAllByText('S')[1]?.className).toContain(
-      'typo-sub-header-3',
-    )
-    expect(screen.getAllByText('S')[0]?.getAttribute('aria-label')).toBe(
-      '일요일',
-    )
-    expect(screen.getAllByText('S')[1]?.getAttribute('aria-label')).toBe(
-      '토요일',
-    )
-    expect(screen.getAllByText('M')[0]?.className).toContain('typo-body-5')
+    expect(screen.queryByText(/^[SMTWF]$/)).toBeNull()
     expect(screen.getByRole('button', { name: '2026년 6월 1일' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '2026년 6월 30일' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: '2026년 6월 31일' })).toBeNull()
@@ -68,10 +55,6 @@ describe('Calendar', () => {
 
     expect(selectedDate.getAttribute('aria-pressed')).toBe('true')
     expect(selectedDate.hasAttribute('aria-selected')).toBe(false)
-    expect(selectedDate.className).toContain('size-8')
-    expect(
-      screen.getByRole('button', { name: '2026년 6월 7일' }).className,
-    ).toContain('h-8')
     expect((disabledDate as HTMLButtonElement).disabled).toBe(true)
 
     fireEvent.click(disabledDate)

--- a/packages/hds-ui/src/components/calendar/Calendar.tsx
+++ b/packages/hds-ui/src/components/calendar/Calendar.tsx
@@ -3,27 +3,6 @@ import type { ComponentPropsWithoutRef } from 'react'
 
 import { cn } from '../../utils'
 
-const DEFAULT_WEEKDAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const
-const DEFAULT_WEEKDAY_ARIA_LABELS = [
-  '일요일',
-  '월요일',
-  '화요일',
-  '수요일',
-  '목요일',
-  '금요일',
-  '토요일',
-] as const
-
-type WeekdayLabels = readonly [
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
-  string,
-]
-
 export type CalendarProps = Omit<
   ComponentPropsWithoutRef<'section'>,
   'children' | 'onChange'
@@ -38,8 +17,6 @@ export type CalendarProps = Omit<
   formatYearLabel?: (month: Date) => string
   formatMonthLabel?: (month: Date) => string
   getDateAriaLabel?: (date: Date) => string
-  weekdayLabels?: WeekdayLabels
-  weekdayAriaLabels?: WeekdayLabels
 }
 
 const createMonthDate = (date: Date, day = 1) => {
@@ -94,8 +71,6 @@ export const Calendar = ({
   formatYearLabel = defaultFormatYearLabel,
   formatMonthLabel = defaultFormatMonthLabel,
   getDateAriaLabel = defaultGetDateAriaLabel,
-  weekdayLabels = DEFAULT_WEEKDAY_LABELS,
-  weekdayAriaLabels = DEFAULT_WEEKDAY_ARIA_LABELS,
   className,
   'aria-label': ariaLabel = '달력',
   ...props
@@ -122,7 +97,7 @@ export const Calendar = ({
       className={cn('w-full font-sans', className)}
       {...props}
     >
-      <div className="mb-[22px] flex h-11 items-center justify-between">
+      <div className="mb-6.5 flex h-11 items-center justify-between">
         <button
           aria-label="이전 달"
           className="text-cool-gray-900 focus-visible:outline-cool-gray-900 disabled:text-cool-gray-400 flex size-6 appearance-none items-center justify-center rounded-[5px] border-0 bg-transparent p-0 text-[24px] focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
@@ -150,23 +125,7 @@ export const Calendar = ({
           <NextIcon aria-hidden="true" />
         </button>
       </div>
-      <div className="bg-primary-100 mb-[22px] grid grid-cols-7 rounded-[5px]">
-        {weekdayLabels.map((label, index) => (
-          <span
-            aria-label={weekdayAriaLabels[index]}
-            className={cn(
-              'flex items-center justify-center px-3 py-[5px] text-black',
-              index === 0 || index === 6 ? 'typo-sub-header-3' : 'typo-body-5',
-              index === 0 && 'text-primary-400',
-              index === 6 && 'text-point-300',
-            )}
-            key={`${label}-${index}`}
-          >
-            {label}
-          </span>
-        ))}
-      </div>
-      <div className="grid grid-cols-7 gap-y-[10px]">
+      <div className="grid grid-cols-[repeat(7,auto)] justify-between gap-y-1.5">
         {Array.from({ length: firstWeekday }, (_, index) => (
           <span aria-hidden="true" key={`empty-${index}`} />
         ))}
@@ -178,14 +137,17 @@ export const Calendar = ({
             checkIsSameDay(date, selectedDate)
 
           return (
-            <div className="flex min-w-0 justify-center" key={date.getTime()}>
+            <div
+              className="flex size-9 items-center justify-center"
+              key={date.getTime()}
+            >
               <button
                 aria-label={getDateAriaLabel(date)}
                 aria-pressed={isSelected}
                 className={cn(
-                  'typo-body-4 focus-visible:outline-cool-gray-900 disabled:text-cool-gray-400 flex h-8 appearance-none items-center justify-center rounded-[5px] border-0 bg-transparent px-3 py-[5px] text-black focus-visible:outline-2 focus-visible:outline-offset-2',
+                  'typo-body-4 focus-visible:outline-cool-gray-900 disabled:text-cool-gray-400 flex w-8.5 shrink-0 appearance-none items-center justify-center rounded-[5px] border-0 bg-transparent px-1.5 py-1.25 text-black focus-visible:outline-2 focus-visible:outline-offset-2',
                   isSelected &&
-                    'typo-sub-header-2 size-8 bg-black p-0 text-white',
+                    'typo-sub-header-2 size-9 bg-black px-1.75 py-1 text-white',
                 )}
                 disabled={isDisabled}
                 onClick={() => onDateSelect?.(date)}


### PR DESCRIPTION
## 📌 요약

기존 Calendar를 최신 Figma 디자인에 맞춰 수정했습니다. 요일 행을 제거하고 날짜 크기와 간격을 조정했으며, 날짜 선택 시 주변 날짜의 위치가 움직이지 않도록 배치를 정리했습니다.

Jira: HASHI-177

`develop`을 대상으로 하는 독립 PR입니다. Input/Textarea 리디자인 작업과는 의존 관계가 없습니다.

## 📚 작업 내용

### Calendar 디자인 반영

- 요일 행 제거
- 헤더와 날짜 영역 사이 간격을 22px에서 26px로 변경
- 일반 날짜 너비를 34px, 선택 날짜 크기를 32×32px에서 36×36px로 조정
- 날짜 배치 공간을 36×36px로 통일하고 행 사이 간격을 6px로 변경
- 부모 너비에 맞춰 7개 날짜 열 사이의 간격을 균등하게 분산

### Public API 및 스펙 정리

- 요일 행 제거에 따라 `weekdayLabels`, `weekdayAriaLabels` props 제거
- 기존 앱 호출부에서 해당 props를 사용하지 않는 것을 확인
- 날짜 선택, 비활성 날짜 처리, 월 이동, `minMonth` 동작 유지
- `Calendar.spec.md`에 크기, 간격, 반응형 배치와 제거된 props 반영

### Storybook 및 테스트

- Figma 비교용 콘텐츠 너비를 346px로 조정
- 좁은 컨테이너와 6주로 표시되는 달의 예시 추가
- 요일 행이 표시되지 않는지 확인하도록 테스트 수정

## 🔎 상세 설명

Calendar는 기존처럼 `month`, `selectedDate`를 받아 렌더링하고, 날짜 선택과 월 이동을 callback으로 전달합니다. 예약 가능 여부 계산과 API 처리는 호출부에서 담당합니다.

[Calendar Figma](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7869-36523&m=dev)의 시각 기준을 반영하되, 예시에 표시된 날짜 배열을 그대로 복제하지 않고 실제 연월의 일수와 시작 요일을 계산하는 기존 로직을 유지했습니다.

## 💭 고민한 부분

### 너비를 피그마 수치로 고정할지

피그마의 346px를 컴포넌트 너비로 고정하면 사용하는 화면마다 맞추기 어려워집니다. 비교용 Storybook에만 해당 너비를 적용하고, Calendar 자체는 부모 너비를 채우도록 했습니다.

날짜 셀은 36px로 유지하고 셀 사이 간격이 남은 너비에 맞춰 늘어납니다. 최소 콘텐츠 너비는 252px이며, 320px 화면에서 좌우 여백을 제외한 256px 콘텐츠 너비를 확인했습니다.

### 일반 날짜와 선택 날짜의 크기 차이를 어떻게 처리할지

일반 날짜 버튼과 선택 날짜 버튼을 그대로 배치하면 선택 상태에 따라 행 높이나 날짜 위치가 달라질 수 있습니다. 모든 날짜의 배치 공간을 36×36px로 통일하고 버튼을 중앙에 정렬해 선택 전후 위치를 유지했습니다.

피그마 기본/선택 예시의 날짜 영역 시작점은 2px 차이가 있어, 헤더와 날짜 영역 간격은 선택 예시의 26px로 통일했습니다.

## ✅ 검증

- [x] HDS 자동 테스트: 19개 파일, 179개 테스트 통과 — Calendar 7개 포함
- [x] `pnpm --filter @hashi/hds-ui lint`
- [x] `pnpm --filter @hashi/hds-ui typecheck`
- [x] `pnpm --filter @hashi/client typecheck`
- [x] 변경된 4개 파일의 `pnpm exec prettier … --check`
- [x] `git diff --check`
- [x] 브라우저 확인(9/7): 346px·256px 콘텐츠 너비, 320px 화면, 선택 전후 날짜 중심 좌표 유지
- [x] 브라우저 확인(9/7): 비활성 날짜, 월 이동, 6주 렌더링, Tab 이동 및 Enter 선택

실제 예약 API 및 예약 제출은 이번 변경과 검증 범위에 포함하지 않았습니다.

## 👀 리뷰어에게

- 요일 행 제거와 날짜 간격이 최신 디자인 의도에 맞는지 확인 부탁드립니다.
- `NarrowContainer`, `SixWeekMonth` Story에서도 날짜 배치와 선택 상태를 확인할 수 있습니다.

## 📸 Storybook

- [기본 Calendar](https://6a39332c67b59aad1e4f42e8-zggbecnwmz.chromatic.com/?path=/story/components-calendar--default)
- [선택 상태](https://6a39332c67b59aad1e4f42e8-zggbecnwmz.chromatic.com/?path=/story/components-calendar--selected-date)
- [좁은 컨테이너](https://6a39332c67b59aad1e4f42e8-zggbecnwmz.chromatic.com/?path=/story/components-calendar--narrow-container)
- [6주로 표시되는 달](https://6a39332c67b59aad1e4f42e8-zggbecnwmz.chromatic.com/?path=/story/components-calendar--six-week-month)
