### PR TITLE
Feat(hds-ui): HASHI-186 Accordion 컴포넌트 구현

### DIFF
--- a/packages/hds-ui/src/components/accordion/Accordion.spec.md
+++ b/packages/hds-ui/src/components/accordion/Accordion.spec.md
@@ -1,0 +1,167 @@
+# Component Spec: `Accordion`
+
+Jira: HASHI-186
+
+## Purpose
+
+`Accordion`은 HASHI Design System의 접힘/펼침 UI primitive입니다.
+
+약관, 안내 문구처럼 제목을 먼저 보여주고 사용자가 필요한 경우 상세 내용을 펼쳐 확인하는 흐름을 제공합니다.
+
+## HDS Responsibilities
+
+HDS가 담당하는 것:
+
+- collapsed / expanded 상태 전환
+- title 영역과 content 영역의 시각 구조
+- expanded 여부에 따른 title typography 변경
+- content를 `children`으로 자유롭게 렌더링
+- controlled / uncontrolled 상태 제어
+- keyboard interaction과 focus-visible outline을 포함한 기본 접근성 계약
+
+HDS가 담당하지 않는 것:
+
+- 약관 title/content 데이터 생성
+- 서버 응답 fetch
+- 약관 동의 여부 validation
+- form submit
+- route 이동
+- API 호출
+- analytics
+
+## Public API
+
+```tsx
+<Accordion title={term.title}>{term.content}</Accordion>
+
+<Accordion
+  title={term.title}
+  expanded={expanded}
+  onExpandedChange={setExpanded}
+>
+  {term.content}
+</Accordion>
+```
+
+Exported value:
+
+- `Accordion`
+
+Exported types:
+
+- `AccordionProps`
+
+## Props
+
+### `title`
+
+- type: `ReactNode`
+- required: `true`
+- description: accordion header에 렌더링할 title입니다. 서버에서 받은 약관 제목도 prop으로 전달할 수 있습니다.
+
+### `children`
+
+- type: `ReactNode`
+- required: `true`
+- description: expanded 상태에서 렌더링할 content입니다. 서버에서 받은 약관 내용이나 호출부가 조합한 ReactNode를 전달합니다.
+
+### `defaultExpanded`
+
+- type: `boolean`
+- required: `false`
+- default: `false`
+- description: uncontrolled 사용 시 초기 expanded 상태입니다.
+
+### `expanded`
+
+- type: `boolean`
+- required: `false`
+- description: controlled 사용 시 현재 expanded 상태입니다.
+
+### `onExpandedChange`
+
+- type: `(expanded: boolean) => void`
+- required: `false`
+- description: trigger 클릭으로 다음 expanded 상태가 요청될 때 호출됩니다.
+
+### `className`
+
+- type: `string`
+- required: `false`
+- description: root element에 병합할 class입니다.
+
+### `contentClassName`
+
+- type: `string`
+- required: `false`
+- description: content element에 병합할 class입니다.
+
+## States
+
+- collapsed: content를 렌더링하지 않고 title을 `typo-body-5`로 표시합니다.
+- expanded: content를 렌더링하고 title을 `typo-sub-header-3`로 표시합니다.
+- controlled: 호출부가 `expanded`와 `onExpandedChange`로 상태를 관리합니다.
+- uncontrolled: 컴포넌트가 `defaultExpanded` 기반으로 내부 상태를 관리합니다.
+
+hover, pressed, disabled, loading 상태는 현재 Figma에 정의되어 있지 않아 v1에 포함하지 않습니다.
+
+## Styling
+
+- root width: `w-full`
+- root padding: horizontal `20px`, vertical `8px`
+- root border: `border-b`, `secondary-200`
+- expanded gap: `4px`
+- header min-height: `32px`
+- title color: `black`
+- collapsed title typography: `typo-body-5`
+- expanded title typography: `typo-sub-header-3`
+- title overflow: 줄바꿈 허용
+- icon size: `20px * 20px`
+- icon color: `cool-gray-900`
+- content typography: `typo-caption-2`
+- content line-height: `1.5`
+- content color: `warm-gray-300`
+- focus-visible: HDS button 계열과 동일하게 `cool-gray-900` outline을 표시합니다.
+
+Figma의 component width `393px`는 예시 viewport 기준이므로 컴포넌트에서는 부모 너비를 따르는 `w-full`을 사용합니다.
+
+## Accessibility
+
+- header는 `button type="button"`으로 렌더링합니다.
+- expanded 상태를 `aria-expanded`로 전달합니다.
+- trigger와 content는 `aria-controls` / `id`로 연결합니다.
+- icon은 장식 요소이므로 `aria-hidden="true"`와 `focusable="false"`를 적용합니다.
+- keyboard interaction은 native button 동작을 따릅니다.
+
+## Storybook
+
+- [x] Collapsed
+- [x] Expanded
+- [x] LongTitle
+- [x] Controlled
+
+Controls:
+
+- `title`
+- `children`
+- `defaultExpanded`
+- `expanded`
+
+Storybook의 약관 문구는 UI 확인용 예시이며, 실제 서비스 데이터는 호출부에서 서버 응답을 전달합니다.
+
+## Test
+
+- [x] title button 렌더링
+- [x] collapsed 기본 상태에서 content 미렌더링
+- [x] `defaultExpanded` 상태에서 content 렌더링
+- [x] trigger click 시 expanded 상태 전환
+- [x] controlled mode에서 `onExpandedChange` 호출
+- [x] state별 typography/color token 적용
+
+## Verification
+
+- [ ] `pnpm --filter @hashi/hds-ui lint`
+- [ ] `pnpm --filter @hashi/hds-ui typecheck`
+- [ ] `pnpm --filter @hashi/hds-ui build-storybook`
+- [ ] `pnpm --filter @hashi/hds-ui test`
+- [ ] `git diff --check`

