### PR TITLE
Fix(hds-ui): HASHI-174 Checkbox 리디자인 반영

### DIFF
--- a/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
@@ -82,7 +82,8 @@ Exported types:
 ## Styling
 
 - box size: `26px * 26px`
-- icon size: `10px * 9.5px`
+- icon canvas size: `26px * 26px`
+- check vector size: SVG viewBox 내부 기준 약 `10px * 9.5px`
 - radius: `3px`
 - rest background: `bg-cool-gray-100`
 - hover background: `group-hover:bg-cool-gray-200`
@@ -92,7 +93,7 @@ Exported types:
 - disabled: `cursor-not-allowed`
 - focus-visible: native input focus를 `peer-focus-visible` outline으로 visual box에 표시합니다.
 
-Figma Dev Mode의 `2.6rem` 값은 사용하지 않고 px 기준 `h-[26px] w-[26px]`를 사용합니다. `CheckIcon`은 `@hashi/hds-icons`에서 import하고, Figma의 check vector 크기에 맞춰 `h-[9.5px] w-[10px]`로 렌더링합니다.
+Figma Dev Mode의 `2.6rem` 값은 사용하지 않고 px 기준 `h-[26px] w-[26px]`를 사용합니다. `CheckIcon`은 `@hashi/hds-icons`에서 import합니다. `CheckIcon`의 SVG viewBox가 `0 0 26 26`이고 path 자체가 Figma의 check vector 크기를 가지므로, SVG 전체를 `26px * 26px`로 렌더링해 내부 check path가 의도한 크기로 보이게 합니다.
 
 ## Accessibility
 

--- a/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.spec.md
@@ -1,6 +1,6 @@
 # Component Spec: `Checkbox`
 
-Jira: HASHI-53
+Jira: HASHI-174
 
 ## Purpose
 
@@ -16,6 +16,7 @@ HDS가 담당하는 것:
 - native input ref 전달
 - checkbox icon의 시각 구조
 - checked 상태에 따른 CheckIcon 색상 표현
+- enabled 상태의 hover / pressed 배경 feedback
 - disabled 상태의 기본 interaction 차단
 - label 클릭과 keyboard interaction을 포함한 기본 접근성 계약
 
@@ -69,24 +70,29 @@ Exported types:
 
 ## States
 
-- unchecked: Cool_Gray_100 배경과 흰색 CheckIcon을 표시합니다.
-- checked: Cool_Gray_100 배경과 Cool_Gray_800 CheckIcon을 표시합니다.
-- disabled: native input disabled 상태를 사용하고 `cursor-not-allowed`만 적용합니다.
+- unchecked: 흰색 CheckIcon을 표시합니다.
+- checked: Cool_Gray_900 CheckIcon을 표시합니다.
+- rest: Cool_Gray_100 배경을 표시합니다.
+- hover: enabled 상태에서 Cool_Gray_200 배경을 표시합니다.
+- pressed: enabled 상태에서 Cool_Gray_300 배경을 표시합니다.
+- disabled: native input disabled 상태를 사용하고 `cursor-not-allowed`만 적용합니다. 리디자인에 별도 disabled visual variant가 없으므로 hover / pressed 배경 feedback은 적용하지 않습니다.
 - controlled: 호출부가 `checked`와 `onChange`로 상태를 관리합니다.
 - uncontrolled: native input이 `defaultChecked` 기반으로 상태를 관리합니다.
 
 ## Styling
 
 - box size: `26px * 26px`
-- icon size: `26px * 26px`
+- icon size: `10px * 9.5px`
 - radius: `3px`
-- background: `bg-cool-gray-100`
+- rest background: `bg-cool-gray-100`
+- hover background: `group-hover:bg-cool-gray-200`
+- pressed background: `group-active:bg-cool-gray-300`
 - unchecked icon color: `text-white`
-- checked icon color: `peer-checked:text-cool-gray-800`
+- checked icon color: `peer-checked:text-cool-gray-900`
 - disabled: `cursor-not-allowed`
 - focus-visible: native input focus를 `peer-focus-visible` outline으로 visual box에 표시합니다.
 
