### PR TITLE
Chore(root): HASHI-179 자동 리뷰어 할당 및 승인 기준 1명으로 변경

### DIFF
--- a/.agents/recipes/jira-branch-pr.md
+++ b/.agents/recipes/jira-branch-pr.md
@@ -32,11 +32,11 @@ type(scope): HASHI-00 작업 내용
 
 5. PR은 `develop`을 대상으로 생성하고 `.github/pull_request_template.md`를 채웁니다.
 6. PR 본문에는 Jira key, 작업 내용, 설계 판단, 테스트 또는 수동 확인 결과를 포함합니다.
-7. `apps/client/**` PR은 `docs/workflows/code-review.md`에 따라 자동 요청된 리뷰어 2명을 확인합니다. 개인 일정이나 변경 영역의 전문성 때문에 조정이 필요하면 reviewer를 수동으로 변경하거나 추가합니다.
+7. `apps/client/**` PR은 `docs/workflows/code-review.md`에 따라 자동 요청된 리뷰어 1명을 확인합니다. 개인 일정이나 변경 영역의 전문성 때문에 조정이 필요하면 reviewer를 수동으로 변경하거나 추가합니다.
 
 ## Done Criteria
 
 - 브랜치명, 커밋 메시지, PR 본문에 같은 Jira key가 사용됩니다.
 - PR 대상 브랜치는 `develop`입니다.
 - unrelated 변경이 섞이지 않습니다.
-- 필요한 테스트·수동 확인 근거와 리뷰어 2명 지정이 PR에 반영됩니다.
+- 필요한 테스트·수동 확인 근거와 리뷰어 1명 지정이 PR에 반영됩니다.

