### PR TITLE
Fix(hds-ui): HASHI-176 InputField·Textarea 리디자인 반영

### DIFF
--- a/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.spec.md
+++ b/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.spec.md
@@ -57,7 +57,7 @@
 - [x] 선택된 이미지 미리보기 우상단에는 18px 삭제 아이콘 버튼을 표시합니다.
 - [x] 이미지 삭제 버튼을 누르면 해당 이미지를 제외한 `photoFiles`를 `onPhotoFilesChange`에 전달합니다.
 - [x] 이미지 삭제 버튼을 누르면 기존 사진 오류 메시지를 초기화합니다.
-- [x] 리뷰 본문 textarea는 HDS `Textarea`를 사용합니다.
+- [x] 리뷰 본문 textarea는 HDS `Textarea`를 사용하며, 공통 Input 리디자인 이후에도 `min-h-57.5`로 기존 최소 높이 `230px`를 유지합니다.
 - [x] textarea placeholder는 `리뷰를 작성해 주세요.`입니다.
 - [x] textarea에는 `maxLength`를 전달해 HDS `Textarea`의 입력 제한 로직을 사용합니다.
 - [x] textarea 본문은 Figma `Long Body 1` 기준인 `typo-long-body-1`을 사용합니다.

--- a/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.tsx
+++ b/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.tsx
@@ -107,7 +107,7 @@ export const InputReviewMain = ({
             maxLength={maxLength}
             placeholder="리뷰를 작성해 주세요."
             showCounter={false}
-            textareaClassName="typo-long-body-1 focus-visible:border-warm-gray-100 focus-visible:outline-none"
+            textareaClassName="typo-long-body-1 min-h-57.5 focus-visible:border-warm-gray-100 focus-visible:outline-none"
             value={value}
             onBlur={() => setHasReviewTextBlurred(true)}
             onChange={handleReviewTextChange}

--- a/packages/hds-ui/src/components/inputField/InputField.spec.md
+++ b/packages/hds-ui/src/components/inputField/InputField.spec.md
@@ -1,127 +1,62 @@
 # Component Spec: `InputField`
 
-Jira: HASHI-64
+Jira: HASHI-176 (기존 HASHI-64 리디자인)
 
 ## Purpose
 
-`InputField`는 여러 화면에서 재사용 가능한 HDS 공통 입력 primitive입니다.
-
-HDS는 label, input box, right icon slot, right element slot, disabled state, focus style, className merge, native input attribute forwarding, baseline accessibility만 담당합니다. 연락처, 전화번호, 인증번호, 재전송, 확인, 인증 API, route, analytics, 제품별 검증 정책은 호출부가 처리합니다.
-
-## Usage Location
-
-- `packages/hds-ui/src/components/inputField/InputField.tsx`
-
-## Requirements
-
-- [x] 제품 도메인 copy나 검증 정책을 하드코딩하지 않습니다.
-- [x] native `input` props를 전달합니다.
-- [x] `label`, `rightIcon`, `rightElement`, `disabled`, `className`을 지원합니다.
-- [x] `label`이 있으면 `htmlFor`와 `id`로 input에 연결합니다.
-- [x] `id`가 전달되면 해당 id를 우선 사용합니다.
-- [x] `rightElement`는 외부에서 주입된 element를 렌더링만 합니다.
-- [x] `rightIcon`은 외부에서 주입된 icon을 장식 영역에 렌더링만 합니다.
-- [x] error / invalid 상태와 도메인 검증은 1차 구현에서 제외합니다.
-- [x] 컴포넌트 기본 width는 `w-full`이며 화면 고정 width를 하드코딩하지 않습니다.
+제품 의미가 없는 한 줄 입력 primitive입니다. label, 입력 외형, 우측 slot, disabled, focus, native input props를 담당합니다. 검증 정책, 인증 API, 제품 문구와 제출 동작은 호출부가 소유합니다.
 
 ## Figma References
 
-| Node         | Name                               | Notes                               |
-| ------------ | ---------------------------------- | ----------------------------------- |
-| `2136:64708` | `input_name`                       | label + placeholder 기본 input      |
-| `2136:64489` | `input_contact_verified`           | label + right action                |
-| `2136:64707` | `input_verification_code_disabled` | placeholder + right action          |
-| `2136:64711` | `input_verification_code_complete` | value + success icon + right action |
-
-Figma의 `연락처`, `010-7875-7856`, `4846`, `재전송`, `확인`, `인증하기` 문구는 HDS 내부에 하드코딩하지 않고 Storybook 예시에서만 사용합니다.
+- [Input line](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7869-36441&m=dev)
+- rest: `7869:36479`, input: `7869:36481`, 본문 typography: `7869:36480`
+- 2026-09-08 ego-browser의 Dev Mode 화면과 속성 패널에서 확인했습니다.
 
 ## Public API
 
 ```tsx
-<InputField
-  label="연락처"
-  placeholder="연락처를 입력해 주세요."
-  rightElement={<Button>인증하기</Button>}
-/>
+<InputField label="라벨" placeholder="텍스트" onChange={handleChange} />
 ```
 
-Exported value:
+- export: `InputField`, `InputFieldProps` (변경 없음)
+- `label`: input과 연결되는 선택적 label. 생략 시 `aria-label` 또는 `aria-labelledby` 필수.
+- `rightIcon`: 장식용 아이콘 slot.
+- `rightElement`: 호출부가 동작과 접근성을 소유하는 action/content slot.
+- `className`: 외형을 담당하는 input box에 병합.
+- native input props, controlled `value`, uncontrolled `defaultValue`, ref 전달을 유지합니다. native `size`는 제외합니다.
 
-- `InputField`
+## States And Behavior
 
-Exported type:
-
-- `InputFieldProps`
-
-## Props
-
-- `label`: `string`, optional label rendered above the input.
-- `rightIcon`: `ReactNode`, optional decorative right icon slot.
-- `rightElement`: `ReactNode`, optional right action/content slot.
-- `className`: `string`, optional className merged into the visual input box container.
-- native `input` props except `size` and inner input `className`.
-
-## States
-
-- default: editable input with optional placeholder.
-- labeled: label is rendered and connected to the input.
-- with right icon: external icon is rendered in the right icon slot.
-- with right element: external action/content is rendered in the right element slot.
-- focused: no additional outline style is applied by default.
-- disabled: native disabled input with disabled cursor/text treatment.
-
-## Behavior
-
-1. The root renders a full-width vertical stack.
-2. `label` renders above the input box with an `8px` gap.
-3. The input renders native attributes and event handlers.
-4. `rightIcon` and `rightElement` render on the right side without owning their meaning or behavior.
-5. The input uses `min-w-0` and `flex-1` so right-side content can coexist in narrow mobile widths.
+- rest는 placeholder, input은 실제 입력값으로 표현합니다. 별도 시각 상태 prop을 추가하지 않습니다.
+- label은 `htmlFor`와 `id`로 연결하며, 전달된 id를 우선합니다.
+- 박스 여백을 누르면 input에 focus합니다. 우측 slot 동작은 가로채지 않습니다.
+- disabled이면 native input을 비활성화하고 우측 action slot은 `inert` 처리합니다.
+- 키보드 focus는 박스 바깥쪽 `cool-gray-500` 2px outline, offset 2px로 표시합니다. Figma의 rest/input 외 접근성 보완입니다.
 
 ## Styling
 
-- root width: `100%`
-- label/input gap: `8px`
-- input box height: `45px`
-- input box padding-top / padding-bottom: `13px` (`py-3.25`)
-- input box padding-left: `15px`
-- input box padding-right: `15px` without right content, `9px` with right content
-- input box radius: `10px`
-- input box background: `primary-100`
-- label: `font-sans`, `typo-sub-header-2`, `black`
-- input text: `font-sans`, `typo-body-4`, `primary-200`
-- placeholder/hint: input typography와 동일한 `typo-body-4`, `warm-gray-300`
-- inner native input resets: `appearance-none`, `border-0`, `p-0`
-- input and right content minimum gap: `10px`
-- right icon and right element gap: `10px`
-- right action position in Figma examples: `right 9px`, vertically centered in the `45px` box
-- right icon visual box: `22px`
+| 항목               | 이전                   | 리디자인          |
+| ------------------ | ---------------------- | ----------------- |
+| 배경               | primary-100            | white             |
+| 테두리             | 없음                   | warm-gray-100 1px |
+| 높이 / radius      | 45px / 10px            | 유지              |
+| 입력값             | primary-200            | black             |
+| 글꼴 / placeholder | Body 4 / warm-gray-300 | 유지              |
+| 왼쪽 inset         | 15px                   | 테두리 포함 12px  |
 
-Figma selection width is `345px`, but the component uses `w-full` for mobile app layouts. Storybook examples wrap the component in a `345px` preview frame.
+- 너비는 `w-full`. Figma 예시 345px는 Storybook 프레임에만 사용합니다.
+- 세로 정렬은 flex center. Figma의 45px 높이와 19px 텍스트보다 큰 상하 16px padding을 함께 강제하지 않습니다.
+- border 1px + padding 11px로 왼쪽 inset 12px를 맞춥니다. 오른쪽은 긴 입력값이 테두리에 닿지 않도록 같은 inset을 유지합니다.
+- 우측 slot이 있으면 기존의 테두리 포함 오른쪽 inset 9px, slot gap 10px, icon 22px를 유지합니다.
+- label gap 8px와 Sub Header 2 typography를 유지합니다.
 
-## Accessibility
+## Storybook And Verification
 
-- `label` connects to the input through `htmlFor` and `id`.
-- If no `label` is provided, consumers provide `aria-label` or `aria-labelledby`.
-- `disabled` uses the native input `disabled` attribute.
-- `rightIcon` is rendered inside an `aria-hidden` wrapper.
-- `rightElement` accessibility is owned by the provided external element.
+Default, Filled, WithLabel, 우측 icon/action 조합, Disabled, DisabledWithAction, LongText로 확인합니다.
 
-## Storybook
-
-- [x] Default
-- [x] WithLabel
-- [x] WithRightElement
-- [x] WithRightIcon
-- [x] WithRightIconAndElement
-- [x] Disabled
-- [x] PhoneVerificationExample
-- [x] CodeVerificationExample
-
-## Verification
-
-- `corepack pnpm --filter @hashi/hds-ui lint`
-- `corepack pnpm --filter @hashi/hds-ui typecheck`
-- `corepack pnpm --filter @hashi/hds-ui build`
-- `corepack pnpm --filter @hashi/hds-ui test`
-- `corepack pnpm --filter @hashi/hds-ui build-storybook`
+- `pnpm --filter @hashi/hds-ui test`
+- `pnpm --filter @hashi/hds-ui lint`
+- `pnpm --filter @hashi/hds-ui typecheck`
+- `pnpm --filter @hashi/hds-ui build`
+- `pnpm build-storybook`
+- 브라우저에서 입력, focus, disabled action, 좁은 화면 overflow를 확인합니다.

--- a/packages/hds-ui/src/components/inputField/InputField.stories.tsx
+++ b/packages/hds-ui/src/components/inputField/InputField.stories.tsx
@@ -3,9 +3,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button } from '../button'
 import { InputField, type InputFieldProps } from './InputField'
 
-const inputFrameClassName = 'w-[345px] max-w-full'
+const inputFrameClassName = 'w-86.25 max-w-full'
 const actionButtonClassName =
-  'h-[33px] w-[86px] rounded-[5px] px-0 text-[12px] font-medium leading-none'
+  'h-8.25 w-21.5 rounded-[5px] px-0 text-[12px] font-medium leading-none'
 
 const renderActionButton = (children: string, disabled = false) => (
   <Button
@@ -19,8 +19,8 @@ const renderActionButton = (children: string, disabled = false) => (
 )
 
 const renderSuccessIcon = () => (
-  <span className="border-success text-success inline-flex size-[22px] items-center justify-center rounded-full border">
-    <CheckIcon className="size-[22px]" />
+  <span className="border-success text-success inline-flex size-5.5 items-center justify-center rounded-full border">
+    <CheckIcon className="size-5.5" />
   </span>
 )
 
@@ -137,4 +137,21 @@ export const CodeVerificationExample: Story = {
     rightIcon: renderSuccessIcon(),
     rightElement: renderActionButton('확인'),
   } satisfies InputFieldProps,
+}
+
+export const Filled: Story = {
+  args: { defaultValue: '텍스트' },
+}
+
+export const LongText: Story = {
+  args: {
+    label: '긴 입력값',
+    defaultValue:
+      '아주 긴 입력값도 입력 영역 안에서 스크롤할 수 있어야 합니다.'.repeat(4),
+    rightElement: renderActionButton('확인'),
+  },
+}
+
+export const DisabledWithAction: Story = {
+  args: { disabled: true, rightElement: renderActionButton('확인') },
 }

--- a/packages/hds-ui/src/components/inputField/InputField.test.tsx
+++ b/packages/hds-ui/src/components/inputField/InputField.test.tsx
@@ -83,25 +83,6 @@ describe('InputField', () => {
     expect(input).toHaveFocus()
   })
 
-  it('does not render a focus outline on the input box', () => {
-    render(<InputField aria-label="name" />)
-
-    const inputBox = screen.getByRole('textbox', { name: 'name' }).parentElement
-
-    expect(inputBox).not.toHaveClass('focus-within:outline-cool-gray-500')
-    expect(inputBox).not.toHaveClass('focus-within:outline-2')
-    expect(inputBox).not.toHaveClass('focus-within:outline-offset-0')
-  })
-
-  it('uses 13px vertical padding on the input box', () => {
-    render(<InputField aria-label="name" />)
-
-    const inputBox = screen.getByRole('textbox', { name: 'name' }).parentElement
-
-    expect(inputBox).toHaveClass('h-[45px]')
-    expect(inputBox).toHaveClass('py-3.25')
-  })
-
   it('resets native input spacing so the wrapper owns the inner padding', () => {
     render(<InputField aria-label="name" />)
 

--- a/packages/hds-ui/src/components/inputField/InputField.tsx
+++ b/packages/hds-ui/src/components/inputField/InputField.tsx
@@ -97,8 +97,9 @@ export const InputField = ({
       <div
         data-disabled={disabled || undefined}
         className={cn(
-          'bg-primary-100 flex h-[45px] w-full items-center rounded-[10px] py-3.25',
-          hasRightContent ? 'pr-[9px] pl-[15px]' : 'px-[15px]',
+          'border-warm-gray-100 flex h-11.25 w-full items-center rounded-[10px] border bg-white',
+          hasRightContent ? 'pr-2 pl-2.75' : 'px-2.75',
+          'has-[:focus-visible]:outline-cool-gray-500 has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2',
           'data-[disabled=true]:cursor-not-allowed',
           className,
         )}
@@ -114,7 +115,7 @@ export const InputField = ({
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
           disabled={disabled}
-          className="typo-body-4 text-primary-200 placeholder:text-warm-gray-300 disabled:text-warm-gray-300 min-w-0 flex-1 appearance-none border-0 bg-transparent p-0 font-sans outline-none disabled:cursor-not-allowed"
+          className="typo-body-4 placeholder:text-warm-gray-300 disabled:text-warm-gray-300 min-w-0 flex-1 appearance-none border-0 bg-transparent p-0 font-sans text-black outline-none disabled:cursor-not-allowed"
         />
 
         {hasRightContent ? (
@@ -125,7 +126,7 @@ export const InputField = ({
             {rightIcon ? (
               <span
                 aria-hidden="true"
-                className="inline-flex size-[22px] shrink-0 items-center justify-center"
+                className="inline-flex size-5.5 shrink-0 items-center justify-center"
               >
                 {rightIcon}
               </span>

--- a/packages/hds-ui/src/components/textarea/Textarea.spec.md
+++ b/packages/hds-ui/src/components/textarea/Textarea.spec.md
@@ -1,112 +1,70 @@
 # Component Spec: `Textarea`
 
-Jira: HASHI-63
+Jira: HASHI-176 (기존 HASHI-63 리디자인)
 
 ## Purpose
 
-`Textarea`는 여러 줄 텍스트 입력을 제공하는 HDS form primitive입니다.
+여러 줄 입력, 안내 문구, 글자 수 counter와 초과 상태를 표현하는 HDS primitive입니다. 제품 문구, 검증 정책, 제출 가능 여부, API는 호출부가 소유합니다.
 
-HDS는 textarea box, helper text, character counter, disabled state, className merge, native textarea attribute forwarding, baseline accessibility만 담당합니다. 리뷰, 식당, 후기, 문의, 신고, route, API, analytics, 제출 가능 여부, 제품별 검증 정책은 호출부가 처리합니다.
+## Figma References
 
-## Usage Location
-
-- `packages/hds-ui/src/components/textarea/Textarea.tsx`
-
-## Requirements
-
-- [x] 제품 도메인 copy나 검증 정책을 하드코딩하지 않습니다.
-- [x] native `textarea` props를 전달합니다.
-- [x] `placeholder`, `helperText`, `maxLength`, `disabled`, `className`, `textareaClassName`을 지원합니다.
-- [x] `maxLength`가 있으면 counter를 기본 표시합니다.
-- [x] counter는 `value`, `defaultValue`, 사용자 입력 이벤트를 기준으로 내부 계산합니다.
-- [x] `showCounter={false}`로 counter를 숨길 수 있습니다.
-- [x] HTML `maxLength` attribute로 입력 길이 제한을 위임합니다.
-- [x] 입력 이벤트나 controlled value가 `maxLength`를 초과해도 컴포넌트가 `maxLength`까지만 표시합니다.
-- [x] resize를 막습니다.
-- [x] error / invalid 상태와 minLength 검증은 1차 구현에서 제외합니다.
-
-## Figma Reference
-
-| Node         | Name                   | Size / Style                                                                           |
-| ------------ | ---------------------- | -------------------------------------------------------------------------------------- |
-| `1735:39329` | `input_textbox_review` | width `353px`, box min-height `230px`, padding `20px`, radius `10px`, helper gap `8px` |
-
-Figma의 `리뷰를 작성해 주세요.`, `10자 이상`, `0 / 1000` 문구는 HDS 내부에 하드코딩하지 않고 Storybook 예시에서만 사용합니다.
+- [Input textbox](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7869-36483&m=dev)
+- 기본 variant `7869:36505`, 입력 박스 `7869:36506`, 텍스트 `7869:36507`, 초과 문구 `7869:36516`, 초과 counter `7869:36518`
+- 2026-09-08 ego-browser의 Dev Mode 화면과 속성 패널에서 확인했습니다.
 
 ## Public API
 
 ```tsx
 <Textarea
-  placeholder="리뷰를 작성해 주세요."
-  helperText="10자 이상"
+  aria-label="내용"
   maxLength={1000}
+  maxLengthBehavior="allow"
+  errorMessage="글자 수 제한을 초과했어요."
 />
 ```
 
-Exported value:
+Export: `Textarea`, `TextareaProps`. 기존 export를 유지합니다.
 
-- `Textarea`
+- `maxLengthBehavior`: `'prevent' | 'allow'`, 기본 `'prevent'`.
+  - prevent: 기존대로 native maxLength, controlled/default value, 입력 이벤트를 제한합니다.
+  - allow: 내용을 자르지 않으며 native maxLength를 전달하지 않습니다. maxLength는 counter와 초과 여부 판단에 사용합니다.
+- `errorMessage`: invalid일 때 helperText 대신 표시하는 문구. 문구 자체는 호출부에서 전달합니다.
+- `helperText`: 기본 안내 문구. errorMessage가 없으면 invalid여도 유지합니다.
+- `showCounter`: 기본은 maxLength가 있을 때 true. false로 숨겨도 초과 상태 계산은 유지합니다.
+- `rows`: native rows, 기본 1. 여러 줄 표시가 필요한 호출부에서 지정할 수 있습니다.
+- `className`: root, `textareaClassName`: 실제 textarea에 병합합니다.
+- native textarea props, ref, value/defaultValue, disabled, aria 속성을 유지합니다.
 
-Exported type:
+## States And Behavior
 
-- `TextareaProps`
-
-## Props
-
-- `helperText`: `string`, optional helper text rendered below the textarea.
-- `showCounter`: `boolean`, optional. Defaults to `true` when `maxLength` exists.
-- `className`: `string`, optional wrapper className.
-- `textareaClassName`: `string`, optional inner textarea className.
-- native `textarea` props except `children` and inner textarea `className`.
-
-## States
-
-- default: editable textarea with placeholder, helper text, and optional counter.
-- focused: browser focus is visible with HDS token outline and border.
-- disabled: native disabled textarea with disabled visual treatment.
-- controlled: `value` drives the input and counter.
-- uncontrolled: `defaultValue` and user input drive the counter.
-
-## Behavior
-
-1. The root renders a fixed design-system width with `max-width: 100%`.
-2. The textarea renders native attributes and event handlers.
-3. `onChange` updates the internal counter and then calls the provided handler.
-4. When `value` changes in controlled usage, the rendered value and counter are limited to `maxLength`.
-5. `maxLength` is passed to the native textarea.
-6. If an input event produces a value longer than `maxLength`, the DOM value is trimmed to `maxLength` before the counter is updated.
+- default, focused, disabled, controlled/uncontrolled, over limit를 지원합니다.
+- counter는 실제 렌더링하는 값의 JavaScript 문자열 길이(UTF-16 code unit)를 계산합니다. 임의 counter prop은 없습니다.
+- count > maxLength일 때만 초과입니다. 경계값과 초과 후 삭제하여 복구하는 흐름을 지원합니다.
+- 초과하면 aria-invalid=true, 현재 글자 수와 안내 문구는 primary-400입니다. 최대 글자 수와 테두리는 기존 회색을 유지합니다.
+- 외부 aria-invalid를 보존하며 외부 invalid도 errorMessage를 표시합니다. 현재 글자 수의 빨간색은 길이 초과일 때만 적용합니다.
+- helper와 counter id는 외부 aria-describedby에 합쳐 연결하고 counter는 aria-live=polite를 유지합니다.
+- maxLengthBehavior=allow는 제출을 막지 않습니다. 폼 검증과 제출 차단은 호출부 책임입니다.
 
 ## Styling
 
-- root width: `353px`
-- root gap: `8px`
-- textarea min-height: `230px`
-- textarea padding: `20px`
-- border: `1px`, `warm-gray-100`
-- border radius: `10px`
-- input text: `font-sans`, `typo-body-4`, `primary-200`
-- input override: consumers can pass `textareaClassName` to extend or override inner textarea styles.
-- placeholder: `warm-gray-300`
-- helper/counter: `font-sans`, `typo-body-6`, `line-height: 1.36`
-- helper text: `warm-gray-300`
-- current count: `primary-200`
-- max count: `warm-gray-300`
+- root는 w-full. Figma 예시 너비 346px는 Storybook 프레임에만 적용합니다.
+- 이전 최소 높이 230px를 Figma의 min-height 56px로 변경하고 rows=1을 기본으로 합니다.
+- Figma의 20px inset에는 inside stroke가 포함됩니다. CSS border 1px + padding 19px로 맞추며, 19px 글꼴 환경에서 한 줄 박스는 59px입니다.
+- white 배경, warm-gray-100 1px border, radius 10px, Body 4, primary-200 본문, warm-gray-300 placeholder를 유지합니다.
+- 하단 간격 8px. helper는 Body 7, counter는 Body 6 / line-height 1.36, counter 내부 간격 2px.
+- 긴 안내 문구는 줄바꿈하고 counter 영역은 축소하지 않습니다.
+- focus-visible outline과 disabled 외형은 유지합니다.
+- 리뷰 입력 호출부는 min-height 230px를 명시해 기존 큰 입력 영역을 유지합니다. 예약 요청사항의 기존 140px override도 유지합니다.
+- Figma 초과 예시는 placeholder와 1200/1000을 함께 보이지만, 실제 컴포넌트와 story는 1200자의 실제 입력값과 일치하는 counter를 표시합니다.
 
-## Accessibility
+## Storybook And Verification
 
-- Consumers provide a visible label, `aria-label`, or `aria-labelledby`.
-- Counter uses `aria-live="polite"` when rendered.
-- Disabled state uses native `disabled`.
+Default, ReviewExample, Disabled, AllowOverLimit, OverLimit, LongHelperText를 제공합니다.
 
-## Storybook
-
-- [x] Default
-- [x] Review example
-- [x] Disabled
-
-## Verification
-
-- `corepack pnpm --filter @hashi/hds-ui lint`
-- `corepack pnpm --filter @hashi/hds-ui typecheck`
-- `corepack pnpm --filter @hashi/hds-ui build`
-- `corepack pnpm --filter @hashi/hds-ui test`
+- `pnpm --filter @hashi/hds-ui test`
+- `pnpm --filter @hashi/hds-ui lint`
+- `pnpm --filter @hashi/hds-ui typecheck`
+- `pnpm --filter @hashi/hds-ui build`
+- `pnpm build-storybook`
+- prevent 기존 계약, allow 입력/controlled/default 값, 경계값·초과·복구, error 접근성 연결을 자동 테스트합니다.
+- 브라우저에서 키보드 입력, 좁은 화면, focus, 초과/복구를 확인합니다.

--- a/packages/hds-ui/src/components/textarea/Textarea.stories.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.stories.tsx
@@ -1,18 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Textarea } from './Textarea'
 
-const meta = {
+const meta: Meta<typeof Textarea> = {
   title: 'Components/Textarea',
   component: Textarea,
   tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-86.5 max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
   args: {
+    'aria-label': '내용',
     placeholder: '내용을 입력해 주세요.',
-    helperText: '도움말을 입력할 수 있습니다.',
+    helperText: undefined,
     maxLength: 1000,
     disabled: false,
     showCounter: undefined,
   },
   argTypes: {
+    maxLengthBehavior: { control: 'select', options: ['prevent', 'allow'] },
+    errorMessage: { control: 'text' },
     placeholder: {
       control: 'text',
     },
@@ -38,7 +48,7 @@ const meta = {
       control: false,
     },
   },
-} satisfies Meta<typeof Textarea>
+}
 
 export default meta
 
@@ -49,6 +59,7 @@ export const Default: Story = {}
 export const ReviewExample: Story = {
   args: {
     placeholder: '리뷰를 작성해 주세요.',
+    textareaClassName: 'min-h-57.5',
     helperText: '10자 이상',
     maxLength: 1000,
   },
@@ -60,5 +71,30 @@ export const Disabled: Story = {
     helperText: '입력할 수 없습니다.',
     maxLength: 1000,
     disabled: true,
+  },
+}
+
+export const AllowOverLimit: Story = {
+  args: {
+    maxLength: 10,
+    maxLengthBehavior: 'allow',
+    errorMessage: '글자 수 제한을 초과했어요.',
+    placeholder: '10자를 넘게 입력해 보세요.',
+  },
+}
+
+export const OverLimit: Story = {
+  args: {
+    maxLength: 1000,
+    maxLengthBehavior: 'allow',
+    defaultValue: '가'.repeat(1200),
+    errorMessage: '글자 수 제한을 초과했어요.',
+  },
+}
+
+export const LongHelperText: Story = {
+  args: {
+    helperText:
+      '입력한 내용을 확인해주세요. 긴 안내 문구도 작은 화면에서 잘리지 않고 모두 읽을 수 있어야 합니다.',
   },
 }

--- a/packages/hds-ui/src/components/textarea/Textarea.test.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.test.tsx
@@ -7,6 +7,98 @@ afterEach(() => {
 })
 
 describe('Textarea', () => {
+  it('allows over-limit input without truncating the change event and clears the error on recovery', () => {
+    const handleChange = vi.fn()
+    render(
+      <Textarea
+        aria-label="memo"
+        maxLength={5}
+        maxLengthBehavior="allow"
+        helperText="안내"
+        errorMessage="글자 수 제한을 초과했어요."
+        onChange={(event) => handleChange(event.currentTarget.value)}
+      />,
+    )
+    const textarea = screen.getByRole('textbox', { name: 'memo' })
+    expect(textarea).not.toHaveAttribute('maxlength')
+    fireEvent.change(textarea, { target: { value: 'abcdef' } })
+    expect(textarea).toHaveValue('abcdef')
+    expect(handleChange).toHaveBeenLastCalledWith('abcdef')
+    expect(screen.getByText('6')).toBeTruthy()
+    expect(textarea).toHaveAttribute('aria-invalid', 'true')
+    expect(textarea).toHaveAccessibleDescription(
+      '글자 수 제한을 초과했어요. 6 /5',
+    )
+
+    fireEvent.change(textarea, { target: { value: 'abcde' } })
+    expect(textarea).not.toHaveAttribute('aria-invalid')
+    expect(screen.queryByText('글자 수 제한을 초과했어요.')).toBeNull()
+    expect(screen.getByText('안내')).toBeTruthy()
+    expect(screen.getByText('5')).toBeTruthy()
+  })
+
+  it('preserves controlled over-limit values and responds to limit changes', () => {
+    const { rerender } = render(
+      <Textarea
+        aria-label="memo"
+        value="abcdef"
+        maxLength={5}
+        maxLengthBehavior="allow"
+        readOnly
+      />,
+    )
+    const textarea = screen.getByRole('textbox', { name: 'memo' })
+    expect(textarea).toHaveValue('abcdef')
+    expect(textarea).toHaveAttribute('aria-invalid', 'true')
+    rerender(
+      <Textarea
+        aria-label="memo"
+        value="abcdef"
+        maxLength={6}
+        maxLengthBehavior="allow"
+        readOnly
+      />,
+    )
+    expect(textarea).toHaveValue('abcdef')
+    expect(textarea).not.toHaveAttribute('aria-invalid')
+  })
+
+  it('counts an over-limit defaultValue and preserves external invalid state', () => {
+    render(
+      <Textarea
+        aria-label="memo"
+        defaultValue="abcdef"
+        maxLength={5}
+        maxLengthBehavior="allow"
+        aria-invalid="true"
+        errorMessage="입력을 확인해주세요."
+      />,
+    )
+    const textarea = screen.getByRole('textbox', { name: 'memo' })
+    expect(textarea).toHaveValue('abcdef')
+    expect(screen.getByText('6')).toBeTruthy()
+    fireEvent.change(textarea, { target: { value: 'a' } })
+    expect(textarea).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('입력을 확인해주세요.')).toBeTruthy()
+  })
+
+  it('keeps hard limits as the default and passes the trimmed value to the caller', () => {
+    const handleChange = vi.fn()
+    render(
+      <Textarea
+        aria-label="memo"
+        maxLength={5}
+        defaultValue="abcdef"
+        onChange={(event) => handleChange(event.currentTarget.value)}
+      />,
+    )
+    const textarea = screen.getByRole('textbox', { name: 'memo' })
+    expect(textarea).toHaveValue('abcde')
+    expect(textarea).toHaveAttribute('maxlength', '5')
+    fireEvent.change(textarea, { target: { value: '123456' } })
+    expect(handleChange).toHaveBeenCalledWith('12345')
+  })
+
   it('renders placeholder and helper text', () => {
     render(
       <Textarea

--- a/packages/hds-ui/src/components/textarea/Textarea.tsx
+++ b/packages/hds-ui/src/components/textarea/Textarea.tsx
@@ -31,6 +31,8 @@ export interface TextareaProps extends Omit<
   'children' | 'className'
 > {
   helperText?: string
+  errorMessage?: string
+  maxLengthBehavior?: 'prevent' | 'allow'
   showCounter?: boolean
   className?: string
   textareaClassName?: string
@@ -38,6 +40,8 @@ export interface TextareaProps extends Omit<
 
 export const Textarea = ({
   helperText,
+  errorMessage,
+  maxLengthBehavior = 'prevent',
   showCounter,
   className,
   textareaClassName,
@@ -45,10 +49,12 @@ export const Textarea = ({
   defaultValue,
   maxLength,
   disabled = false,
+  rows = 1,
   onBeforeInput,
   onChange,
   id,
   'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
   ...props
 }: TextareaProps) => {
   const generatedId = useId()
@@ -57,15 +63,23 @@ export const Textarea = ({
   const counterId = `${textareaId}-counter`
 
   const isControlled = value !== undefined
-  const limitedValue = limitText(value, maxLength)
-  const limitedDefaultValue = limitText(defaultValue, maxLength)
+  const inputMaxLength = maxLengthBehavior === 'prevent' ? maxLength : undefined
+  const limitedValue = limitText(value, inputMaxLength)
+  const limitedDefaultValue = limitText(defaultValue, inputMaxLength)
   const [uncontrolledValue, setUncontrolledValue] = useState(
     () => limitedDefaultValue,
   )
   const currentValue = isControlled ? limitedValue : uncontrolledValue
   const count = getTextLength(currentValue)
   const shouldShowCounter = showCounter ?? maxLength !== undefined
-  const hasHelperText = helperText != null && helperText !== ''
+  const isOverLimit = maxLength !== undefined && count > maxLength
+  const isInvalid =
+    isOverLimit ||
+    (ariaInvalid !== undefined &&
+      ariaInvalid !== false &&
+      ariaInvalid !== 'false')
+  const supportText = isInvalid && errorMessage ? errorMessage : helperText
+  const hasHelperText = supportText != null && supportText !== ''
   const hasSupportRow = hasHelperText || shouldShowCounter
 
   const describedBy = [
@@ -79,7 +93,7 @@ export const Textarea = ({
   const handleBeforeInput = (event: ReactInputEvent<HTMLTextAreaElement>) => {
     onBeforeInput?.(event)
 
-    if (event.defaultPrevented || maxLength === undefined) {
+    if (event.defaultPrevented || inputMaxLength === undefined) {
       return
     }
 
@@ -89,7 +103,7 @@ export const Textarea = ({
 
     if (
       selectedLength === 0 &&
-      textarea.value.length >= maxLength &&
+      textarea.value.length >= inputMaxLength &&
       inputEvent.data
     ) {
       event.preventDefault()
@@ -98,9 +112,9 @@ export const Textarea = ({
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const nextValue =
-      maxLength === undefined
+      inputMaxLength === undefined
         ? event.currentTarget.value
-        : event.currentTarget.value.slice(0, maxLength)
+        : event.currentTarget.value.slice(0, inputMaxLength)
 
     if (event.currentTarget.value !== nextValue) {
       event.currentTarget.value = nextValue
@@ -120,12 +134,14 @@ export const Textarea = ({
         id={textareaId}
         aria-describedby={describedBy || undefined}
         value={isControlled ? limitedValue : uncontrolledValue}
-        maxLength={maxLength}
+        maxLength={inputMaxLength}
+        aria-invalid={isOverLimit ? true : ariaInvalid}
+        rows={rows}
         disabled={disabled}
         onBeforeInput={handleBeforeInput}
         onChange={handleChange}
         className={cn(
-          'border-warm-gray-100 min-h-[230px] w-full resize-none rounded-[10px] border bg-white p-5',
+          'border-warm-gray-100 min-h-14 w-full resize-none rounded-[10px] border bg-white p-4.75',
           'typo-body-4 text-primary-200 placeholder:text-warm-gray-300 font-sans',
           'focus-visible:border-cool-gray-500 focus-visible:outline-cool-gray-500 focus-visible:outline-2 focus-visible:outline-offset-0',
           'disabled:bg-secondary-200 disabled:text-warm-gray-300 disabled:cursor-not-allowed',
@@ -133,13 +149,16 @@ export const Textarea = ({
         )}
       />
       {hasSupportRow ? (
-        <div className="typo-body-6 flex w-full items-center justify-between gap-3 font-sans leading-[1.36] whitespace-nowrap">
+        <div className="typo-body-6 flex w-full items-start justify-between gap-3 font-sans leading-[1.36]">
           {hasHelperText ? (
             <p
               id={helperTextId}
-              className="text-warm-gray-300 min-w-0 truncate"
+              className={cn(
+                'typo-body-7 min-w-0 break-words',
+                isInvalid ? 'text-primary-400' : 'text-warm-gray-300',
+              )}
             >
-              {helperText}
+              {supportText}
             </p>
           ) : (
             <span aria-hidden="true" />
@@ -148,9 +167,15 @@ export const Textarea = ({
             <p
               id={counterId}
               aria-live="polite"
-              className="flex shrink-0 items-end gap-[2px]"
+              className="flex shrink-0 items-end gap-0.5"
             >
-              <span className="text-primary-200">{count}</span>
+              <span
+                className={
+                  isOverLimit ? 'text-primary-400' : 'text-primary-200'
+                }
+              >
+                {count}
+              </span>
               {maxLength !== undefined ? (
                 <span className="text-warm-gray-300">/{maxLength}</span>
               ) : null}


### PR DESCRIPTION
## 📌 요약

최신 Figma에 맞춰 InputField와 Textarea의 외형을 수정했습니다. Textarea에는 글자 수 초과 상태를 표현하는 옵션을 추가하고, 기존 입력 제한 동작은 기본값으로 유지했습니다.

Jira: HASHI-176

`develop` 대상의 독립 PR이며, Calendar 리디자인 PR #165와 의존 관계가 없습니다.

## 📚 작업 내용

### InputField 디자인 반영

- 배경을 `primary-100`에서 흰색으로 변경하고 `warm-gray-100` 1px 테두리 추가
- 입력값 색상을 검정으로 변경
- 왼쪽 여백을 테두리 포함 12px로 조정
- 높이 45px와 모서리 반경 10px 유지
- 키보드로 이동할 때 입력 영역을 식별할 수 있도록 포커스 테두리 추가

### Textarea 디자인 및 초과 상태 반영

- 기본 최소 높이를 230px에서 56px로 변경하고 `rows={1}` 적용
- 테두리를 포함한 내부 여백을 20px로 조정
- 긴 안내 문구가 잘리지 않도록 줄바꿈 처리하고 카운터 영역 유지
- `maxLengthBehavior` 옵션 추가: 기본은 초과 입력 차단, `allow` 지정 시 초과 입력 허용
- `errorMessage` 옵션 추가: 오류 상태에서 기본 안내 문구 대신 표시
- 글자 수 초과 시 안내 문구와 현재 글자 수를 빨간색으로 표시
- 오류 상태와 안내 문구를 `aria-invalid`, `aria-describedby`로 연결

### 기존 화면 및 문서 정리

- 리뷰 입력 화면에 최소 높이 230px를 명시해 기존 입력 영역 유지
- 컴포넌트·리뷰 입력 스펙 갱신
- 초과 입력·복구·긴 안내 문구 등 Storybook 예시와 테스트 보완

## 🔎 상세 설명

InputField의 기존 props와 우측 아이콘·액션 사용 방식은 유지했습니다.

Textarea는 아래처럼 호출부에서 선택한 경우에만 초과 입력을 허용합니다.

```tsx
<Textarea
  maxLength={1000}
  maxLengthBehavior="allow"
  errorMessage="글자 수 제한을 초과했어요."
/>
```

별도 설정이 없으면 기존처럼 `maxLength` 이후 입력을 막습니다. 기존 예약 요청사항과 리뷰 화면의 입력 제한 정책은 유지됩니다.

`allow`는 초과 상태를 표시하기 위한 옵션입니다. 오류 문구와 제출 가능 여부는 사용하는 화면에서 결정하며, Textarea가 제출을 차단하지는 않습니다.

디자인 기준: [Input line](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7869-36441&m=dev), [Input textbox](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7869-36483&m=dev)

## 💭 고민한 부분

### 피그마의 초과 상태를 어떻게 지원할지

피그마에는 `1200/1000`처럼 제한을 넘은 상태가 있지만, 기존 Textarea는 초과 입력을 막아 해당 상태를 표현할 수 없었습니다.

모든 호출부의 동작을 변경하는 대신 초과 허용 옵션을 추가했습니다. 빨간 안내와 카운터의 표현은 디자인을 따르고, 실제 화면에서 초과 입력을 허용할지는 호출부가 선택하도록 했습니다.

### 기본 높이를 바꾸면 기존 화면도 작아지는 문제

공통 Textarea에 있던 230px 최소 높이를 작은 입력 영역에도 일괄 적용하기 어려웠습니다. 기본 최소 높이는 피그마 기준으로 낮추고, 큰 영역이 필요한 리뷰 화면에서 230px를 지정했습니다.

최소 높이 56px는 고정 높이가 아닙니다. 현재 글꼴의 줄 높이와 여백을 합치면 한 줄 입력 박스는 59px로 렌더링됩니다.

### 화면 너비와 접근성

컴포넌트 너비는 부모 영역을 채우도록 유지했습니다. 긴 안내는 줄바꿈하고 카운터는 줄어들지 않도록 처리했습니다.

InputField의 키보드 포커스 표시는 피그마의 기본·입력 상태 외에 접근성을 보완한 부분입니다.

## ✅ 검증

- [x] `pnpm --filter @hashi/hds-ui test`: 19개 파일, 181개 테스트 통과
- [x] client에서 `pnpm exec vitest run src/features/review/components/inputReviewMain/InputReviewMain.test.tsx src/features/reservation/components/reservationRequestNoteField/ReservationRequestNoteField.test.tsx`: 2개 파일, 21개 테스트 통과
- [x] `pnpm --filter @hashi/hds-ui lint`
- [x] `pnpm --filter @hashi/hds-ui typecheck`
- [x] `pnpm --filter @hashi/client typecheck`
- [x] 변경된 10개 파일의 `pnpm exec prettier … --check`
- [x] `git diff --check`
- [x] 브라우저 검증(9/8): 초과 시 빨간 안내·카운터 표시, 삭제 시 정상 상태 복구
- [x] 브라우저 검증(9/8): Textarea 320·393·768px 너비에서 안내·카운터 잘림 및 가로 넘침 없음
- [x] 브라우저 검증(9/8): 비활성 상태에서 입력 차단

실제 예약 제출과 예약 페이지 전체의 반응형 검증은 포함하지 않았습니다.

## 👀 리뷰어에게

- 초과 입력 허용을 선택 옵션으로 제공하는 방식이 적절한지 확인 부탁드립니다.
- Textarea 기본 높이를 줄이고 필요한 화면에서 높이를 지정하는 방식도 함께 봐주시면 좋겠습니다.

## 📸 Storybook

- [InputField 기본 상태](https://6a39332c67b59aad1e4f42e8-ugvcuzplab.chromatic.com/?path=/story/components-inputfield--default)
- [Textarea 기본 상태](https://6a39332c67b59aad1e4f42e8-ugvcuzplab.chromatic.com/?path=/story/components-textarea--default)
- [초과 입력·복구 테스트](https://6a39332c67b59aad1e4f42e8-ugvcuzplab.chromatic.com/?path=/story/components-textarea--allow-over-limit)
- [1200/1000 초과 상태](https://6a39332c67b59aad1e4f42e8-ugvcuzplab.chromatic.com/?path=/story/components-textarea--over-limit)
- [긴 안내 문구](https://6a39332c67b59aad1e4f42e8-ugvcuzplab.chromatic.com/?path=/story/components-textarea--long-helper-text)
