### PR TITLE
Fix(hds-ui): HASHI-178 TimeSlotPicker 리디자인 반영

### DIFF
--- a/apps/client/src/features/reservation/components/reservationTimeSelector/ReservationTimeSelector.spec.md
+++ b/apps/client/src/features/reservation/components/reservationTimeSelector/ReservationTimeSelector.spec.md
@@ -1,0 +1,21 @@
+# Component Spec: `ReservationTimeSelector`
+
+## Purpose And Public API
+
+식당 예약과 어디든 예약에서 HDS `TimeSlotPicker`를 연결하는 앱 내부 adapter입니다. package public export는 없습니다.
+
+- `timeSlots`: 화면에서 생성한 시간 문자열 목록.
+- `selectedTime`: 현재 선택된 시간.
+- `disabled`: 날짜 선택 전 등 호출부 정책에 따른 전체 비활성 상태.
+- `onTimeSelect`: 선택한 문자열을 화면 상태로 반영하는 필수 callback.
+
+## Responsibility
+
+네 props를 `TimeSlotPicker`에 전달합니다. 시간 목록 생성, 날짜 변경 시 선택 초기화, 예약 가능 여부, submit 정책은 기존 page/hook에서 유지합니다.
+
+표시·선택·disabled·키보드 동작과 반응형 배치는 HDS가 담당합니다. 비활성 색상은 Figma 기준인 Warm_Gray_100 배경·White 글자로 변경됩니다.
+
+## Verification
+
+- `RestaurantReservationNewPage.test.tsx`, `AnywhereReservationPage.test.tsx`에서 실제 adapter와 HDS 조합을 검증합니다.
+- `useReservationFormControls.test.ts`에서 날짜 변경 후 시간 초기화와 비활성 규칙을 확인합니다.

