### PR TITLE
Fix(client): HASHI-192 Review Input 이미지 첨부 영역 리디자인

### DIFF
--- a/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.spec.md
+++ b/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.spec.md
@@ -50,7 +50,7 @@
 - [x] file input은 `accept="image/jpeg,image/png,image/webp"`와 `multiple`을 가집니다.
 - [x] file input이 변경되면 JPEG, PNG, WEBP이면서 장당 5MB 이하인 파일만 기존 `photoFiles` 뒤에 이어 `onPhotoFilesChange`에 전달합니다.
 - [x] 지원하지 않는 MIME 타입은 `photoFiles`에 추가하지 않고 `JPG, PNG, WEBP 형식의 사진만 첨부할 수 있어요.`를 표시합니다.
-- [x] 장당 5MB를 초과한 파일은 `photoFiles`에 추가하지 않고 `사진은 장당 5MB 이하로 첨부해주세요.`를 표시합니다.
+- [x] 장당 5MB를 초과한 파일은 `photoFiles`에 추가하지 않고 `용량이 초과되었어요.`를 표시합니다.
 - [x] 선택된 사진이 10장이 되면 사진 추가 버튼과 숨겨진 file input을 비활성화합니다.
 - [x] 남은 사진 슬롯보다 많은 파일을 선택하면 최대 10장까지만 `photoFiles`에 추가하고 `사진은 최대 10장까지 첨부할 수 있어요.`를 표시합니다.
 - [x] 선택된 `photoFiles`가 있으면 사진 추가 버튼과 선택된 이미지 미리보기를 가로 스크롤 목록으로 표시합니다.
@@ -152,7 +152,7 @@ InputReviewMain
 2. 사용자가 사진 첨부 트리거를 누르면 숨겨진 file input click을 실행합니다.
 3. 사용자가 파일을 선택하면 JPEG, PNG, WEBP이면서 5MB 이하인 파일 중 남은 사진 슬롯 수만큼만 `onPhotoFilesChange?.([...photoFiles, ...nextFiles])`로 전달합니다.
 4. 지원하지 않는 MIME 타입이 있으면 해당 파일은 거절하고 `JPG, PNG, WEBP 형식의 사진만 첨부할 수 있어요.`를 표시합니다.
-5. 5MB를 초과한 파일이 있으면 해당 파일은 거절하고 `사진은 장당 5MB 이하로 첨부해주세요.`를 표시합니다.
+5. 5MB를 초과한 파일이 있으면 해당 파일은 거절하고 `용량이 초과되었어요.`를 표시합니다.
 6. 남은 사진 슬롯보다 많은 파일을 선택하면 초과 파일은 거절하고 `사진은 최대 10장까지 첨부할 수 있어요.`를 표시합니다.
 7. 선택된 사진이 10장이면 사진 추가 버튼과 file input은 비활성화됩니다.
 8. 선택된 `photoFiles`가 있으면 사진 추가 버튼과 이미지 미리보기를 `overflow-x-auto` 가로 스크롤 목록으로 표시합니다.