--- a/.github/reviewer-assignment.json
+++ b/.github/reviewer-assignment.json
@@ -1,6 +1,6 @@
 {
   "lookbackDays": 30,
-  "requiredReviewerCount": 2,
+  "requiredReviewerCount": 1,
   "reviewers": [
     {
       "enabled": true,

--- a/.github/scripts/assign-reviewers.cjs
+++ b/.github/scripts/assign-reviewers.cjs
@@ -14,12 +14,11 @@ const readReviewerConfig = (configPath = DEFAULT_CONFIG_PATH) => {
 }
 
 const validateReviewerConfig = (config) => {
-  if (!Number.isInteger(config.requiredReviewerCount)) {
-    throw new Error('requiredReviewerCount must be an integer.')
-  }
-
-  if (config.requiredReviewerCount !== 2) {
-    throw new Error('requiredReviewerCount must be 2.')
+  if (
+    !Number.isInteger(config.requiredReviewerCount) ||
+    config.requiredReviewerCount <= 0
+  ) {
+    throw new Error('requiredReviewerCount must be a positive integer.')
   }
 
   if (!Number.isInteger(config.lookbackDays) || config.lookbackDays <= 0) {
@@ -61,7 +60,7 @@ const validateReviewerConfig = (config) => {
 
   if (enabledReviewers.length < config.requiredReviewerCount + 1) {
     throw new Error(
-      'At least 3 enabled reviewers are required to assign 2 reviewers while excluding the PR author.',
+      `At least ${config.requiredReviewerCount + 1} enabled reviewers are required to assign ${config.requiredReviewerCount} reviewer${config.requiredReviewerCount === 1 ? '' : 's'} while excluding the PR author.`,
     )
   }
 }

--- a/.github/scripts/assign-reviewers.test.cjs
+++ b/.github/scripts/assign-reviewers.test.cjs
@@ -16,7 +16,7 @@ const {
 
 const createConfig = () => ({
   lookbackDays: 30,
-  requiredReviewerCount: 2,
+  requiredReviewerCount: 1,
   reviewers: [
     { enabled: true, login: 'jyeon03', weight: 1 },
     { enabled: true, login: 'chungyo', weight: 1 },
@@ -25,14 +25,28 @@ const createConfig = () => ({
   ],
 })
 
-test('validateReviewerConfig requires exactly 2 reviewers', () => {
+test('validateReviewerConfig requires at least 1 reviewer', () => {
   const config = createConfig()
 
   assert.doesNotThrow(() => validateReviewerConfig(config))
 
   assert.throws(
-    () => validateReviewerConfig({ ...config, requiredReviewerCount: 3 }),
-    /requiredReviewerCount must be 2/,
+    () => validateReviewerConfig({ ...config, requiredReviewerCount: 0 }),
+    /requiredReviewerCount must be a positive integer/,
+  )
+})
+
+test('validateReviewerConfig keeps enough enabled reviewers after excluding the author', () => {
+  const config = createConfig()
+
+  config.reviewers = [
+    { enabled: true, login: 'jyeon03', weight: 1 },
+    { enabled: false, login: 'chungyo', weight: 1 },
+  ]
+
+  assert.throws(
+    () => validateReviewerConfig(config),
+    /At least 2 enabled reviewers are required to assign 1 reviewer while excluding the PR author/,
   )
 })
 
@@ -128,7 +142,7 @@ test('collectReviewStats counts only reviews submitted within the lookback windo
   assert.equal(reviewStats.has('external-reviewer'), false)
 })
 
-test('selectReviewers excludes the PR author and always returns 2 reviewers', () => {
+test('selectReviewers excludes the PR author and returns the configured number of reviewers', () => {
   const config = createConfig()
   const reviewStats = createInitialReviewStats(config.reviewers)
 
@@ -139,7 +153,7 @@ test('selectReviewers excludes the PR author and always returns 2 reviewers', ()
     reviewStats,
   })
 
-  assert.equal(reviewers.length, 2)
+  assert.equal(reviewers.length, 1)
   assert.ok(!reviewers.includes('jyeon03'))
 })
 
@@ -159,7 +173,7 @@ test('selectReviewers prefers reviewers with fewer recent reviews and assignment
     reviewStats,
   })
 
-  assert.deepEqual(new Set(reviewers), new Set(['chungyo', 'gyeongbibin']))
+  assert.deepEqual(reviewers, ['chungyo'])
 })
 
 test('selectReviewers ignores disabled reviewers', () => {
@@ -177,7 +191,7 @@ test('selectReviewers ignores disabled reviewers', () => {
     reviewStats,
   })
 
-  assert.equal(reviewers.length, 2)
+  assert.equal(reviewers.length, 1)
   assert.ok(!reviewers.includes('yurimidaH'))
 })
 

--- a/docs/conventions/git.md
+++ b/docs/conventions/git.md
@@ -8,7 +8,7 @@ HASHI Client는 Jira로 작업을 관리하고 GitHub로 코드 리뷰와 병합
 2. Jira 티켓 번호를 기준으로 브랜치를 생성합니다.
 3. 작업 브랜치에서 개발합니다.
 4. 작업이 끝나면 `develop` 브랜치로 PR을 생성합니다.
-5. 최소 2명 이상의 approve를 받은 뒤 merge합니다.
+5. 최소 1명 이상의 approve를 받은 뒤 merge합니다.
 6. merge된 브랜치는 삭제합니다.
 
 ## 역할 분리
@@ -150,7 +150,7 @@ Refactor(auth): 인증 로직 분리
 Style(input): Input 컴포넌트 스타일 수정
 ```
 
-PR 본문은 `.github/pull_request_template.md`를 기준으로 작성하고, 관련 Jira 티켓 번호를 명시합니다. `apps/client/**` PR은 `docs/workflows/testing.md`의 테스트 근거와 `docs/workflows/code-review.md`의 리뷰어 2명 지정 기준을 함께 따릅니다.
+PR 본문은 `.github/pull_request_template.md`를 기준으로 작성하고, 관련 Jira 티켓 번호를 명시합니다. `apps/client/**` PR은 `docs/workflows/testing.md`의 테스트 근거와 `docs/workflows/code-review.md`의 리뷰어 1명 지정 기준을 함께 따릅니다.
 
 ```markdown
 ## 📌 요약

--- a/docs/workflows/code-review.md
+++ b/docs/workflows/code-review.md
@@ -10,8 +10,8 @@
 
 ## Reviewers
 
-- 모든 client PR에는 작성자를 제외한 리뷰어 2명을 지정합니다.
-- 기본 승인 기준은 2명 이상의 approve입니다. 추가 전문 리뷰가 필요하면 리뷰어를 더 지정할 수 있습니다.
+- 모든 client PR에는 작성자를 제외한 리뷰어 1명을 지정합니다.
+- 기본 승인 기준은 1명 이상의 approve입니다. 추가 전문 리뷰가 필요하면 리뷰어를 더 지정할 수 있습니다.
 - 리뷰어는 단순 approve를 위한 역할이 아니라, 구현 의도·상태·구조를 이해하고 피드백하는 책임을 가집니다.
 - 작성자는 PR의 `상세 설명`, `고민한 부분`, `리뷰어에게`를 통해 리뷰 시작에 필요한 맥락을 제공합니다.
 
@@ -23,7 +23,7 @@
 2. 최근 30일 동안 GitHub API가 반환한 reviewer 요청과 제출 review를 집계합니다.
 3. `(요청 횟수 + review 횟수) / weight`가 낮은 후보를 우선합니다.
 4. 점수가 같으면 PR 번호와 GitHub login을 사용한 결정적 순서로 정렬합니다.
-5. 정렬 결과에서 2명을 선택해 reviewer로 요청합니다.
+5. 정렬 결과에서 1명을 선택해 reviewer로 요청합니다.
 
 reviewer roster, 조회 기간, 배정 인원, 활성화 여부, 가중치는 `.github/reviewer-assignment.json`에서 관리합니다.
 
@@ -59,7 +59,7 @@ P1은 merge를 막는 blocking issue입니다. P2부터 P5는 우선순위만으
 
 ## Automation Scope
 
-`.github/workflows/auto-assign-author.yml`은 PR 작성자를 assignee로 등록하고, `.github/workflows/auto-assign-reviewers.yml`은 draft가 아닌 PR에 리뷰어 2명을 자동 요청합니다.
+`.github/workflows/auto-assign-author.yml`은 PR 작성자를 assignee로 등록하고, `.github/workflows/auto-assign-reviewers.yml`은 draft가 아닌 PR에 리뷰어 1명을 자동 요청합니다.
 
 - reviewer 자동 요청은 PR이 `opened`, `ready_for_review`, `reopened` 상태가 될 때 실행합니다.
 - 연속 배정 회피, 개인 일정, 변경 영역별 전문성은 자동으로 판단하지 않습니다.

--- a/docs/workflows/pr-checklist.md
+++ b/docs/workflows/pr-checklist.md
@@ -14,7 +14,7 @@ PR을 열기 전 변경 범위, Jira 연결, 검증 결과를 명확히 남깁�
 - 구현 기준 spec이 필요한 작업이면 [Spec Writing](./spec-writing.md)에 따라 `*.spec.md`를 작성하거나 갱신합니다.
 - `apps/client/**` 코드 변경은 [Client Testing Policy](./testing.md)에 따라 `Test Required`와 `Test Optional`을 구분합니다. `Test Required`는 자동 테스트를 준비하고, 테스트를 생략할 때는 생략 사유와 수동 확인 근거를 함께 준비합니다.
 - 문서 영향이 있는 변경이면 `README.md`, `AGENTS.md`, `docs/` 문서 갱신 여부를 확인합니다.
-- `apps/client/**` PR은 [Client Code Review Policy](./code-review.md)에 따라 작성자를 제외한 리뷰어 2명을 지정합니다.
+- `apps/client/**` PR은 [Client Code Review Policy](./code-review.md)에 따라 작성자를 제외한 리뷰어 1명을 지정합니다.
 
 ## PR Body
 
@@ -176,7 +176,7 @@ UI 변경:
 
 ## Before Merge
 
-- 최소 2명 이상의 approve를 받습니다.
-- `apps/client/**` PR은 [Client Code Review Policy](./code-review.md)에 따라 지정된 2명의 리뷰어가 리뷰했는지 확인합니다.
+- 최소 1명 이상의 approve를 받습니다.
+- `apps/client/**` PR은 [Client Code Review Policy](./code-review.md)에 따라 지정된 리뷰어 1명이 리뷰했는지 확인합니다.
 - 필요한 경우 Jira 상태가 `QA` 또는 `CODE REVIEW`에 있는지 확인합니다.
 - PR 병합 후 브랜치를 삭제합니다.


### PR DESCRIPTION
📌 요약
> 팀원의 리뷰 부담을 조정하기 위해 자동 리뷰어 할당 인원과 기본 승인 기준을 2명에서 1명으로 변경했습니다.

Jira: HASHI-179

📚 작업 내용
- 자동 리뷰어 할당 인원을 1명으로 변경
- 리뷰어 수 검증 로직에서 2명 하드코딩 제거
- 작성자를 제외하고 설정된 인원만큼 할당할 수 있는지 동적으로 검증
- 자동 리뷰어 할당 테스트를 1명 기준으로 수정
- 코드리뷰 및 PR 운영 문서를 1명 기준으로 통일