-Figma Dev Mode의 `2.6rem` 값은 사용하지 않고 px 기준 `h-[26px] w-[26px]`를 사용합니다. `CheckIcon`은 `@hashi/hds-icons`에서 import하고, SVG viewBox가 26x26이므로 `h-[26px] w-[26px]`로 렌더링합니다.
+Figma Dev Mode의 `2.6rem` 값은 사용하지 않고 px 기준 `h-[26px] w-[26px]`를 사용합니다. `CheckIcon`은 `@hashi/hds-icons`에서 import하고, Figma의 check vector 크기에 맞춰 `h-[9.5px] w-[10px]`로 렌더링합니다.
 
 ## Accessibility
 
@@ -119,6 +125,8 @@ Controls:
 - [x] native checkbox input ref 전달
 - [x] click 시 checked 상태 토글
 - [x] disabled 상태에서 click 시 checked 상태 유지
+- [x] enabled 상태에서 rest / hover / pressed visual class 적용
+- [x] disabled 상태에서 hover / pressed visual class 미적용
 - [x] CheckIcon `aria-hidden` 처리
 
 ## Verification

--- a/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
@@ -67,6 +67,32 @@ describe('Checkbox', () => {
     expect(handleChange).not.toHaveBeenCalled()
   })
 
+  it('applies redesigned visual states when enabled', () => {
+    const { container } = render(<Checkbox>Checkbox</Checkbox>)
+    const icon = container.querySelector('svg')
+    const visualBox = icon?.parentElement
+
+    expect(visualBox).toHaveClass(
+      'bg-cool-gray-100',
+      'group-hover:bg-cool-gray-200',
+      'group-active:bg-cool-gray-300',
+      'peer-checked:text-cool-gray-900',
+    )
+    expect(icon).toHaveClass('h-[9.5px]', 'w-[10px]')
+  })
+
+  it('keeps disabled checkbox from applying hover and pressed visuals', () => {
+    const { container } = render(<Checkbox disabled>Checkbox</Checkbox>)
+    const icon = container.querySelector('svg')
+    const visualBox = icon?.parentElement
+
+    expect(visualBox).toHaveClass('bg-cool-gray-100')
+    expect(visualBox).not.toHaveClass(
+      'group-hover:bg-cool-gray-200',
+      'group-active:bg-cool-gray-300',
+    )
+  })
+
   it('hides CheckIcon from assistive technologies', () => {
     const { container } = render(<Checkbox>Checkbox</Checkbox>)
     const icon = container.querySelector('svg')

--- a/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.test.tsx
@@ -78,7 +78,7 @@ describe('Checkbox', () => {
       'group-active:bg-cool-gray-300',
       'peer-checked:text-cool-gray-900',
     )
-    expect(icon).toHaveClass('h-[9.5px]', 'w-[10px]')
+    expect(icon).toHaveClass('h-[26px]', 'w-[26px]')
   })
 
   it('keeps disabled checkbox from applying hover and pressed visuals', () => {

--- a/packages/hds-ui/src/components/checkbox/Checkbox.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.tsx
@@ -28,10 +28,16 @@ export const Checkbox = ({
         disabled={disabled}
         {...props}
       />
-      <span className="bg-cool-gray-100 peer-focus-visible:outline-cool-gray-800 peer-checked:text-cool-gray-800 flex h-[26px] w-[26px] items-center justify-center rounded-[3px] text-white peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2">
+      <span
+        className={cn(
+          'bg-cool-gray-100 peer-focus-visible:outline-cool-gray-900 peer-checked:text-cool-gray-900 flex h-[26px] w-[26px] items-center justify-center rounded-[3px] text-white transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2',
+          !disabled &&
+            'group-hover:bg-cool-gray-200 group-active:bg-cool-gray-300',
+        )}
+      >
         <CheckIcon
           aria-hidden="true"
-          className="h-[26px] w-[26px]"
+          className="h-[9.5px] w-[10px]"
           focusable="false"
         />
       </span>

--- a/packages/hds-ui/src/components/checkbox/Checkbox.tsx
+++ b/packages/hds-ui/src/components/checkbox/Checkbox.tsx
@@ -37,7 +37,7 @@ export const Checkbox = ({
       >
         <CheckIcon
           aria-hidden="true"
-          className="h-[9.5px] w-[10px]"
+          className="h-[26px] w-[26px]"
           focusable="false"
         />
       </span>


### PR DESCRIPTION
## 📌 요약

최신 Figma에 맞춰 HDS `Checkbox`의 rest / hover / pressed / selected 상태 스타일을 수정했습니다.

Jira: [HASHI-174](https://siksa.atlassian.net/browse/HASHI-174)

## 📚 작업 내용

- Checkbox box 크기와 radius를 Figma 기준으로 유지
- rest / hover / pressed 상태의 배경색 반영
- selected 상태의 CheckIcon 색상을 Cool_Gray_900으로 변경
- CheckIcon 크기를 Figma 기준인 10px * 9.5px로 조정
- disabled 상태에서는 hover / pressed feedback이 적용되지 않도록 처리
- Checkbox spec과 단위 테스트를 리디자인 기준에 맞게 갱신

## 🔎 상세 설명

기존 Checkbox는 배경색이 항상 Cool_Gray_100으로 고정되어 있고, checked 여부에 따라 CheckIcon 색상만 변경되는 구조였습니다.

이번 작업에서는 Figma의 `status: rest / hover / pressed`, `selected: true / false` 조합을 기준으로 enabled 상태의 interaction feedback을 추가했습니다.

| 상태 | 적용 내용 |
| --- | --- |
| rest | Cool_Gray_100 배경 |
| hover | Cool_Gray_200 배경 |
| pressed | Cool_Gray_300 배경 |
| selected=false | 흰색 CheckIcon |
| selected=true | Cool_Gray_900 CheckIcon |

disabled variant는 Figma에 별도로 정의되어 있지 않아 임의의 disabled visual style은 추가하지 않았습니다. 기존처럼 native disabled로 interaction을 막고, disabled 상태에서는 hover / pressed 배경 feedback이 적용되지 않도록 했습니다.

## 💭 고민한 부분

### 고민한 문제

Figma에는 rest / hover / pressed / selected 상태가 정의되어 있었지만, disabled visual variant는 따로 확인되지 않았습니다.

### 고려한 선택지

- Figma에 없는 disabled 색상이나 opacity를 임의로 추가
- disabled는 기존처럼 기능적으로만 유지하고, enabled 상태의 visual feedback만 반영

### 최종 선택과 이유

디자인시스템 컴포넌트에서 Figma에 없는 시각 상태를 임의로 만들면 기준이 흔들릴 수 있다고 판단했습니다.

따라서 disabled는 native disabled 동작과 cursor만 유지하고, hover / pressed feedback은 enabled 상태에서만 적용되도록 했습니다.

### 남은 고민

추후 Figma에 disabled variant가 추가되면 Checkbox disabled visual spec을 별도로 확장할 수 있습니다.

## ✅ 검증

- [x] `pnpm --filter @hashi/hds-ui exec vitest run src/components/checkbox/Checkbox.test.tsx`
- [x] `pnpm --filter @hashi/hds-ui lint`
- [x] `pnpm --filter @hashi/hds-ui typecheck`
- [x] `pnpm --filter @hashi/hds-ui build-storybook`
- [x] `git diff --check`

## 👀 리뷰어에게

- Figma에 없는 disabled visual을 임의로 추가하지 않고 기존 native disabled 정책을 유지한 판단이 적절한지 확인 부탁드립니다.
- enabled 상태의 hover / pressed feedback과 selected 색상 기준이 디자인 의도와 맞는지 봐주시면 좋겠습니다.

## 📸 Storybook

- [Checkbox Docs](https://6a39332c67b59aad1e4f42e8-cjbfpnpzuh.chromatic.com/?path=/docs/components-checkbox--docs)
- [Checkbox Default](https://6a39332c67b59aad1e4f42e8-cjbfpnpzuh.chromatic.com/?path=/story/components-checkbox--default)
- [Checkbox Checked](https://6a39332c67b59aad1e4f42e8-cjbfpnpzuh.chromatic.com/?path=/story/components-checkbox--checked)
- [Checkbox Disabled](https://6a39332c67b59aad1e4f42e8-cjbfpnpzuh.chromatic.com/?path=/story/components-checkbox--disabled)
- [Checkbox Disabled Checked](https://6a39332c67b59aad1e4f42e8-cjbfpnpzuh.chromatic.com/?path=/story/components-checkbox--disabled-checked)

hover / pressed 상태는 enabled Checkbox에서 직접 interaction으로 확인부탁드리옵니다!