--- a/packages/hds-ui/src/components/accordion/Accordion.stories.tsx
+++ b/packages/hds-ui/src/components/accordion/Accordion.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { Accordion } from './Accordion'
+
+const termsContent =
+  '본 동의서는 Hashi가 이용자의 식당 예약을 진행하기 위해 개인정보를 예약 대상 식당에 제공하는 것에 관한 내용을 안내하는 것을 목적으로 합니다.'
+
+const meta: Meta<typeof Accordion> = {
+  title: 'Components/Accordion',
+  component: Accordion,
+  tags: ['autodocs'],
+  args: {
+    title: '제1조 (목적)',
+    children: termsContent,
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    children: {
+      control: 'text',
+    },
+    defaultExpanded: {
+      control: 'boolean',
+    },
+    expanded: {
+      control: 'boolean',
+    },
+    onExpandedChange: {
+      action: 'expanded changed',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[393px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Collapsed: Story = {}
+
+export const Expanded: Story = {
+  args: {
+    defaultExpanded: true,
+  },
+}
+
+export const LongTitle: Story = {
+  args: {
+    title:
+      '제1조 (목적) 개인정보 제공 동의 및 식당 예약 진행을 위한 긴 약관 제목',
+  },
+}
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+      <Accordion {...args} expanded={expanded} onExpandedChange={setExpanded} />
+    )
+  },
+}

--- a/packages/hds-ui/src/components/accordion/Accordion.test.tsx
+++ b/packages/hds-ui/src/components/accordion/Accordion.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Accordion } from './Accordion'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Accordion', () => {
+  it('renders the title as a full-width toggle button', () => {
+    render(<Accordion title="제1조 (목적)">약관 내용</Accordion>)
+
+    const trigger = screen.getByRole('button', { name: '제1조 (목적)' })
+
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger.parentElement).toHaveClass('w-full')
+  })
+
+  it('does not render content while collapsed by default', () => {
+    render(<Accordion title="제1조 (목적)">약관 내용</Accordion>)
+
+    expect(screen.queryByText('약관 내용')).not.toBeInTheDocument()
+  })
+
+  it('renders content when expanded by default', () => {
+    render(
+      <Accordion title="제1조 (목적)" defaultExpanded>
+        약관 내용
+      </Accordion>,
+    )
+
+    expect(screen.getByText('약관 내용')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: '제1조 (목적)' }),
+    ).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('toggles expanded state when the trigger is clicked', () => {
+    render(<Accordion title="제1조 (목적)">약관 내용</Accordion>)
+
+    fireEvent.click(screen.getByRole('button', { name: '제1조 (목적)' }))
+
+    expect(screen.getByText('약관 내용')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: '제1조 (목적)' }),
+    ).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('calls onExpandedChange without changing content in controlled mode', () => {
+    const handleExpandedChange = vi.fn()
+
+    render(
+      <Accordion
+        title="제1조 (목적)"
+        expanded={false}
+        onExpandedChange={handleExpandedChange}
+      >
+        약관 내용
+      </Accordion>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '제1조 (목적)' }))
+
+    expect(handleExpandedChange).toHaveBeenCalledTimes(1)
+    expect(handleExpandedChange).toHaveBeenCalledWith(true)
+    expect(screen.queryByText('약관 내용')).not.toBeInTheDocument()
+  })
+
+  it('applies Figma typography and color tokens by state', () => {
+    const { rerender } = render(
+      <Accordion title="제1조 (목적)">약관 내용</Accordion>,
+    )
+
+    expect(screen.getByText('제1조 (목적)')).toHaveClass(
+      'typo-body-5',
+      'text-black',
+    )
+
+    rerender(
+      <Accordion title="제1조 (목적)" expanded>
+        약관 내용
+      </Accordion>,
+    )
+
+    expect(screen.getByText('제1조 (목적)')).toHaveClass(
+      'typo-sub-header-3',
+      'text-black',
+    )
+    expect(screen.getByText('약관 내용')).toHaveClass(
+      'typo-caption-2',
+      'text-warm-gray-300',
+      'leading-[1.5]',
+    )
+  })
+})