--- a/apps/client/src/features/reservation/components/reservationTimeSelector/ReservationTimeSelector.tsx
+++ b/apps/client/src/features/reservation/components/reservationTimeSelector/ReservationTimeSelector.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/shared/utils'
+import { TimeSlotPicker } from '@hashi/hds-ui'
 
 interface ReservationTimeSelectorProps {
   timeSlots: readonly string[]
@@ -14,26 +14,11 @@ export const ReservationTimeSelector = ({
   onTimeSelect,
 }: ReservationTimeSelectorProps) => {
   return (
-    <div className="grid grid-cols-4 gap-[7px]" role="group" aria-label="시간">
-      {timeSlots.map((time) => {
-        const isSelected = selectedTime === time
-
-        return (
-          <button
-            aria-pressed={isSelected}
-            className={cn(
-              'typo-body-5 bg-secondary-200 text-primary-200 focus-visible:outline-cool-gray-900 disabled:text-warm-gray-300 flex h-9 min-w-0 items-center justify-center rounded-[5px] px-2 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed',
-              isSelected && 'bg-black text-white',
-            )}
-            disabled={disabled}
-            key={time}
-            onClick={() => onTimeSelect(time)}
-            type="button"
-          >
-            {time}
-          </button>
-        )
-      })}
-    </div>
+    <TimeSlotPicker
+      disabled={disabled}
+      onTimeSelect={onTimeSelect}
+      selectedTime={selectedTime}
+      timeSlots={timeSlots}
+    />
   )
 }

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -73,3 +73,6 @@ export type {
 } from './carousel'
 export { Calendar } from './calendar'
 export type { CalendarProps } from './calendar'
+
+export { TimeSlotPicker } from './timeSlotPicker'
+export type { TimeSlotPickerProps } from './timeSlotPicker'

--- a/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.spec.md
+++ b/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.spec.md
@@ -1,0 +1,74 @@
+# Component Spec: `TimeSlotPicker`
+
+## Purpose
+
+호출부가 전달한 시간 문자열을 4열 버튼 목록으로 표시하는 HDS primitive입니다. 기존 앱의 `ReservationTimeSelector`에서 표시와 선택 UI를 분리합니다.
+
+시간 목록 생성, 날짜·타임존 계산, 예약 가능 여부, API, 제품 문구, 제출은 호출부 책임입니다. 기존 예약 화면 두 곳이 같은 API로 사용합니다.
+
+## Figma Reference
+
+- [TimeSlotPicker](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7945-92731&m=dev)
+- 기본 variant: `7945:92838`, 버튼: `7945:92840`, 글꼴: `7945:92841`
+- 선택 variant: `7945:92792`, 선택 글꼴: `7945:92795`
+- 비활성 variant: `7945:92746`, 버튼: `7945:92748`
+- 2026-09-08 ego-browser에서 Dev Mode 화면과 속성 패널을 확인했습니다.
+
+## Public API
+
+```tsx
+<TimeSlotPicker
+  timeSlots={['11:00', '11:30', '12:00']}
+  selectedTime={selectedTime}
+  onTimeSelect={setSelectedTime}
+  disabled={disabled}
+/>
+```
+
+- Export: `TimeSlotPicker`, `TimeSlotPickerProps`.
+- `timeSlots`: 필수 `readonly string[]`. 표시값과 선택값이 같은 고유 문자열 목록이며, 전달받은 순서를 유지합니다. 시간 파싱·포맷·생성을 하지 않습니다.
+- `selectedTime`: 선택값. 내부 선택 상태를 만들지 않는 controlled 컴포넌트입니다.
+- `onTimeSelect`: 활성 버튼을 누르면 해당 문자열을 전달하는 선택적 callback입니다. 같은 버튼을 다시 눌러도 선택 해제를 자체 처리하지 않습니다.
+- `disabled`: 기본 false. 모든 시간 버튼을 native disabled로 처리합니다.
+- `className`: root에 병합합니다.
+- `children` 외 native div props를 지원하며 root role은 group입니다. 기본 accessible name은 `시간`이고 `aria-label` 또는 `aria-labelledby`로 지정할 수 있습니다.
+
+## States And Behavior
+
+- 기본 / 선택 / 전체 비활성 상태를 지원합니다. 개별 시간 비활성화와 다중 선택은 현재 범위에 포함하지 않습니다.
+- selectedTime과 같은 문자열의 버튼에 `aria-pressed=true`를 적용합니다. 목록 밖의 값이면 선택된 버튼이 없습니다.
+- disabled가 되어도 호출부의 선택값을 바꾸지 않습니다. 선택값이 있는 비활성 버튼도 회색 배경·흰 글씨로 표시합니다.
+- 버튼은 type=button이므로 폼을 제출하지 않습니다.
+- Tab으로 버튼 간 이동, Enter/Space로 선택하는 native button 동작과 focus-visible outline을 제공합니다. radio group의 방향키 동작은 도입하지 않습니다.
+- 빈 목록은 버튼과 안내 문구 없이 빈 group으로 표시합니다. empty 안내는 사용하는 화면에서 제공합니다.
+- 목록·선택값 변경은 그대로 렌더링하며 초기화 정책이나 callback을 자동 실행하지 않습니다.
+
+## Styling And Responsive Layout
+
+- 부모 너비를 채우는 4열 grid, 가로·세로 간격 7px.
+- 버튼 높이 36px, radius 5px, Body 5 (15px), 중앙 정렬.
+- 기본: Secondary_200 배경, Primary_200 글자.
+- 선택: Black 배경, White 글자.
+- 비활성: Warm_Gray_100 배경, White 글자. 기존 앱의 Secondary_200 배경·Warm_Gray_300 글자에서 변경합니다.
+- 포커스: Cool_Gray_900 2px outline, offset 2px. 기존 키보드 표시를 유지합니다.
+- Figma 예시 전체 너비 346px, 버튼 81px를 고정하지 않고 균등한 4열로 분배합니다. 346px에서는 (346 - 7×3) / 4 = 81.25px입니다.
+- Figma의 버튼 좌우 padding 18px는 좁은 화면에서 시간 문자열을 자를 수 있어 기존 8px 최소 여백과 중앙 정렬을 유지합니다. 일반 시간 문자열의 중심 위치는 같습니다.
+- 긴 문자열은 한 줄 말줄임 처리하며 접근성 이름은 전체 문자열을 유지합니다. 부분 행도 앞선 행과 같은 열 너비를 사용합니다.
+- 320px 화면 / 256px 콘텐츠 너비에서도 4열을 유지합니다. 최소 폭 이하에서 열 개수를 자동 변경하지 않습니다.
+
+## Storybook
+
+Default, Selected, Disabled, DisabledWithSelection, Interactive, NarrowContainer, LongText, PartialRow, Empty.
+
+Interactive와 NarrowContainer는 Storybook args를 선택 상태로 사용합니다. Controls의 selectedTime 변경·초기화와 미리보기의 시간 선택이 양방향으로 동기화됩니다.
+
+## Verification
+
+- 단위 테스트: 전달 순서·라벨, controlled 선택 및 목록 교체, 비활성 callback 차단, 폼 제출 방지, 외부 accessible name 및 빈 목록.
+- 앱 회귀 테스트: 식당 예약·어디든 예약 페이지의 날짜 선택 전 disabled, 날짜 변경 후 시간 초기화 및 시간 선택 흐름.
+- 브라우저 확인: 기본·선택·비활성 색상, 클릭과 키보드, 좁은 너비, 긴 문자열, 부분 행.
+- `pnpm --filter @hashi/hds-ui test`, `lint`, `typecheck`, `build`.
+- `pnpm --filter @hashi/client typecheck`, 관련 페이지 테스트.
+- `pnpm build-storybook`, `pnpm format:check`, `git diff --check`.
+
+2026-09-08 검증 결과: HDS 20개 파일/184개 테스트, 앱 예약 페이지·폼 hook 3개 파일/24개 테스트 통과. HDS 및 client lint, HDS/client/admin typecheck, HDS build, Storybook build, format check, harness check를 통과했습니다. 브라우저에서 320/393/768px 너비, 실제 클릭·Enter·Space 선택, disabled, 긴 문자열, 부분 행, 빈 목록을 확인했습니다. 실제 예약 API 및 예약 제출은 검증 범위에 포함하지 않습니다.

--- a/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.stories.tsx
+++ b/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.stories.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useArgs } from 'storybook/preview-api'
+
+import { TimeSlotPicker } from './TimeSlotPicker'
+import type { TimeSlotPickerProps } from './TimeSlotPicker'
+
+const TIME_SLOTS = [
+  '11:00',
+  '11:30',
+  '12:00',
+  '12:30',
+  '13:00',
+  '13:30',
+  '14:00',
+  '14:30',
+  '15:00',
+  '15:30',
+  '16:00',
+  '16:30',
+  '17:00',
+  '17:30',
+  '18:00',
+  '18:30',
+  '19:00',
+  '19:30',
+  '20:00',
+  '20:30',
+]
+
+const InteractivePicker = (args: TimeSlotPickerProps) => {
+  const [{ selectedTime }, updateArgs] = useArgs<TimeSlotPickerProps>()
+
+  const handleTimeSelect = (time: string) => {
+    updateArgs({ selectedTime: time })
+  }
+
+  return (
+    <TimeSlotPicker
+      {...args}
+      selectedTime={selectedTime}
+      onTimeSelect={handleTimeSelect}
+    />
+  )
+}
+
+const pickerDecorator = (Story: () => ReactNode) => (
+  <div className="w-full max-w-102.5 bg-white px-8 py-6">
+    <Story />
+  </div>
+)
+
+const meta = {
+  title: 'Components/TimeSlotPicker',
+  component: TimeSlotPicker,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  decorators: [pickerDecorator],
+  args: { timeSlots: TIME_SLOTS, disabled: false },
+  argTypes: {
+    timeSlots: { control: 'object' },
+    selectedTime: { control: 'select', options: [undefined, ...TIME_SLOTS] },
+    disabled: { control: 'boolean' },
+    onTimeSelect: { control: false },
+    className: { control: false },
+  },
+} satisfies Meta<typeof TimeSlotPicker>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const Selected: Story = { args: { selectedTime: '11:00' } }
+export const Disabled: Story = { args: { disabled: true } }
+export const DisabledWithSelection: Story = {
+  args: { disabled: true, selectedTime: '11:00' },
+}
+export const Interactive: Story = { render: InteractivePicker }
+export const NarrowContainer: Story = {
+  render: InteractivePicker,
+  decorators: [
+    (Story) => (
+      <div className="w-64 max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+}
+export const LongText: Story = {
+  args: {
+    timeSlots: ['오전 11시 30분 (현지 시각)', '12:00', '12:30', '13:00'],
+  },
+}
+export const PartialRow: Story = { args: { timeSlots: TIME_SLOTS.slice(0, 6) } }
+export const Empty: Story = { args: { timeSlots: [] } }

--- a/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.test.tsx
+++ b/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TimeSlotPicker } from './TimeSlotPicker'
+
+afterEach(cleanup)
+
+describe('TimeSlotPicker', () => {
+  it('renders supplied labels in order without generating or selecting times', () => {
+    render(<TimeSlotPicker timeSlots={['23:30', '00:00', '오전 9:00']} />)
+
+    expect(screen.getByRole('group', { name: '시간' })).toBeTruthy()
+    expect(
+      screen.getAllByRole('button').map((button) => button.textContent),
+    ).toEqual(['23:30', '00:00', '오전 9:00'])
+    expect(screen.queryByRole('button', { pressed: true })).toBeNull()
+  })
+
+  it('reports the clicked value and leaves selection under caller control', () => {
+    const onTimeSelect = vi.fn()
+    const { rerender } = render(
+      <TimeSlotPicker
+        timeSlots={['11:00', '11:30']}
+        selectedTime="11:00"
+        onTimeSelect={onTimeSelect}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '11:30' }))
+
+    expect(onTimeSelect).toHaveBeenCalledExactlyOnceWith('11:30')
+    expect(
+      screen.getByRole('button', { name: '11:00', pressed: true }),
+    ).toBeTruthy()
+
+    rerender(
+      <TimeSlotPicker
+        timeSlots={['11:00', '11:30']}
+        selectedTime="11:30"
+        onTimeSelect={onTimeSelect}
+      />,
+    )
+    expect(
+      screen.getByRole('button', { name: '11:30', pressed: true }),
+    ).toBeTruthy()
+
+    rerender(
+      <TimeSlotPicker timeSlots={['12:00']} onTimeSelect={onTimeSelect} />,
+    )
+    expect(screen.queryByRole('button', { pressed: true })).toBeNull()
+    expect(screen.queryByRole('button', { name: '11:30' })).toBeNull()
+  })
+
+  it('disables every button and does not report a selection', () => {
+    const onTimeSelect = vi.fn()
+    render(
+      <TimeSlotPicker
+        disabled
+        timeSlots={['11:00', '11:30']}
+        selectedTime="11:00"
+        onTimeSelect={onTimeSelect}
+      />,
+    )
+
+    screen.getAllByRole('button').forEach((button) => {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+      fireEvent.click(button)
+    })
+    expect(onTimeSelect).not.toHaveBeenCalled()
+  })
+
+  it('does not submit a containing form when choosing a time', () => {
+    const onSubmit = vi.fn((event: { preventDefault: () => void }) =>
+      event.preventDefault(),
+    )
+    render(
+      <form onSubmit={onSubmit}>
+        <TimeSlotPicker timeSlots={['11:00']} />
+      </form>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '11:00' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('supports an external group label and an empty list without product copy', () => {
+    render(
+      <>
+        <h2 id="time-heading">출발 시각</h2>
+        <TimeSlotPicker aria-labelledby="time-heading" timeSlots={[]} />
+      </>,
+    )
+
+    expect(screen.getByRole('group', { name: '출발 시각' }).textContent).toBe(
+      '',
+    )
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.tsx
+++ b/packages/hds-ui/src/components/timeSlotPicker/TimeSlotPicker.tsx
@@ -1,0 +1,52 @@
+import type { ComponentPropsWithoutRef } from 'react'
+
+import { cn } from '../../utils'
+
+export interface TimeSlotPickerProps extends Omit<
+  ComponentPropsWithoutRef<'div'>,
+  'children'
+> {
+  timeSlots: readonly string[]
+  selectedTime?: string
+  disabled?: boolean
+  onTimeSelect?: (time: string) => void
+}
+
+export const TimeSlotPicker = ({
+  timeSlots,
+  selectedTime,
+  disabled = false,
+  onTimeSelect,
+  className,
+  'aria-label': ariaLabel = '시간',
+  ...props
+}: TimeSlotPickerProps) => {
+  return (
+    <div
+      {...props}
+      role="group"
+      aria-label={ariaLabel}
+      className={cn('grid w-full grid-cols-4 gap-1.75 font-sans', className)}
+    >
+      {timeSlots.map((time) => {
+        const isSelected = selectedTime === time
+
+        return (
+          <button
+            key={time}
+            type="button"
+            aria-pressed={isSelected}
+            disabled={disabled}
+            onClick={() => onTimeSelect?.(time)}
+            className={cn(
+              'typo-body-5 bg-secondary-200 text-primary-200 focus-visible:outline-cool-gray-900 disabled:bg-warm-gray-100 flex h-9 min-w-0 cursor-pointer appearance-none items-center justify-center rounded-[5px] border-0 px-2 text-center focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:text-white',
+              isSelected && !disabled && 'bg-black text-white',
+            )}
+          >
+            <span className="min-w-0 truncate">{time}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/hds-ui/src/components/timeSlotPicker/index.ts
+++ b/packages/hds-ui/src/components/timeSlotPicker/index.ts
@@ -1,0 +1,2 @@
+export { TimeSlotPicker } from './TimeSlotPicker'
+export type { TimeSlotPickerProps } from './TimeSlotPicker'


### PR DESCRIPTION
## 📌 요약

예약 화면의 시간 선택 UI를 HDS `TimeSlotPicker`로 분리하고 최신 Figma의 비활성 스타일을 반영했습니다.

Jira: [HASHI-178](https://siksa.atlassian.net/browse/HASHI-178)

`develop`을 대상으로 하는 독립 PR입니다. Calendar·Input 리디자인 PR에 의존하지 않습니다.

## 📚 작업 내용

- `TimeSlotPicker` 컴포넌트와 public export 추가
- 식당 예약·어디든 예약의 `ReservationTimeSelector`에 연결
- 기본·선택·전체 비활성 상태와 긴 문구 말줄임 처리
- Storybook 9개 시나리오와 단위 테스트 5개 추가
- Interactive·NarrowContainer의 선택값을 `useArgs`로 관리해 Controls와 미리보기 양방향 동기화
- HDS 컴포넌트와 앱 adapter의 spec 작성

## 🔎 상세 설명

`timeSlots`, `selectedTime`, `disabled`, `onTimeSelect`를 통해 표시와 선택을 처리합니다. 내부 선택 상태를 만들지 않으며, 시간 생성·날짜 변경 시 초기화·예약 가능 여부는 기존 앱에서 관리합니다.

[TimeSlotPicker Figma](https://www.figma.com/design/UHaom01PvoRx2wRCYa1kS1/Hashi.kr?node-id=7945-92731&m=dev)의 기본·선택·비활성 상태를 반영했습니다. 기존 기본/선택 색상은 유지하고, 비활성 상태를 Warm Gray 100 배경·흰색 글자로 변경했습니다.

native button의 `type="button"`, `disabled`, `aria-pressed`와 포커스 표시를 사용합니다. 시간 선택으로 폼을 제출하지 않으며, 빈 목록의 안내 문구는 호출부 책임으로 남깁니다.

## 💭 고민한 부분

Figma 예시의 전체 너비 346px와 버튼 너비 81px를 고정하면 사용하는 화면의 너비에 대응하기 어렵습니다. 높이 36px·간격 7px은 유지하고, 부모 너비에 맞춰 4열을 균등하게 분배했습니다.

버튼 좌우 여백은 Figma의 18px 대신 기존 8px을 유지했습니다. 좁은 화면에서도 일반 시간 문자열을 표시하고, 긴 문자열은 한 줄 말줄임 처리합니다. 해당 차이는 spec에 기록했습니다.

## ✅ 검증

- [x] HDS 전체 테스트 184개 통과 — 9월 9일, Storybook 동기화 수정 전
- [x] TimeSlotPicker 테스트 5개와 예약 페이지·폼 hook 테스트 24개 통과 — 9월 9일 코드 리뷰
- [x] HDS lint 및 HDS·client typecheck 통과
- [x] Storybook 동기화 수정 후 HDS typecheck, story lint·포맷 검사, `pnpm build-storybook` 통과
- [x] `git diff --check`
- [x] 브라우저에서 클릭·재선택·Tab/Enter/Space·비활성·빈 목록·긴 문구·부분 행 확인
- [x] 실제 예약 화면 2곳에서 날짜→시간 선택, 다음 버튼 활성화, 날짜 변경 시 초기화 확인
- [x] 320·393·768px에서 4열 배치와 가로 넘침 없음 확인
- [x] Storybook Controls→미리보기, 미리보기→Controls, Reset 동기화 확인 — Interactive·NarrowContainer 각각 검증

실제 예약 화면은 개발용 토큰으로 검증했습니다. 예약 제출과 카카오 로그인 자체는 검증 범위에 포함하지 않았습니다. Storybook build의 기존 chunk 크기 경고는 남아 있습니다.

## 👀 리뷰어에게

- 앱의 예약 정책과 HDS의 표시·선택 책임이 적절하게 나뉘었는지 확인 부탁드립니다.
- 비활성 색상과 좁은 화면 배치는 DisabledWithSelection·NarrowContainer에서 확인할 수 있습니다.

## 📸 Storybook

[Chromatic 배포 진행 및 결과](https://github.com/TEAM-HASHI/HASHI-CLIENT/actions/runs/34350983079)에서 확인할 수 있습니다.