--- a/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.test.tsx
+++ b/apps/client/src/features/review/components/inputReviewMain/InputReviewMain.test.tsx
@@ -136,9 +136,10 @@ describe('InputReviewMain', () => {
 
     expect(handlePhotoFilesChange).toHaveBeenCalledTimes(1)
     expect(handlePhotoFilesChange).toHaveBeenCalledWith([validImageFile])
-    expect(
-      screen.getByText('사진은 장당 5MB 이하로 첨부해주세요.'),
-    ).toHaveClass('text-primary-400')
+    expect(screen.getByText('용량이 초과되었어요.')).toHaveClass(
+      'typo-body-7',
+      'text-primary-400',
+    )
   })
 
   it('rejects unsupported photo MIME types and keeps supported files', () => {
@@ -160,7 +161,7 @@ describe('InputReviewMain', () => {
     expect(handlePhotoFilesChange).toHaveBeenCalledWith([supportedImageFile])
     expect(
       screen.getByText('JPG, PNG, WEBP 형식의 사진만 첨부할 수 있어요.'),
-    ).toHaveClass('text-primary-400')
+    ).toHaveClass('typo-body-7', 'text-primary-400')
   })
 
   it('appends newly selected photo files to existing photo files', () => {
@@ -218,7 +219,7 @@ describe('InputReviewMain', () => {
     ])
     expect(
       screen.getByText('사진은 최대 10장까지 첨부할 수 있어요.'),
-    ).toHaveClass('text-primary-400')
+    ).toHaveClass('typo-body-7', 'text-primary-400')
   })
 
   it('clears the max count error when a selected photo is removed', () => {
@@ -277,6 +278,12 @@ describe('InputReviewMain', () => {
 
     render(<InputReviewMain photoFiles={photoFiles} />)
 
+    const photoAddTrigger = screen.getByRole('button', {
+      name: '사진을 첨부해 주세요. (선택)',
+    })
+
+    expect(photoAddTrigger).toHaveClass('size-[130px]', 'rounded-[5px]')
+    expect(screen.queryByText('사진 추가')).not.toBeInTheDocument()
     expect(
       screen.getByRole('list', { name: '선택된 리뷰 사진 목록' }),
     ).toHaveClass(
@@ -293,7 +300,7 @@ describe('InputReviewMain', () => {
     ).toHaveAttribute('src', 'blob:review-1.png')
     expect(
       screen.getByRole('img', { name: 'review-1.png 미리보기' }),
-    ).toHaveClass('rounded-[10px]')
+    ).toHaveClass('rounded-[5px]')
     expect(
       screen.getByRole('img', { name: 'review-2.png 미리보기' }),
     ).toHaveAttribute('src', 'blob:review-2.png')

--- a/apps/client/src/features/review/components/inputReviewMain/ReviewPhotoUploader.test.tsx
+++ b/apps/client/src/features/review/components/inputReviewMain/ReviewPhotoUploader.test.tsx
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom/vitest'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ReviewPhotoUploader } from '@/features/review/components/inputReviewMain/ReviewPhotoUploader'
 
@@ -29,6 +29,10 @@ const renderReviewPhotoUploader = (
 }
 
 describe('ReviewPhotoUploader', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   it('renders the empty photo trigger with responsive width', () => {
     const { onPhotoTriggerClick } = renderReviewPhotoUploader()
 
@@ -72,8 +76,12 @@ describe('ReviewPhotoUploader', () => {
       'overflow-y-hidden',
     )
     expect(
+      screen.getByRole('button', { name: '사진을 첨부해 주세요. (선택)' }),
+    ).toHaveClass('size-[130px]', 'rounded-[5px]')
+    expect(screen.queryByText('사진 추가')).not.toBeInTheDocument()
+    expect(
       screen.getByRole('img', { name: 'review-1.png 미리보기' }),
-    ).toHaveClass('rounded-[10px]')
+    ).toHaveClass('rounded-[5px]')
 
     fireEvent.click(
       screen.getByRole('button', { name: 'review-1.png 사진 삭제' }),
@@ -90,6 +98,6 @@ describe('ReviewPhotoUploader', () => {
 
     expect(
       screen.getByText('사진은 최대 10장까지 첨부할 수 있어요.'),
-    ).toHaveClass('text-primary-400')
+    ).toHaveClass('typo-body-7', 'text-primary-400')
   })
 })

--- a/apps/client/src/features/review/components/inputReviewMain/ReviewPhotoUploader.tsx
+++ b/apps/client/src/features/review/components/inputReviewMain/ReviewPhotoUploader.tsx
@@ -29,6 +29,12 @@ const photoTriggerClassName = cn(
   'focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40',
 )
 
+const photoTileTriggerClassName = cn(
+  'border-warm-gray-100 text-warm-gray-300 focus-visible:outline-cool-gray-500',
+  'flex size-[130px] shrink-0 items-center justify-center rounded-[5px] border bg-white',
+  'focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40',
+)
+
 const photoTriggerContent = (
   <>
     <CameraIcon aria-hidden="true" className="size-6 shrink-0 opacity-50" />
@@ -63,7 +69,7 @@ export const ReviewPhotoUploader = ({
             <button
               aria-controls={photoInputId}
               aria-label="사진을 첨부해 주세요. (선택)"
-              className="border-warm-gray-100 text-warm-gray-300 focus-visible:outline-cool-gray-500 flex size-[130px] flex-col items-center justify-center gap-2 rounded-[10px] border bg-white px-5 py-10 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-40"
+              className={photoTileTriggerClassName}
               disabled={isPhotoInputDisabled}
               type="button"
               onClick={onPhotoTriggerClick}
@@ -72,15 +78,17 @@ export const ReviewPhotoUploader = ({
                 aria-hidden="true"
                 className="size-6 shrink-0 opacity-50"
               />
-              <span className="typo-body-4 whitespace-nowrap">사진 추가</span>
             </button>
           </li>
           {photoPreviewItems.map(({ id, name, src }, index) => (
-            <li key={id} className="relative size-[130px] shrink-0">
+            <li
+              key={id}
+              className="relative size-[130px] shrink-0 rounded-[5px]"
+            >
               <img
                 src={src}
                 alt={`${name} 미리보기`}
-                className="border-warm-gray-100 size-full rounded-[10px] border object-cover"
+                className="size-full rounded-[5px] object-cover"
               />
               <button
                 aria-label={`${name} 사진 삭제`}
@@ -119,7 +127,7 @@ export const ReviewPhotoUploader = ({
       {photoErrorMessage ? (
         <p
           aria-live="polite"
-          className="typo-body-6 text-primary-400 w-full break-words"
+          className="typo-body-7 text-primary-400 w-full break-words"
         >
           {photoErrorMessage}
         </p>

--- a/apps/client/src/features/review/constants/reviewInputRules.ts
+++ b/apps/client/src/features/review/constants/reviewInputRules.ts
@@ -12,7 +12,6 @@ export const REVIEW_PHOTO_ACCEPTED_MIME_TYPES = [
 export const REVIEW_PHOTO_ACCEPT = REVIEW_PHOTO_ACCEPTED_MIME_TYPES.join(',')
 export const REVIEW_PHOTO_TYPE_ERROR_MESSAGE =
   'JPG, PNG, WEBP 형식의 사진만 첨부할 수 있어요.'
-export const REVIEW_PHOTO_SIZE_ERROR_MESSAGE =
-  '사진은 장당 5MB 이하로 첨부해주세요.'
+export const REVIEW_PHOTO_SIZE_ERROR_MESSAGE = '용량이 초과되었어요.'
 export const REVIEW_PHOTO_MAX_COUNT_ERROR_MESSAGE =
   '사진은 최대 10장까지 첨부할 수 있어요.'

--- a/apps/client/src/pages/reviewNew/ReviewNewPage.test.tsx
+++ b/apps/client/src/pages/reviewNew/ReviewNewPage.test.tsx
@@ -258,8 +258,6 @@ describe('ReviewNewPage', () => {
       target: { files: [largePhotoFile] },
     })
 
-    expect(
-      screen.getByText('사진은 장당 5MB 이하로 첨부해주세요.'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('용량이 초과되었어요.')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 📌 요약

Review Input 이미지 첨부 영역 리디자인을 반영했습니다.

Jira: HASHI-192

## 📚 작업 내용

- Review Input 이미지 첨부 영역의 uploaded 상태 UI를 Figma 기준으로 수정했습니다.
- 사진 추가 타일을 아이콘-only 형태로 변경했습니다.
- 선택된 사진 미리보기 타일 radius를 Figma 기준으로 조정했습니다.
- 사진 첨부 에러 메시지 typography와 용량 초과 문구를 Figma 기준으로 변경했습니다.
- 관련 spec/test를 변경사항에 맞게 갱신했습니다.

## 🔎 상세 설명

Figma에서는 TextArea 섹션 안에 Review Input 조합이 포함되어 있지만, 코드 기준으로 이미지 첨부 영역은 HDS `Textarea` primitive가 아니라 review feature의 `ReviewPhotoUploader` 책임으로 판단했습니다.

따라서 이번 PR에서는 HDS `Textarea`는 변경하지 않고, `InputReviewMain` 내부의 사진 첨부 영역만 보정했습니다.

반영 내용:

- uploaded 상태의 사진 추가 버튼
  - `130px` 타일
  - `5px` radius
  - 텍스트 제거
  - 카메라 아이콘만 노출
- 선택된 사진 미리보기
  - `130px` 타일
  - `5px` radius
- 에러 메시지
  - `Body 7`
  - `Primary_400`
- 용량 초과 문구
  - `용량이 초과되었어요.`

## 💭 고민한 부분

### 고민한 문제

- Figma의 TextArea 섹션 안에 Review Input 전체 조합이 포함되어 있어, HDS `Textarea`를 수정해야 하는지 Review feature 영역만 수정해야 하는지 경계 판단이 필요했습니다.
- Figma의 over limit 상태가 uploaded row 형태로 표현되어 있어, 사진이 0장인 상태의 용량 초과까지 동일한 layout으로 바꿔야 하는지 고민했습니다.

### 고려한 선택지

- HDS `Textarea`까지 함께 수정
- Review feature의 이미지 첨부 영역만 수정
- 사진 0장 상태의 용량 초과도 uploaded layout으로 강제 전환
- 선택된 사진이 있을 때만 uploaded layout 유지

### 최종 선택과 이유

- HDS `Textarea`는 이번 작업 범위에서 제외했습니다.
  - 이미지 첨부 영역은 HDS primitive가 아니라 `ReviewPhotoUploader`의 책임으로 판단했습니다.
- 사진이 0장인 상태에서 용량 초과 파일을 선택한 경우에는 default 첨부 박스를 유지하고 에러 문구만 노출하도록 유지했습니다.
  - 실제로 첨부된 사진이 없는데 uploaded layout으로 강제 전환하는 것은 상태와 UI가 맞지 않는다고 판단했습니다.
  - Figma의 over limit variant는 이미 사진이 첨부된 uploaded 상태에서 추가 첨부가 용량 초과된 케이스로 해석했습니다.

### 남은 고민

- 디자이너 의도가 “사진 0장 상태에서 용량 초과 파일을 선택해도 uploaded layout으로 보여야 한다”라면 추가 보정이 필요합니다.

## ✅ 검증

- [x] 자동 테스트: `corepack pnpm --filter @hashi/client test -- ReviewPhotoUploader.test.tsx InputReviewMain.test.tsx ReviewNewPage.test.tsx`
- [x] 타입 체크: `corepack pnpm --filter @hashi/client typecheck`
- [x] 린트: `corepack pnpm --filter @hashi/client lint`
- [x] 포맷 체크: `corepack pnpm format:check`
- [x] diff whitespace 확인: `git diff --check`
- [x] 수동 확인: 로컬 앱에서 Review Input 기본/업로드/용량 초과 상태 확인

## 👀 리뷰어에게

- Figma의 Review Input 이미지 첨부 영역은 TextArea 섹션에 포함되어 있지만, 코드 책임상 HDS `Textarea`가 아닌 review feature 영역으로 판단해 `ReviewPhotoUploader`만 수정했습니다.
- 사진이 0장인 상태에서 용량 초과 파일을 선택한 경우 default 첨부 박스 아래에 에러 문구를 노출하는 현재 동작이 괜찮은지 확인 부탁드립니다.