--- a/packages/hds-ui/src/components/accordion/Accordion.tsx
+++ b/packages/hds-ui/src/components/accordion/Accordion.tsx
@@ -1,0 +1,91 @@
+import type { ComponentPropsWithRef, ReactNode } from 'react'
+import { useId, useState } from 'react'
+import { TapDownIcon, TapUpIcon } from '@hashi/hds-icons'
+import { cn } from '../../utils'
+
+export type AccordionProps = Omit<
+  ComponentPropsWithRef<'div'>,
+  'children' | 'title'
+> & {
+  title: ReactNode
+  children: ReactNode
+  defaultExpanded?: boolean
+  expanded?: boolean
+  onExpandedChange?: (expanded: boolean) => void
+  contentClassName?: string
+}
+
+export const Accordion = ({
+  title,
+  children,
+  defaultExpanded = false,
+  expanded,
+  onExpandedChange,
+  className,
+  contentClassName,
+  ref,
+  ...props
+}: AccordionProps) => {
+  const contentId = useId()
+  const [uncontrolledExpanded, setUncontrolledExpanded] =
+    useState(defaultExpanded)
+  const isControlled = expanded !== undefined
+  const isExpanded = isControlled ? expanded : uncontrolledExpanded
+  const ToggleIcon = isExpanded ? TapUpIcon : TapDownIcon
+
+  const handleToggle = () => {
+    const nextExpanded = !isExpanded
+
+    if (!isControlled) {
+      setUncontrolledExpanded(nextExpanded)
+    }
+
+    onExpandedChange?.(nextExpanded)
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'border-secondary-200 flex w-full flex-col items-center border-b px-5 py-2',
+        isExpanded && 'gap-1',
+        className,
+      )}
+      {...props}
+    >
+      <button
+        type="button"
+        aria-controls={contentId}
+        aria-expanded={isExpanded}
+        className="focus-visible:outline-cool-gray-900 flex min-h-8 w-full appearance-none items-center justify-between gap-3 border-0 bg-transparent p-0 text-left font-sans focus-visible:outline-2 focus-visible:outline-offset-2"
+        onClick={handleToggle}
+      >
+        <span
+          className={cn(
+            'min-w-0 flex-1 break-words text-black',
+            isExpanded ? 'typo-sub-header-3' : 'typo-body-5',
+          )}
+        >
+          {title}
+        </span>
+        <ToggleIcon
+          aria-hidden="true"
+          className="text-cool-gray-900 size-5 shrink-0"
+          focusable="false"
+        />
+      </button>
+
+      {isExpanded ? (
+        <div
+          id={contentId}
+          className={cn(
+            'typo-caption-2 text-warm-gray-300 w-full leading-[1.5]',
+            contentClassName,
+          )}
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/hds-ui/src/components/accordion/index.ts
+++ b/packages/hds-ui/src/components/accordion/index.ts
@@ -1,0 +1,2 @@
+export { Accordion } from './Accordion'
+export type { AccordionProps } from './Accordion'

--- a/packages/hds-ui/src/components/index.ts
+++ b/packages/hds-ui/src/components/index.ts
@@ -1,5 +1,7 @@
 export { Avatar } from './avatar'
 export type { AvatarProps, AvatarSize } from './avatar'
+export { Accordion } from './accordion'
+export type { AccordionProps } from './accordion'
 export { Button } from './button'
 export type {
   ButtonProps,


### PR DESCRIPTION
## 📌 요약

Accordion 공통 컴포넌트를 신규 구현했습니다.

- collapsed / expanded 상태를 지원합니다.
- 부모 너비를 기준으로 `width: 100%`로 렌더링됩니다.
- content 영역은 `children`으로 자유롭게 받을 수 있도록 구성했습니다.
- 서버에서 내려오는 title/content를 그대로 주입할 수 있도록 하드코딩 없이 구현했습니다.
- controlled / uncontrolled 사용 방식을 모두 지원합니다.
- Storybook과 spec 문서를 함께 추가했습니다.

Jira: HASHI-186

## 📚 작업 내용

- Accordion 컴포넌트 신규 추가
- collapsed / expanded 상태별 title typography 반영
  - collapsed: `body 5`
  - expanded: `sub header 3`
- content typography 반영
  - `caption 2`
  - `warm-gray-300`
- 접힘 상태에서는 content DOM을 렌더링하지 않도록 처리
- 긴 title은 말줄임 없이 줄바꿈되도록 처리
- focus-visible 스타일은 기존 HDS 컴포넌트 규칙을 따르도록 적용
- Storybook 문서 및 상태별 스토리 추가
- spec 문서 추가
- 테스트 추가

## 고민한 부분

### Content 영역과 아이콘 영역 분리 여부

Figma metadata 기준으로 Accordion의 header와 content body는 동일하게 내부 너비 353px을 사용하고 있었습니다.
따라서 content가 아이콘 영역을 피하도록 별도 right padding을 주기보다는, 부모 padding 안에서 `w-full`을 사용하는 방식으로 구현했습니다.

Storybook에서는 브라우저의 실제 텍스트 렌더링/줄바꿈 조건에 따라 피그마 예시와 줄바꿈 위치가 달라 보일 수 있지만, 컴포넌트 자체는 서버에서 내려오는 children을 자유롭게 렌더링해야 하므로 줄바꿈이나 문구를 컴포넌트 내부에서 하드코딩하지 않았습니다.

### controlled API 지원 여부

초기 상태만 지정하는 `defaultExpanded`뿐 아니라, 사용하는 쪽에서 열림 상태를 직접 제어할 수 있도록 `expanded`, `onExpandedChange`도 함께 지원했습니다.

약관처럼 서버 데이터 기반으로 여러 Accordion을 렌더링하거나, 특정 조건에서 외부 상태로 펼침 여부를 제어해야 하는 경우를 고려했습니다.

## 리뷰어에게 요청하는 포인트

- Figma 기준으로 header/content width를 동일하게 가져간 판단이 적절한지 확인 부탁드립니다.
- content를 icon 영역만큼 임의로 줄이지 않고 `children`을 자유롭게 렌더링하도록 둔 방향이 공통 컴포넌트 책임에 맞는지 확인 부탁드립니다.
- controlled / uncontrolled API를 함께 지원하는 방식이 HDS 공통 컴포넌트 사용성 관점에서 괜찮은지 확인 부탁드립니다.
- focus-visible 스타일이 기존 HDS 컴포넌트 규칙과 어긋나지 않는지 확인 부탁드립니다.
- - 또한, 디자이너분께서 요청하신 텍스트 스타일 변경사항도 반영하였으니 확인 부탁드립니다!

## ✅ 확인 사항

- [x] lint 통과
- [x] typecheck 통과
- [x] test 통과
- [x] build-storybook 통과

## 📸 Storybook

- [Accordion Docs](https://6a39332c67b59aad1e4f42e8-afovhwqzmb.chromatic.com/?path=/docs/components-accordion--docs)